### PR TITLE
fix(db): words jsonb 마이그레이션 USING 절 서브쿼리 제약 우회

### DIFF
--- a/supabase/migrations/20260426000001_decks_words_jsonb.sql
+++ b/supabase/migrations/20260426000001_decks_words_jsonb.sql
@@ -28,6 +28,20 @@ BEGIN
 
   -- 이미 JSONB라면 아무 것도 하지 않음 (멱등)
   IF current_data_type = 'ARRAY' THEN
+    -- ALTER COLUMN ... USING 절은 서브쿼리(SELECT ...)를 허용하지 않으므로
+    -- 변환 로직을 임시 함수로 감싼다. pg_temp 스키마는 세션 종료 시 자동 정리됨.
+    CREATE FUNCTION pg_temp.text_array_to_word_jsonb(arr TEXT[])
+    RETURNS JSONB
+    LANGUAGE SQL
+    IMMUTABLE
+    AS $func$
+      SELECT COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object('word', w, 'tags', '[]'::jsonb))
+           FROM unnest(arr) AS w),
+        '[]'::jsonb
+      )
+    $func$;
+
     -- TEXT[] -> JSONB:
     --   NULL 또는 빈 배열은 '[]'::jsonb,
     --   각 요소는 {"word": <text>, "tags": []} 객체로 변환.
@@ -39,13 +53,7 @@ BEGIN
       USING (
         CASE
           WHEN words IS NULL THEN '[]'::jsonb
-          ELSE COALESCE(
-            (
-              SELECT jsonb_agg(jsonb_build_object('word', w, 'tags', '[]'::jsonb))
-                FROM unnest(words) AS w
-            ),
-            '[]'::jsonb
-          )
+          ELSE pg_temp.text_array_to_word_jsonb(words)
         END
       );
 


### PR DESCRIPTION
## 요약

`20260426000001_decks_words_jsonb` 마이그레이션의 `ALTER COLUMN ... USING` 절에 서브쿼리가 들어가 prod 적용 시 fail 한 문제 수정.

## 배경

PR #12 머지 후 워크플로우 첫 실행:

```
Applying migration 20260425000001_decks_categories.sql... ✅
Applying migration 20260426000001_decks_words_jsonb.sql...
ERROR: cannot use subquery in transform expression (SQLSTATE 0A000)
```

PostgreSQL은 `ALTER COLUMN ... TYPE ... USING (expression)`에서 **서브쿼리를 허용하지 않습니다** (`feature_not_supported`). 기존 마이그레이션은 USING 절에 다음을 직접 박았음:

```sql
USING (
  CASE
    WHEN words IS NULL THEN '[]'::jsonb
    ELSE COALESCE(
      (SELECT jsonb_agg(...) FROM unnest(words) AS w),  -- ← 서브쿼리
      '[]'::jsonb
    )
  END
)
```

## 변경

변환 로직을 `pg_temp` 스키마의 임시 함수로 감싸 USING 절에서는 **함수 호출(scalar expression)** 만 사용하도록 수정:

```sql
CREATE FUNCTION pg_temp.text_array_to_word_jsonb(arr TEXT[])
RETURNS JSONB LANGUAGE SQL IMMUTABLE AS $func$
  SELECT COALESCE(
    (SELECT jsonb_agg(jsonb_build_object('word', w, 'tags', '[]'::jsonb))
       FROM unnest(arr) AS w),
    '[]'::jsonb
  )
$func$;

ALTER TABLE public.decks
  ALTER COLUMN words TYPE JSONB
  USING (
    CASE
      WHEN words IS NULL THEN '[]'::jsonb
      ELSE pg_temp.text_array_to_word_jsonb(words)
    END
  );
```

`pg_temp` 스키마는 세션 종료 시 자동 정리되어 cleanup 불필요.

멱등성과 결과 데이터는 기존과 동일 (이미 JSONB이면 분기 통과 안 함).

## 머지 후 기대 동작

워크플로우 재실행 시 history에 없는 마이그레이션 두 개가 적용됨:

| # | 마이그레이션 | 효과 |
|---|---|---|
| 1 | `20260426000001_decks_words_jsonb` | `words` text[] → jsonb 변환 + 백필 |
| 2 | `20260428000001_decks_script` | `script TEXT` 추가 |

## 머지 후 검증

```sql
SELECT column_name, data_type FROM information_schema.columns
WHERE table_schema='public' AND table_name='decks'
ORDER BY ordinal_position;
```

`words=jsonb`, `script=text` 확인. 그 후 prod 덱 생성 정상 동작 확인.

https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC)_