### PR TITLE
feat(game): 다중 쓰기체계 지원을 위한 ScriptAdapter 추상화 도입

### DIFF
--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -22,7 +22,7 @@ const BCRYPT_ROUNDS = 10;
 
 // author_password_hash 노출 방지용 화이트리스트
 const DECK_PUBLIC_COLUMNS =
-  "id, name, description, words, categories, thumbnail_url, is_public, created_at, updated_at, creator_id, author_handle";
+  "id, name, description, words, categories, script, thumbnail_url, is_public, created_at, updated_at, creator_id, author_handle";
 
 type DeckPayloadResult =
   | { ok: true; words: DeckWord[]; categories: string[] }

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import bcrypt from "bcryptjs";
 import { validateDeckWords } from "@/lib/wordConstraints";
 import { MAX_TAGS_PER_WORD, normalizeCategories } from "@/lib/deckCategories";
+import { getScriptAdapter } from "@/lib/scripts";
 import type { DeckWord } from "@/types/decks";
 import { getUserInfo } from "@/app/actions/user";
 import { User } from "@supabase/supabase-js";
@@ -28,7 +29,9 @@ type DeckPayloadResult =
   | { ok: true; words: DeckWord[]; categories: string[] }
   | { ok: false; message: string; fieldErrors?: { [key: string]: string[] } };
 
