### PR TITLE
fix(db): prod에 누락된 decks.categories 컬럼 복구

### DIFF
--- a/supabase/migrations/20260429000001_decks_recover_categories.sql
+++ b/supabase/migrations/20260429000001_decks_recover_categories.sql
@@ -1,0 +1,13 @@
+-- =============================================
+-- decks.categories 복구
+--
+-- 사정: 20260426000001_decks_words_jsonb 마이그레이션이 BEGIN/COMMIT으로
+-- 자기 트랜잭션을 명시했고, supabase CLI의 외부 트랜잭션과 nested 처리되면서
+-- migration history에는 등록됐으나 ADD COLUMN categories는 prod에 반영되지
+-- 않은 상태가 발생.
+--
+-- 멱등적이므로 이미 컬럼이 존재하는 dev 등 다른 환경에서는 skip됨.
+-- =============================================
+
+ALTER TABLE public.decks
+  ADD COLUMN IF NOT EXISTS categories TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## 요약

prod에 누락된 `decks.categories` 컬럼을 복구하고, 함께 미적용 상태였던 `decks.script` 컬럼도 워크플로우 자동 실행으로 적용.

## 배경

미로그인 사용자에게 덱이 안 보이는 문제 진단 결과 (DB는 RLS·권한·정책 모두 정상이고 `is_public = true`인 4개 덱 존재):

| 항목 | 상태 |
|---|---|
| `migration history` | `0425`, `0426` 등록됨, `0428` 등록 안 됨 |
| `decks.words` | `jsonb` ✅ |
| `decks.categories` | **prod에 컬럼 없음** ❌ |
| `decks.script` | **prod에 컬럼 없음** ❌ |

`getDecks` server action의 select 화이트리스트에는 `categories`/`script`가 포함되어 있어, 두 컬럼이 없는 prod에서 PostgREST가 `column does not exist` 에러를 반환 → server action이 빈 fallback → 미로그인 사용자에게 빈 화면.

## categories 누락 원인

`20260426000001_decks_words_jsonb.sql`이 마이그레이션 본문 자체에 `BEGIN; ... COMMIT;`을 명시했는데, supabase CLI가 마이그레이션을 외부 트랜잭션으로 한 번 더 감싸 적용하는 과정에서 nested 처리에 의해 `ADD COLUMN categories` 부분만 실제 commit이 누락된 것으로 추정. migration history에는 정상 등록되어 supabase db push가 재시도하지 않는 상태.

## 변경

`supabase/migrations/20260429000001_decks_recover_categories.sql` 신규:

```sql
ALTER TABLE public.decks
  ADD COLUMN IF NOT EXISTS categories TEXT[] NOT NULL DEFAULT '{}';
```

`IF NOT EXISTS`로 이미 컬럼이 있는 다른 환경(dev 등)에서는 자연스럽게 skip.

## 머지 시 일어날 일

워크플로우가 자동 트리거되어 history에 없는 마이그레이션을 순서대로 적용:

| # | 마이그레이션 | 효과 |
|---|---|---|
| 1 | `20260428000001_decks_script` | `script TEXT NOT NULL DEFAULT 'latin'` 추가 |
| 2 | `20260429000001_decks_recover_categories` | `categories TEXT[]` 복구 |

## 머지 후 검증

```sql
SELECT column_name, data_type FROM information_schema.columns
WHERE table_schema='public' AND table_name='decks'
  AND column_name IN ('script', 'categories');
```

→ 두 컬럼 모두 보여야 함.

```sql
SELECT version, name FROM supabase_migrations.schema_migrations ORDER BY version;
```

→ `0425`/`0426`/`0428`/`0429` 모두 등록.

이후 미로그인 상태에서 사이트 접속 → 4개 덱 표시되는지 확인.

## 후속 (별도)

향후 마이그레이션은 본문에 `BEGIN/COMMIT`을 명시하지 않는 게 안전합니다. supabase CLI가 자동 트랜잭션을 감싸므로 중복은 nested transaction이 되어 이번과 같은 부분 commit 사고 가능성을 만듭니다.

https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaPf29TERsMgLPCJkxJtLC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데크에 카테고리 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->