### PR TITLE
ci: Supabase 마이그레이션 자동 배포 + categories 컬럼 정합화

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy Supabase migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/supabase-deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: supabase-migrations
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Push migrations
+        run: supabase db push

--- a/supabase/migrations/20260425000001_decks_categories.sql
+++ b/supabase/migrations/20260425000001_decks_categories.sql
@@ -1,0 +1,8 @@
+-- =============================================
+-- decks.categories: 덱 분류 태그 배열.
+-- 이전에 Supabase Studio에서 직접 생성됐던 컬럼을 마이그레이션으로 정합화.
+-- 멱등적으로 작성: 이미 적용된 환경에서도 안전하게 재실행 가능.
+-- =============================================
+
+ALTER TABLE public.decks
+  ADD COLUMN IF NOT EXISTS categories TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## 요약

- main 브랜치 머지 시 `supabase db push`를 자동 실행하는 GitHub Actions 워크플로우 추가
- repo에 누락돼 있던 `decks.categories` 컬럼 마이그레이션 파일 추가 (이전엔 Studio에서 직접 추가됐었음)

## 배경

prod DB가 repo의 마이그레이션 파일과 drift된 상태였습니다. 진단 결과:

| 컬럼 / 변경 | 코드 참조 | prod 상태 | repo 마이그레이션 |
|---|---|---|---|
| `words` (text[] → jsonb) | ✅ | ❌ text[] 그대로 | ✅ `20260426000001` |
| `categories` | ✅ | ❌ 없음 | ❌ 파일 없음 |
| `script` | ✅ | ❌ 없음 | ✅ `20260428000001` (PR #11) |

→ "덱 생성 실패: Could not find the 'categories' column of 'decks' in the schema cache" 에러의 직접 원인.

이번 PR은 **단발성 정합화 + 향후 재발 방지**를 한 번에 처리합니다.

## 변경 사항

### 1. `.github/workflows/supabase-deploy.yml` (신규)

- 트리거: main 푸시 + `supabase/migrations/**` 또는 워크플로우 자체 변경
- 수동 실행: `workflow_dispatch` 지원
- 동작: `supabase link` → `supabase db push` (history에 없는 마이그레이션만 적용)
- 동시 실행 방지: `concurrency` 그룹 설정

### 2. `supabase/migrations/20260425000001_decks_categories.sql` (신규)

```sql
ALTER TABLE public.decks
  ADD COLUMN IF NOT EXISTS categories TEXT[] NOT NULL DEFAULT '{}';
```

타임스탬프를 `0426`(words jsonb 변환)보다 앞에 둬서 적용 순서가 자연스러움.

## 머지 시 일어날 일

워크플로우가 첫 실행되어 prod에 다음 3개 마이그레이션이 순서대로 자동 적용됩니다. 모두 멱등적이라 안전:

| # | 마이그레이션 | 효과 |
|---|---|---|
| 1 | `20260425000001_decks_categories` | `categories TEXT[]` 추가 |
| 2 | `20260426000001_decks_words_jsonb` | `words` text[] → jsonb 변환 + NULL 백필 |
| 3 | `20260428000001_decks_script` | `script TEXT` 추가 |

## 사전 준비 (완료)

GitHub Repo Secrets에 다음 3개 추가됨:

- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_DB_PASSWORD`
- `SUPABASE_PROJECT_REF`

## 머지 후 검증

- [ ] GitHub Actions 탭에서 "Deploy Supabase migrations" 워크플로우 success 확인
- [ ] prod에서 컬럼 정합 확인:

```sql
SELECT column_name, data_type FROM information_schema.columns
WHERE table_schema='public' AND table_name='decks'
ORDER BY ordinal_position;
```

→ `words=jsonb`, `categories=ARRAY`, `script=text` 모두 존재해야 함.

- [ ] 마이그레이션 히스토리 확인:

```sql
SELECT version FROM supabase_migrations.schema_migrations ORDER BY version;
```

→ `20260425000001`, `20260426000001`, `20260428000001` 모두 등록.

- [ ] 배포 환경에서 덱 생성 정상 동작 확인.

https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Decks에 여러 카테고리를 할당할 수 있는 기능이 추가되었습니다.

* **Chores**
  * 데이터베이스 마이그레이션 자동 배포 워크플로우가 구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->