### PR TITLE
ci: secret 길이 출력으로 DB 비밀번호 인증 실패 진단

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           version: latest
 
+      - name: Verify secrets length
+        run: |
+          echo "ref length: ${#SUPABASE_PROJECT_REF}"
+          echo "token prefix: ${SUPABASE_ACCESS_TOKEN:0:4}"
+          echo "pwd length: ${#SUPABASE_DB_PASSWORD}"
+
       - name: Link Supabase project
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
 


### PR DESCRIPTION
## 요약

DB 비밀번호 인증 실패(`SASL auth failed`) 진단을 위해 secret 길이를 출력하는 step 추가. 값 자체는 노출되지 않음.

## 배경

PR #12 머지 후 `supabase db push` 단계에서 `password authentication failed for user "postgres"` 에러 발생. 비밀번호를 reset해 secret을 갱신했음에도 동일 에러.

가능한 원인:
- secret 복사 시 trailing whitespace/줄바꿈 포함 → 길이가 실제보다 +1/+2
- secret 갱신을 빠뜨림

길이 출력으로 빠르게 판가름.

## 변경

`Verify secrets length` step 추가:
```bash
echo "ref length: ${#SUPABASE_PROJECT_REF}"
echo "token prefix: ${SUPABASE_ACCESS_TOKEN:0:4}"
echo "pwd length: ${#SUPABASE_DB_PASSWORD}"
```

## 머지 후 확인

Actions 탭에서 `Verify secrets length` step 출력:
- `ref length: 20` (정상)
- `token prefix: sbp_` (정상)
- `pwd length: ?` ← 16 부근이면 정상, 17/18 등은 trailing whitespace 의심

## 후속

원인 확정 후 디버그 step은 별도 PR로 제거 예정.

https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC)_