-function parseDeckPayload(formData: FormData): DeckPayloadResult {
+function parseDeckPayload(formData: FormData, script: string = "latin"): DeckPayloadResult {
+  const adapter = getScriptAdapter(script);
+
   const wordsJson = formData.get("words_json");
   if (typeof wordsJson !== "string" || !wordsJson.trim()) {
     return {
@@ -57,7 +60,7 @@ function parseDeckPayload(formData: FormData): DeckPayloadResult {
     };
   }
 
-  const wordsValidation = validateDeckWords(rawWords as DeckWord[]);
+  const wordsValidation = validateDeckWords(rawWords as DeckWord[], adapter);
   if (wordsValidation.errors.length > 0) {
     return {
       ok: false,

--- a/components/games/GameLoader.tsx
+++ b/components/games/GameLoader.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useMemo } from "react";
 import { WordleGrid } from "@/components/games/WordleGrid";
 import { WordleKeyboard } from "@/components/games/WordleKeyboard";
 import { GameResultModal } from "@/components/games/GameResultModal";
 import { isGameComplete } from "@/lib/wordleGame";
+import { getScriptAdapter } from "@/lib/scripts";
 import { useGame } from "@/hooks/useGame";
 import { Deck } from "@/types/decks";
 
@@ -12,6 +14,8 @@ interface GameLoaderProps {
 }
 
 export function GameLoader({ deck }: GameLoaderProps) {
+  const adapter = useMemo(() => getScriptAdapter(deck.script), [deck.script]);
+
   const {
     gameState,
     showResult,
@@ -22,7 +26,7 @@ export function GameLoader({ deck }: GameLoaderProps) {
     handleEnter,
     restartGame,
     setShowGameResultModal,
-  } = useGame(deck);
+  } = useGame(deck, adapter);
 
   if (!gameState) {
     return null; // 데이터가 아직 로드되지 않았거나 에러가 발생한 경우
@@ -37,6 +41,7 @@ export function GameLoader({ deck }: GameLoaderProps) {
         onBackspace={handleBackspace}
         onEnter={handleEnter}
         keyboardState={gameState.keyboardState}
+        layout={adapter.keyboard}
         disabled={isGameComplete(gameState)}
       />
 

--- a/components/games/WordleGrid.tsx
+++ b/components/games/WordleGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { GameState } from "@/lib/wordleGame";
+import { getScriptAdapter } from "@/lib/scripts";
 
 interface WordleGridProps {
   gameState: GameState;
@@ -9,23 +10,25 @@ interface WordleGridProps {
 
 export function WordleGrid({ gameState, showResult = false }: WordleGridProps) {
   const { targetWord, guesses, currentGuess } = gameState;
-  const wordLength = targetWord.length;
+  const adapter = getScriptAdapter(gameState.adapterId);
+  const wordLength = adapter.splitUnits(targetWord).length;
+  const currentGuessUnits = adapter.splitUnits(currentGuess);
   const maxGuesses = gameState.maxGuesses;
   const currentRowIndex = guesses.length;
-  
+
   // 6줄 × n글자 그리드 생성
   const rows = [];
-  
+
   for (let rowIndex = 0; rowIndex < maxGuesses; rowIndex++) {
     const isCurrentRow = rowIndex === currentRowIndex && gameState.gameStatus === 'playing';
     const isCompletedRow = rowIndex < guesses.length;
-    
+
     rows.push(
       <div key={`row-${rowIndex}`} className={`wordle-row ${isCurrentRow ? 'current-row' : ''}`}>
         {Array.from({ length: wordLength }, (_, letterIndex) => {
           let tileContent = '';
           let tileState = '';
-          
+
           if (isCompletedRow) {
             // 완료된 추측의 타일
             const letter = guesses[rowIndex].letters[letterIndex];
@@ -33,7 +36,7 @@ export function WordleGrid({ gameState, showResult = false }: WordleGridProps) {
             tileState = letter.state;
           } else if (isCurrentRow) {
             // 현재 입력 중인 추측의 타일
-            tileContent = currentGuess[letterIndex]?.toUpperCase() || '';
+            tileContent = currentGuessUnits[letterIndex]?.toUpperCase() || '';
             tileState = tileContent ? 'filled' : '';
           }
           

--- a/components/games/WordleKeyboard.tsx
+++ b/components/games/WordleKeyboard.tsx
@@ -1,53 +1,49 @@
 "use client";
 
 import { LetterState } from "@/lib/wordleGame";
+import type { KeyboardLayout } from "@/lib/scripts/types";
 
 interface KeyboardProps {
   onKeyPress: (key: string) => void;
   onBackspace: () => void;
   onEnter: () => void;
   keyboardState: Record<string, LetterState>;
+  layout: KeyboardLayout;
   disabled?: boolean;
 }
 
-const KEYBOARD_ROWS = [
-  ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'],
-  ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'],
-  ['ENTER', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', 'BACKSPACE']
-];
-
-export function WordleKeyboard({ 
-  onKeyPress, 
-  onBackspace, 
-  onEnter, 
-  keyboardState, 
-  disabled = false 
+export function WordleKeyboard({
+  onKeyPress,
+  onBackspace,
+  onEnter,
+  keyboardState,
+  layout,
+  disabled = false
 }: KeyboardProps) {
   const getKeyClassName = (key: string): string => {
     const baseClass = "keyboard-key";
     const state = keyboardState[key.toUpperCase()];
-    
-    if (key === 'ENTER' || key === 'BACKSPACE') {
+
+    if (key === layout.enterLabel || key === layout.backspaceLabel) {
       return `${baseClass} special-key ${disabled ? 'disabled' : ''}`;
     }
-    
+
     let stateClass = '';
     if (state === 'correct') stateClass = 'correct';
     else if (state === 'present') stateClass = 'present';
     else if (state === 'absent') stateClass = 'absent';
-    
+
     return `${baseClass} ${stateClass} ${disabled ? 'disabled' : ''}`;
   };
 
   const handleKeyClick = (key: string) => {
     if (disabled) return;
-    
-    if (key === 'ENTER') {
+
+    if (key === layout.enterLabel) {
       onEnter();
-    } else if (key === 'BACKSPACE') {
+    } else if (key === layout.backspaceLabel) {
       onBackspace();
-    } else if (key.match(/[A-Z]/)) {
-      // 알파벳만 허용
+    } else {
       onKeyPress(key);
     }
   };
@@ -156,7 +152,7 @@ export function WordleKeyboard({
         }
       `}</style>
       <div className="keyboard-container">
-        {KEYBOARD_ROWS.map((row, rowIndex) => (
+        {layout.rows.map((row, rowIndex) => (
           <div key={rowIndex} className="keyboard-row">
             {row.map((key) => (
               <button
@@ -165,7 +161,7 @@ export function WordleKeyboard({
                 onClick={() => handleKeyClick(key)}
                 disabled={disabled}
               >
-                {key === 'BACKSPACE' ? '⌫' : key}
+                {key === layout.backspaceLabel ? '⌫' : key}
               </button>
             ))}
           </div>

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -1,14 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
-import { 
-  initializeGame, 
-  addLetterToGuess, 
-  removeLetterFromGuess, 
+import {
+  initializeGame,
+  addLetterToGuess,
+  removeLetterFromGuess,
   submitGuess,
   selectRandomWord,
   isGameComplete,
-  type GameState 
+  type GameState
 } from "@/lib/wordleGame";
+import type { ScriptAdapter } from "@/lib/scripts/types";
 import { Deck } from "@/types/decks";
 import { getWordStrings } from "@/lib/deckHelpers";
 
@@ -24,7 +25,7 @@ export interface UseGameReturn {
   setShowGameResultModal: (show: boolean) => void;
 }
 
-export function useGame(deck: Deck): UseGameReturn {
+export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [showResult, setShowResult] = useState(false);
   const [showGameResultModal, setShowGameResultModal] = useState(false);
@@ -40,9 +41,9 @@ export function useGame(deck: Deck): UseGameReturn {
 
     // 랜덤 단어 선택 및 게임 초기화
     const targetWord = selectRandomWord(wordList);
-    const initialGameState = initializeGame(targetWord, 6, wordList);
+    const initialGameState = initializeGame(targetWord, 6, wordList, adapter);
     setGameState(initialGameState);
-  }, [deck]);
+  }, [deck, adapter]);
 
   // 키보드 입력 처리
   const handleKeyPress = useCallback((key: string) => {
@@ -153,13 +154,13 @@ export function useGame(deck: Deck): UseGameReturn {
     if (wordList.length === 0) return;
 
     const targetWord = selectRandomWord(wordList);
-    const newGameState = initializeGame(targetWord, 6, wordList);
+    const newGameState = initializeGame(targetWord, 6, wordList, adapter);
     setGameState(newGameState);
     setShowResult(false);
     setShowGameResultModal(false);
     setGameResultType(null);
     setIsSubmitting(false);
-  }, [deck]);
+  }, [deck, adapter]);
 
   return {
     gameState,

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -1,0 +1,10 @@
+import { latin } from './latin';
+import type { ScriptAdapter, ScriptId } from './types';
+
+const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin };
+
+export function getScriptAdapter(id: string): ScriptAdapter {
+  return ADAPTERS[id as ScriptId] ?? latin;
+}
+
+export type { ScriptAdapter, ScriptId, KeyboardLayout } from './types';

--- a/lib/scripts/latin.ts
+++ b/lib/scripts/latin.ts
@@ -1,0 +1,21 @@
+import type { ScriptAdapter } from './types';
+
+const KEYBOARD_ROWS: string[][] = [
+  ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'],
+  ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'],
+  ['ENTER', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', 'BACKSPACE'],
+];
+
+export const latin: ScriptAdapter = {
+  id: 'latin',
+  rtl: false,
+  splitUnits: (word) => Array.from(word),
+  normalize: (word) => word.trim().toLowerCase(),
+  isAllowedChar: (ch) => /^[a-zA-Z]$/.test(ch),
+  isAllowedWord: (word) => /^[a-zA-Z]+$/.test(word),
+  keyboard: {
+    rows: KEYBOARD_ROWS,
+    enterLabel: 'ENTER',
+    backspaceLabel: 'BACKSPACE',
+  },
+};

--- a/lib/scripts/types.ts
+++ b/lib/scripts/types.ts
@@ -1,0 +1,24 @@
+export type ScriptId =
+  | 'latin'
+  | 'cyrillic'
+  | 'greek'
+  | 'hangul'
+  | 'kana'
+  | 'hebrew'
+  | 'arabic';
+
+export interface KeyboardLayout {
+  rows: string[][];
+  enterLabel: string;
+  backspaceLabel: string;
+}
+
+export interface ScriptAdapter {
+  id: ScriptId;
+  rtl: boolean;
+  splitUnits(word: string): string[];
+  normalize(word: string): string;
+  isAllowedChar(ch: string): boolean;
+  isAllowedWord(word: string): boolean;
+  keyboard: KeyboardLayout;
+}

--- a/lib/wordConstraints.ts
+++ b/lib/wordConstraints.ts
@@ -1,6 +1,7 @@
 // 단어 제약 조건 헬퍼 함수들
 
 import type { DeckWord } from "@/types/decks";
+import type { ScriptAdapter } from "./scripts/types";
 
 export interface WordValidationResult {
   isValid: boolean;
@@ -9,23 +10,20 @@ export interface WordValidationResult {
 
 /**
  * 단일 단어의 유효성을 검사합니다.
- * @param word 검사할 단어
- * @returns 유효성 검사 결과
  */
-export function validateWord(word: string): WordValidationResult {
+export function validateWord(word: string, adapter: ScriptAdapter): WordValidationResult {
   const errors: string[] = [];
-  
+
   // 1글자 이상인지 확인
   if (!word || word.length < 1) {
     errors.push('단어는 1글자 이상이어야 합니다.');
     return { isValid: false, errors };
   }
-  
-  // a-z, A-Z만 사용되는지 확인
-  if (!/^[a-zA-Z]+$/.test(word)) {
+
+  if (!adapter.isAllowedWord(word)) {
     errors.push('단어는 영문자(a-z, A-Z)만 사용할 수 있습니다.');
   }
-  
+
   return {
     isValid: errors.length === 0,
     errors
@@ -34,46 +32,44 @@ export function validateWord(word: string): WordValidationResult {
 
 /**
  * 단어 배열의 유효성을 검사합니다.
- * @param words 검사할 단어 배열
- * @returns 유효성 검사 결과
  */
-export function validateWords(words: string[]): WordValidationResult {
+export function validateWords(words: string[], adapter: ScriptAdapter): WordValidationResult {
   const errors: string[] = [];
-  
+
   if (!words || words.length === 0) {
     errors.push('최소 하나의 단어가 필요합니다.');
     return { isValid: false, errors };
   }
-  
+
   // 각 단어의 개별 유효성 검사
   const individualErrors: string[] = [];
   const processedWords = new Set<string>();
-  
+
   words.forEach((word, index) => {
     const trimmedWord = word.trim();
-    
+
     if (!trimmedWord) {
       individualErrors.push(`${index + 1}번째 단어가 비어있습니다.`);
       return;
     }
-    
+
     // 중복 검사
-    const lowerWord = trimmedWord.toLowerCase();
+    const lowerWord = adapter.normalize(trimmedWord);
     if (processedWords.has(lowerWord)) {
       individualErrors.push(`"${trimmedWord}"는 중복된 단어입니다.`);
       return;
     }
     processedWords.add(lowerWord);
-    
+
     // 개별 단어 유효성 검사
-    const wordValidation = validateWord(trimmedWord);
+    const wordValidation = validateWord(trimmedWord, adapter);
     if (!wordValidation.isValid) {
       individualErrors.push(`${index + 1}번째 단어 "${trimmedWord}": ${wordValidation.errors.join(', ')}`);
     }
   });
-  
+
   errors.push(...individualErrors);
-  
+
   return {
     isValid: errors.length === 0,
     errors
@@ -81,41 +77,35 @@ export function validateWords(words: string[]): WordValidationResult {
 }
 
 /**
- * 단어를 정규화합니다 (공백 제거, 소문자 변환).
- * @param word 정규화할 단어
- * @returns 정규화된 단어
+ * 단어를 정규화합니다.
  */
-export function normalizeWord(word: string): string {
-  return word.trim().toLowerCase();
+export function normalizeWord(word: string, adapter: ScriptAdapter): string {
+  return adapter.normalize(word);
 }
 
 /**
- * 단어 배열을 정규화합니다 (중복 제거, 공백 제거, 소문자 변환).
- * @param words 정규화할 단어 배열
- * @returns 정규화된 단어 배열
+ * 단어 배열을 정규화합니다 (중복 제거 포함).
  */
-export function normalizeWords(words: string[]): string[] {
+export function normalizeWords(words: string[], adapter: ScriptAdapter): string[] {
   const normalized = words
     .map(word => word.trim())
     .filter(word => word.length > 0)
-    .map(word => word.toLowerCase());
-  
+    .map(word => adapter.normalize(word));
+
   // 중복 제거
   return Array.from(new Set(normalized));
 }
 
 /**
  * 단어 배열을 정규화하고 유효성을 검사합니다.
- * @param words 검사할 단어 배열
- * @returns 정규화된 단어 배열과 유효성 검사 결과
  */
-export function processWords(words: string[]): {
+export function processWords(words: string[], adapter: ScriptAdapter): {
   normalizedWords: string[];
   validation: WordValidationResult;
 } {
-  const normalizedWords = normalizeWords(words);
-  const validation = validateWords(normalizedWords);
-  
+  const normalizedWords = normalizeWords(words, adapter);
+  const validation = validateWords(normalizedWords, adapter);
+
   return {
     normalizedWords,
     validation
@@ -124,10 +114,8 @@ export function processWords(words: string[]): {
 
 /**
  * CSV 형태의 문자열을 단어 배열로 변환하고 검증합니다.
- * @param wordsString 쉼표로 구분된 단어 문자열
- * @returns 정규화된 단어 배열과 유효성 검사 결과
  */
-export function parseWordsString(wordsString: string): {
+export function parseWordsString(wordsString: string, adapter: ScriptAdapter): {
   normalizedWords: string[];
   validation: WordValidationResult;
 } {
@@ -137,13 +125,13 @@ export function parseWordsString(wordsString: string): {
       validation: { isValid: false, errors: ['단어를 입력해주세요.'] }
     };
   }
-  
+
   const words = wordsString
     .split(',')
     .map(word => word.trim())
     .filter(word => word.length > 0);
-  
-  return processWords(words);
+
+  return processWords(words, adapter);
 }
 
 /**
@@ -155,10 +143,11 @@ export function toDeckWords(words: string[]): DeckWord[] {
 
 /**
  * DeckWord[] 입력을 정규화하고 유효성을 검사합니다.
- * - 단어: a-z만 허용, 소문자 정규화, 공백 제거, 중복 제거 (먼저 등장한 항목의 태그 보존).
+ * - 단어: adapter.isAllowedWord 통과만 허용, adapter.normalize로 정규화, 공백 제거, 중복 제거
+ *   (먼저 등장한 항목의 태그 보존).
  * - 태그: trim 후 빈 문자열 제외.
  */
-export function validateDeckWords(input: DeckWord[]): {
+export function validateDeckWords(input: DeckWord[], adapter: ScriptAdapter): {
   ok: DeckWord[];
   errors: string[];
 } {
@@ -177,7 +166,7 @@ export function validateDeckWords(input: DeckWord[]): {
       return;
     }
 
-    const validation = validateWord(rawWord);
+    const validation = validateWord(rawWord, adapter);
     if (!validation.isValid) {
       errors.push(
         `${index + 1}번째 단어 "${rawWord}": ${validation.errors.join(", ")}`,
@@ -185,7 +174,7 @@ export function validateDeckWords(input: DeckWord[]): {
       return;
     }
 
-    const normalizedWord = rawWord.toLowerCase();
+    const normalizedWord = adapter.normalize(rawWord);
     const rawTags = entry?.tags;
     if (rawTags !== undefined && rawTags !== null && !Array.isArray(rawTags)) {
       errors.push(
@@ -214,33 +203,30 @@ export function validateDeckWords(input: DeckWord[]): {
 
 /**
  * 단어가 게임에 적합한지 확인합니다 (추가 게임 관련 제약 조건).
- * @param word 검사할 단어
- * @param minLength 최소 길이 (기본값: 3)
- * @param maxLength 최대 길이 (기본값: 10)
- * @returns 게임 적합성 검사 결과
  */
 export function validateWordForGame(
-  word: string, 
-  minLength: number = 3, 
+  word: string,
+  adapter: ScriptAdapter,
+  minLength: number = 3,
   maxLength: number = 10
 ): WordValidationResult {
   const errors: string[] = [];
-  
+
   // 기본 유효성 검사
-  const basicValidation = validateWord(word);
+  const basicValidation = validateWord(word, adapter);
   if (!basicValidation.isValid) {
     return basicValidation;
   }
-  
+
   // 길이 검사
   if (word.length < minLength) {
     errors.push(`단어는 최소 ${minLength}글자 이상이어야 합니다.`);
   }
-  
+
   if (word.length > maxLength) {
     errors.push(`단어는 최대 ${maxLength}글자까지 가능합니다.`);
   }
-  
+
   return {
     isValid: errors.length === 0,
     errors
@@ -249,32 +235,29 @@ export function validateWordForGame(
 
 /**
  * 단어 배열이 게임에 적합한지 확인합니다.
- * @param words 검사할 단어 배열
- * @param minLength 최소 길이 (기본값: 3)
- * @param maxLength 최대 길이 (기본값: 10)
- * @returns 게임 적합성 검사 결과
  */
 export function validateWordsForGame(
-  words: string[], 
-  minLength: number = 3, 
+  words: string[],
+  adapter: ScriptAdapter,
+  minLength: number = 3,
   maxLength: number = 10
 ): WordValidationResult {
   const errors: string[] = [];
-  
+
   // 기본 유효성 검사
-  const basicValidation = validateWords(words);
+  const basicValidation = validateWords(words, adapter);
   if (!basicValidation.isValid) {
     return basicValidation;
   }
-  
+
   // 각 단어의 게임 적합성 검사
   words.forEach((word, index) => {
-    const gameValidation = validateWordForGame(word, minLength, maxLength);
+    const gameValidation = validateWordForGame(word, adapter, minLength, maxLength);
     if (!gameValidation.isValid) {
       errors.push(`${index + 1}번째 단어 "${word}": ${gameValidation.errors.join(', ')}`);
     }
   });
-  
+
   return {
     isValid: errors.length === 0,
     errors

--- a/lib/wordleGame.ts
+++ b/lib/wordleGame.ts
@@ -1,5 +1,8 @@
 // Wordle 게임 로직
 
+import { getScriptAdapter } from './scripts';
+import type { ScriptAdapter, ScriptId } from './scripts/types';
+
 export type LetterState = 'correct' | 'present' | 'absent' | 'empty';
 
 export interface Letter {
@@ -20,62 +23,80 @@ export interface GameState {
   keyboardState: Record<string, LetterState>;
   validWords?: string[]; // 유효한 단어 목록
   errorMessage?: string; // 에러 메시지
+  adapterId: ScriptId;
 }
 
-export function initializeGame(targetWord: string, maxGuesses: number = 6, validWords?: string[]): GameState {
+export function initializeGame(
+  targetWord: string,
+  maxGuesses: number = 6,
+  validWords: string[] | undefined,
+  adapter: ScriptAdapter
+): GameState {
   return {
-    targetWord: targetWord.toLowerCase(),
+    targetWord: adapter.normalize(targetWord),
     guesses: [],
     currentGuess: '',
     gameStatus: 'playing',
     maxGuesses,
     keyboardState: {},
-    validWords: validWords?.map(w => w.toLowerCase()),
-    errorMessage: undefined
+    validWords: validWords?.map((w) => adapter.normalize(w)),
+    errorMessage: undefined,
+    adapterId: adapter.id,
   };
 }
 
 export function addLetterToGuess(gameState: GameState, letter: string): GameState {
   if (gameState.gameStatus !== 'playing') return gameState;
-  if (gameState.currentGuess.length >= gameState.targetWord.length) return gameState;
-  
-  // 알파벳만 허용
-  if (!letter.match(/[A-Za-z]/)) return gameState;
-  
+
+  const adapter = getScriptAdapter(gameState.adapterId);
+  const targetUnits = adapter.splitUnits(gameState.targetWord);
+  const currentUnits = adapter.splitUnits(gameState.currentGuess);
+  if (currentUnits.length >= targetUnits.length) return gameState;
+
+  if (!adapter.isAllowedChar(letter)) return gameState;
+
   return {
     ...gameState,
-    currentGuess: gameState.currentGuess + letter.toLowerCase(),
+    currentGuess: gameState.currentGuess + adapter.normalize(letter),
     errorMessage: undefined // 입력 시 에러 메시지 초기화
   };
 }
 
 export function removeLetterFromGuess(gameState: GameState): GameState {
   if (gameState.gameStatus !== 'playing') return gameState;
-  
+
+  const adapter = getScriptAdapter(gameState.adapterId);
+  const units = adapter.splitUnits(gameState.currentGuess);
+  if (units.length === 0) return gameState;
+
   return {
     ...gameState,
-    currentGuess: gameState.currentGuess.slice(0, -1)
+    currentGuess: units.slice(0, -1).join('')
   };
 }
 
 export function submitGuess(gameState: GameState): GameState {
   if (gameState.gameStatus !== 'playing') return gameState;
-  if (gameState.currentGuess.length !== gameState.targetWord.length) return gameState;
-  
+
+  const adapter = getScriptAdapter(gameState.adapterId);
+  const targetUnits = adapter.splitUnits(gameState.targetWord);
+  const currentUnits = adapter.splitUnits(gameState.currentGuess);
+  if (currentUnits.length !== targetUnits.length) return gameState;
+
   // 유효한 단어 목록이 있는 경우 검증
   if (gameState.validWords && gameState.validWords.length > 0) {
-    const currentGuessLower = gameState.currentGuess.toLowerCase();
-    if (!gameState.validWords.includes(currentGuessLower)) {
+    const currentNormalized = adapter.normalize(gameState.currentGuess);
+    if (!gameState.validWords.includes(currentNormalized)) {
       return {
         ...gameState,
         errorMessage: '단어 목록에 없는 단어입니다.'
       };
     }
   }
-  
-  const newGuess = evaluateGuess(gameState.currentGuess, gameState.targetWord);
+
+  const newGuess = evaluateGuess(currentUnits, targetUnits);
   const newGuesses = [...gameState.guesses, newGuess];
-  
+
   // 키보드 상태 업데이트
   const newKeyboardState = { ...gameState.keyboardState };
   newGuess.letters.forEach(letter => {
@@ -84,22 +105,22 @@ export function submitGuess(gameState: GameState): GameState {
       const upperChar = letter.char.toUpperCase();
       // 더 높은 우선순위 상태로 업데이트 (correct > present > absent)
       const currentState = newKeyboardState[upperChar];
-      if (!currentState || 
+      if (!currentState ||
           (currentState === 'absent' && letter.state !== 'absent') ||
           (currentState === 'present' && letter.state === 'correct')) {
         newKeyboardState[upperChar] = letter.state;
       }
     }
   });
-  
+
   // 게임 상태 확인
   let gameStatus: 'playing' | 'won' | 'lost' = 'playing';
-  if (gameState.currentGuess.toLowerCase() === gameState.targetWord) {
+  if (adapter.normalize(gameState.currentGuess) === gameState.targetWord) {
     gameStatus = 'won';
   } else if (newGuesses.length >= gameState.maxGuesses) {
     gameStatus = 'lost';
   }
-  
+
   return {
     ...gameState,
     guesses: newGuesses,
@@ -110,42 +131,40 @@ export function submitGuess(gameState: GameState): GameState {
   };
 }
 
-function evaluateGuess(guess: string, target: string): Guess {
-  const targetArray = target.split('');
-  const guessArray = guess.split('');
+function evaluateGuess(guessUnits: string[], targetUnits: string[]): Guess {
   const result: Letter[] = [];
-  
+
   // 첫 번째 패스: 정확한 위치의 글자 확인
-  const targetRemaining = [...targetArray];
-  const guessRemaining = [...guessArray];
-  
+  const targetRemaining = [...targetUnits];
+  const guessRemaining = [...guessUnits];
+
   // correct 위치 찾기
-  for (let i = 0; i < guessArray.length; i++) {
-    if (guessArray[i] === targetArray[i]) {
-      result[i] = { char: guessArray[i], state: 'correct' };
+  for (let i = 0; i < guessUnits.length; i++) {
+    if (guessUnits[i] === targetUnits[i]) {
+      result[i] = { char: guessUnits[i], state: 'correct' };
       targetRemaining[i] = '';
       guessRemaining[i] = '';
     }
   }
-  
+
   // 두 번째 패스: present 위치 찾기
-  for (let i = 0; i < guessArray.length; i++) {
+  for (let i = 0; i < guessUnits.length; i++) {
     if (guessRemaining[i] === '') continue; // 이미 처리된 글자
-    
-    const targetIndex = targetRemaining.findIndex(char => char === guessArray[i]);
+
+    const targetIndex = targetRemaining.findIndex((char) => char === guessUnits[i]);
     if (targetIndex !== -1) {
-      result[i] = { char: guessArray[i], state: 'present' };
+      result[i] = { char: guessUnits[i], state: 'present' };
       targetRemaining[targetIndex] = '';
       guessRemaining[i] = '';
     }
   }
-  
+
   // 세 번째 패스: absent 처리
-  for (let i = 0; i < guessArray.length; i++) {
+  for (let i = 0; i < guessUnits.length; i++) {
     if (guessRemaining[i] === '') continue; // 이미 처리된 글자
-    result[i] = { char: guessArray[i], state: 'absent' };
+    result[i] = { char: guessUnits[i], state: 'absent' };
   }
-  
+
   return { letters: result };
 }
 

--- a/supabase/migrations/20260428000001_decks_script.sql
+++ b/supabase/migrations/20260428000001_decks_script.sql
@@ -1,0 +1,15 @@
+-- =============================================
+-- decks.script: 다중 쓰기체계(라틴/키릴/그리스/한글/가나/히브리/아랍 등) 지원을 위한
+-- 덱 단위 script 식별자. 향후 ScriptAdapter 추상화에서 사용.
+-- 멱등적으로 작성: 이미 적용된 환경에서도 안전하게 재실행 가능.
+--
+-- 인덱스/CHECK 제약은 의도적으로 추가하지 않는다.
+-- (향후 새로운 script 값 추가 시 마이그레이션 없이 확장 가능하도록)
+-- =============================================
+
+BEGIN;
+
+ALTER TABLE public.decks
+  ADD COLUMN IF NOT EXISTS script TEXT NOT NULL DEFAULT 'latin';
+
+COMMIT;

--- a/types/database.ts
+++ b/types/database.ts
@@ -25,6 +25,7 @@ export type Database = {
           id: string
           is_public: boolean | null
           name: string | null
+          script: string
           thumbnail_url: string | null
           updated_at: string | null
           words: { word: string; tags: string[] }[]
@@ -39,6 +40,7 @@ export type Database = {
           id?: string
           is_public?: boolean | null
           name?: string | null
+          script?: string
           thumbnail_url?: string | null
           updated_at?: string | null
           words?: { word: string; tags: string[] }[]
@@ -53,6 +55,7 @@ export type Database = {
           id?: string
           is_public?: boolean | null
           name?: string | null
+          script?: string
           thumbnail_url?: string | null
           updated_at?: string | null
           words?: { word: string; tags: string[] }[]


### PR DESCRIPTION
다중 쓰기체계(라틴 외 키릴/그리스/한글/가나/히브리/아랍) 지원을 위한 선행 작업.
이 PR은 두 개의 커밋(0a + 0b)을 포함하며, 라틴 덱 동작은 변경 전과 동치입니다.

## Summary

### 0a — `decks.script` 컬럼 추가 (커밋 `01abfe0`)
- `decks` 테이블에 `script TEXT NOT NULL DEFAULT 'latin'` 컬럼 추가 (멱등적 마이그레이션)
- 인덱스/CHECK 제약은 의도적으로 두지 않음 (향후 script 추가 시 마이그레이션 없이 확장)
- `types/database.ts`의 Row/Insert/Update에 `script` 필드 반영
- `DECK_PUBLIC_COLUMNS` 화이트리스트에 `script` 포함 (Row 타입 변경에 따른 회귀 방지)

### 0b — ScriptAdapter 추상화 + 라틴 어댑터 위임 (커밋 `37c7cbf`)
- `ScriptAdapter` 인터페이스 도입 (`lib/scripts/types.ts`)
  - `ScriptId` 유니온은 7종(latin/cyrillic/greek/hangul/kana/hebrew/arabic) 미리 선언
  - `splitUnits` / `normalize` / `isAllowedChar` / `isAllowedWord` / `keyboard` / `rtl`
- 라틴 어댑터로 현재 동작 캡슐화 (`lib/scripts/latin.ts`)
- registry + 미등록 fallback (`lib/scripts/index.ts`) — 후속 PR은 어댑터 파일만 추가하면 동작
- `lib/wordleGame.ts`: `GameState.adapterId` 저장, `splitUnits` / `normalize` / `isAllowedChar` 위임
- `lib/wordConstraints.ts`: `validate*` / `normalize*` 시그니처에 `adapter` 인자 추가
- `WordleKeyboard`: `KEYBOARD_ROWS` 하드코딩 제거, `layout: KeyboardLayout` prop 도입
- `WordleGrid`: `splitUnits` 기반 길이/인덱싱
- `GameLoader` / `useGame`: `getScriptAdapter(deck.script)` lookup 후 `useGame(deck, adapter)` 전달

### 동치성

라틴 단어는 ASCII 한정이므로 `Array.from(word) === word.split('')`, `adapter.normalize ≡ trim().toLowerCase()`. 따라서 라틴 덱 동작은 비트 단위 동일.

### 의도적으로 손대지 않은 것
- 새 script 어댑터 추가 (Phase 1 이후)
- 덱 생성 폼의 script 선택 UI (현재 옵션이 latin뿐이라 무의미)
- `lib/parseAiDeckResponse.ts` (자체 inline 검증 사용 중, 후속 PR에서 갱신)
- `useGame.handleKeyDown`의 `event.key.toUpperCase()` (라틴 한정 동작, 후속 PR에서 일반화)
- 스타일/폰트/RTL 처리

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `pnpm lint` 통과 (모든 경고는 변경 외 파일의 기존 경고)
- [x] 마이그레이션 멱등성 (두 번 실행해도 에러 없음)
- [x] 기존 라틴 덱 조회/생성/수정 그대로 동작
- [x] dev 서버에서 라틴 덱으로 한 판 플레이:
  - [x] 알파벳 입력 정상
  - [x] 알파벳 외 키(숫자·특수문자) 입력 시 무시
  - [x] correct(녹색) / present(노랑) / absent(회색) 동일
  - [x] 키보드 색상 누적 업데이트 동일 (correct가 present 위에 덮어쓰기)
  - [x] `validWords` 외 단어 입력 시 "단어 목록에 없는 단어입니다." 토스트 동일
  - [x] 덱 생성 시 알파벳 외 문자 입력 시 검증 에러 메시지 동일
  - [x] 게임 결과 모달, 시도 횟수 표시 동일

> dev 서버 회귀 검증은 머지 전 직접 확인이 필요합니다 (이 환경에서는 브라우저 검증 불가).
