### PR TITLE
refactor(scripts): ScriptAdapter 인터페이스 마감 (PR 0c)

### DIFF
--- a/components/games/GameLoader.tsx
+++ b/components/games/GameLoader.tsx
@@ -34,14 +34,14 @@ export function GameLoader({ deck }: GameLoaderProps) {
 
   return (
     <div className="min-h-screen bg-gray-50 p-5 max-[480px]:p-2.5">
-      <WordleGrid gameState={gameState} showResult={showResult} />
+      <WordleGrid gameState={gameState} adapter={adapter} showResult={showResult} />
 
       <WordleKeyboard
         onKeyPress={handleKeyPress}
         onBackspace={handleBackspace}
         onEnter={handleEnter}
         keyboardState={gameState.keyboardState}
-        layout={adapter.keyboard}
+        adapter={adapter}
         disabled={isGameComplete(gameState)}
       />
 

--- a/components/games/WordleGrid.tsx
+++ b/components/games/WordleGrid.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { GameState } from "@/lib/wordleGame";
-import { getScriptAdapter } from "@/lib/scripts";
+import type { ScriptAdapter } from "@/lib/scripts/types";
 
 interface WordleGridProps {
   gameState: GameState;
+  adapter: ScriptAdapter;
   showResult?: boolean;
 }
 
-export function WordleGrid({ gameState, showResult = false }: WordleGridProps) {
+export function WordleGrid({ gameState, adapter, showResult = false }: WordleGridProps) {
   const { targetWord, guesses, currentGuess } = gameState;
-  const adapter = getScriptAdapter(gameState.adapterId);
   const wordLength = adapter.splitUnits(targetWord).length;
   const currentGuessUnits = adapter.splitUnits(currentGuess);
   const maxGuesses = gameState.maxGuesses;

--- a/components/games/WordleKeyboard.tsx
+++ b/components/games/WordleKeyboard.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { LetterState } from "@/lib/wordleGame";
-import type { KeyboardLayout } from "@/lib/scripts/types";
+import type { ScriptAdapter } from "@/lib/scripts/types";
 
 interface KeyboardProps {
   onKeyPress: (key: string) => void;
   onBackspace: () => void;
   onEnter: () => void;
   keyboardState: Record<string, LetterState>;
-  layout: KeyboardLayout;
+  adapter: ScriptAdapter;
   disabled?: boolean;
 }
 
@@ -17,16 +17,19 @@ export function WordleKeyboard({
   onBackspace,
   onEnter,
   keyboardState,
-  layout,
+  adapter,
   disabled = false
 }: KeyboardProps) {
+  const layout = adapter.keyboard;
+
   const getKeyClassName = (key: string): string => {
     const baseClass = "keyboard-key";
-    const state = keyboardState[key.toUpperCase()];
 
     if (key === layout.enterLabel || key === layout.backspaceLabel) {
       return `${baseClass} special-key ${disabled ? 'disabled' : ''}`;
     }
+
+    const state = keyboardState[adapter.keyId(key)];
 
     let stateClass = '';
     if (state === 'correct') stateClass = 'correct';

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -115,29 +115,30 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!gameState || isGameComplete(gameState)) return;
-      
-      const key = event.key.toUpperCase();
-      
-      // 특수 키 처리
-      if (key === 'ENTER') {
+
+      // 특수 키는 영문 그대로 비교 (브라우저 KeyboardEvent.key 표준값)
+      const rawKey = event.key;
+      const upperKey = rawKey.toUpperCase();
+
+      if (upperKey === 'ENTER') {
         event.preventDefault();
         handleEnter();
         return;
       }
-      
-      if (key === 'BACKSPACE' || key === 'DELETE') {
+
+      if (upperKey === 'BACKSPACE' || upperKey === 'DELETE') {
         event.preventDefault();
         handleBackspace();
         return;
       }
-      
-      // 알파벳만 허용 (길이가 1이고 A-Z인 경우만)
-      if (key.length === 1 && key.match(/[A-Z]/)) {
+
+      // 한 글자 입력은 어댑터로 위임
+      if (rawKey.length === 1 && adapter.isAllowedChar(rawKey)) {
         event.preventDefault();
-        handleKeyPress(key);
+        handleKeyPress(adapter.keyId(rawKey));
         return;
       }
-      
+
       // 다른 모든 키 차단
       if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
         event.preventDefault();
@@ -146,7 +147,7 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [gameState, handleKeyPress, handleBackspace, handleEnter]);
+  }, [gameState, handleKeyPress, handleBackspace, handleEnter, adapter]);
 
   // 게임 재시작
   const restartGame = useCallback(() => {

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -132,10 +132,11 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
         return;
       }
 
-      // 한 글자 입력은 어댑터로 위임
+      // 한 글자 입력: keyId는 키보드 상태 식별자라 입력 문자로 쓰면
+      // 비라틴 스크립트에서 currentGuess가 깨질 수 있음. 실제 입력 문자를 그대로 전달.
       if (rawKey.length === 1 && adapter.isAllowedChar(rawKey)) {
         event.preventDefault();
-        handleKeyPress(adapter.keyId(rawKey));
+        handleKeyPress(rawKey);
         return;
       }
 

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -4,7 +4,14 @@ import type { ScriptAdapter, ScriptId } from './types';
 const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin };
 
 export function getScriptAdapter(id: string): ScriptAdapter {
-  return ADAPTERS[id as ScriptId] ?? latin;
+  const adapter = ADAPTERS[id as ScriptId];
+  if (!adapter) {
+    if (id !== 'latin') {
+      console.warn(`Unknown script "${id}", falling back to latin`);
+    }
+    return latin;
+  }
+  return adapter;
 }
 
 export type { ScriptAdapter, ScriptId, KeyboardLayout } from './types';

--- a/lib/scripts/latin.ts
+++ b/lib/scripts/latin.ts
@@ -11,6 +11,7 @@ export const latin: ScriptAdapter = {
   rtl: false,
   splitUnits: (word) => Array.from(word),
   normalize: (word) => word.trim().toLowerCase(),
+  normalizeChar: (ch) => ch.toLowerCase(),
   isAllowedChar: (ch) => /^[a-zA-Z]$/.test(ch),
   isAllowedWord: (word) => /^[a-zA-Z]+$/.test(word),
   keyboard: {
@@ -18,4 +19,6 @@ export const latin: ScriptAdapter = {
     enterLabel: 'ENTER',
     backspaceLabel: 'BACKSPACE',
   },
+  keyId: (ch) => ch.toUpperCase(),
+  charDescription: '영문자(a-z, A-Z)',
 };

--- a/lib/scripts/types.ts
+++ b/lib/scripts/types.ts
@@ -18,7 +18,10 @@ export interface ScriptAdapter {
   rtl: boolean;
   splitUnits(word: string): string[];
   normalize(word: string): string;
+  normalizeChar(ch: string): string;
   isAllowedChar(ch: string): boolean;
   isAllowedWord(word: string): boolean;
   keyboard: KeyboardLayout;
+  keyId(ch: string): string;
+  charDescription: string;
 }

--- a/lib/wordConstraints.ts
+++ b/lib/wordConstraints.ts
@@ -15,13 +15,13 @@ export function validateWord(word: string, adapter: ScriptAdapter): WordValidati
   const errors: string[] = [];
 
   // 1글자 이상인지 확인
-  if (!word || word.length < 1) {
+  if (!word || adapter.splitUnits(word).length < 1) {
     errors.push('단어는 1글자 이상이어야 합니다.');
     return { isValid: false, errors };
   }
 
   if (!adapter.isAllowedWord(word)) {
-    errors.push('단어는 영문자(a-z, A-Z)만 사용할 수 있습니다.');
+    errors.push(`단어는 ${adapter.charDescription}만 사용할 수 있습니다.`);
   }
 
   return {
@@ -219,11 +219,12 @@ export function validateWordForGame(
   }
 
   // 길이 검사
-  if (word.length < minLength) {
+  const unitLength = adapter.splitUnits(word).length;
+  if (unitLength < minLength) {
     errors.push(`단어는 최소 ${minLength}글자 이상이어야 합니다.`);
   }
 
-  if (word.length > maxLength) {
+  if (unitLength > maxLength) {
     errors.push(`단어는 최대 ${maxLength}글자까지 가능합니다.`);
   }
 

--- a/lib/wordleGame.ts
+++ b/lib/wordleGame.ts
@@ -57,7 +57,7 @@ export function addLetterToGuess(gameState: GameState, letter: string): GameStat
 
   return {
     ...gameState,
-    currentGuess: gameState.currentGuess + adapter.normalize(letter),
+    currentGuess: gameState.currentGuess + adapter.normalizeChar(letter),
     errorMessage: undefined // 입력 시 에러 메시지 초기화
   };
 }
@@ -101,14 +101,14 @@ export function submitGuess(gameState: GameState): GameState {
   const newKeyboardState = { ...gameState.keyboardState };
   newGuess.letters.forEach(letter => {
     if (letter.char && letter.state !== 'empty') {
-      // 키보드에서는 대문자로 저장 (키보드 배열이 대문자이므로)
-      const upperChar = letter.char.toUpperCase();
+      // 어댑터의 keyId로 키보드 상태 키 결정
+      const keyId = adapter.keyId(letter.char);
       // 더 높은 우선순위 상태로 업데이트 (correct > present > absent)
-      const currentState = newKeyboardState[upperChar];
+      const currentState = newKeyboardState[keyId];
       if (!currentState ||
           (currentState === 'absent' && letter.state !== 'absent') ||
           (currentState === 'present' && letter.state === 'correct')) {
-        newKeyboardState[upperChar] = letter.state;
+        newKeyboardState[keyId] = letter.state;
       }
     }
   });


### PR DESCRIPTION
## 요약

PR 0b에서 도입한 `ScriptAdapter` 추상화를 후속 phase(키릴/그리스/한글 등) 진입 전에 정리하는 마감 작업입니다. 라틴 어댑터 동작은 PR 0b 머지 직후 상태와 **비트 단위 동치**입니다.

PR 0b 리뷰 피드백 항목 **2.1 / 2.2 / 2.3 / 2.4 / 3.1 / 4.2** 반영.

## 주요 변경

### 1. ScriptAdapter 인터페이스 확장 (`lib/scripts/types.ts`, `lib/scripts/latin.ts`)
- `normalizeChar(ch)` — 한 글자 정규화 (라틴: `toLowerCase()`)
- `keyId(ch)` — 키보드 상태 추적 식별자 (라틴: `toUpperCase()`)
- `charDescription` — 검증 에러 메시지 보간용 (라틴: `'영문자(a-z, A-Z)'`)

### 2. 검증 로직 일반화 (`lib/wordConstraints.ts`) — 리뷰 2.1 / 2.2
- `validateWord` / `validateWordForGame`의 길이 검사를 `word.length`에서 `adapter.splitUnits(word).length`로 교체
- 하드코딩된 `'단어는 영문자(a-z, A-Z)만 사용할 수 있습니다.'` → `` `단어는 ${adapter.charDescription}만 사용할 수 있습니다.` ``
  (라틴에서는 텍스트 그대로 유지)

### 3. 게임 로직 일반화 (`lib/wordleGame.ts`) — 리뷰 2.3 / 2.4
- `addLetterToGuess`: `adapter.normalize(letter)` → `adapter.normalizeChar(letter)`
  (한 글자에 `trim()`은 의미 없음)
- `submitGuess` 키보드 상태 키: `letter.char.toUpperCase()` → `adapter.keyId(letter.char)`

### 4. 컴포넌트/훅 prop 정리 — 리뷰 2.3 / 3.1
- `hooks/useGame.ts`: `event.key.toUpperCase()` 분기를 `adapter.isAllowedChar` 위임으로 변경. **물리 키보드 입력 문자는 raw key 그대로 `handleKeyPress`에 전달** (정규화는 `addLetterToGuess` → `adapter.normalizeChar`에 일임). `keyId`는 키보드 상태 추적 전용으로 분리.
- `components/games/WordleKeyboard.tsx`: `layout` prop 제거, `adapter` prop을 받아 `adapter.keyId(key)`로 상태 조회
- `components/games/WordleGrid.tsx`: 내부 `getScriptAdapter` 재호출 제거, `adapter` prop으로 수신
- `components/games/GameLoader.tsx`: 동일 adapter 인스턴스를 `useGame` / `WordleGrid` / `WordleKeyboard`에 일관되게 전달

### 5. 미등록 script 경고 (`lib/scripts/index.ts`) — 리뷰 4.2
- `getScriptAdapter(id)`가 미등록 id에 대해 latin으로 fallback할 때 `console.warn` 추가
- `id === 'latin'`인 경우(이론상 도달 불가)는 경고 생략

## 리뷰 피드백 반영 (PR 0c 자체 리뷰)

### Blocking ✅ 수정 완료 (commit `fbf310d`)
- **물리 키보드 입력에서 `keyId`를 입력 문자로 사용하던 문제** — `keyId`는 표시/상태 조회용 canonical id라 비라틴 스크립트에서 `currentGuess`가 깨질 수 있음. `handleKeyPress(rawKey)`로 변경하고 정규화는 `addLetterToGuess`의 `normalizeChar`에 일임.

### Non-blocking — 후속 트랙 처리
1. **`enterKeyId`/`backspaceKeyId` 분리** — 현 라틴 라벨이 영어 `'ENTER'`/`'BACKSPACE'`라 안전. i18n 트랙(`charDescription` 한국어 하드코딩 정리)과 함께 일괄 처리하는 게 자연스럽다고 판단.
2. **deck 로딩 시 unknown script hard fail** — PR 0c 사양서가 "fallback + warn"을 명시했고, 현 시점엔 라틴 외 어댑터가 없어 실제 도달 케이스가 없음. Phase 1 새 어댑터 등록 시 deck validation 단계에 명시적 에러를 추가하는 게 자연스러움.

## 손대지 않은 범위 (의도)
- 새 script 어댑터 추가 — Phase 1 작업
- 덱 폼 script 셀렉터 — Phase 1 작업
- AI 프롬프트 분기 — Phase 1 작업
- i18n 인프라 — `charDescription`은 한국어 하드코딩 유지, 후속 i18n 트랙에서 일괄 처리

## 자동 검증 결과
- `pnpm exec tsc --noEmit` ✅ 통과
- `pnpm lint` ✅ 0 errors (4 pre-existing warnings, 본 PR과 무관)
- `pnpm build` ✅ 통과

## 회귀 검증 체크리스트 (수동)
라틴 덱 동작이 PR 0b 머지 직후 상태와 비트 단위 동일한지 확인합니다.

- [x] `pnpm typecheck` 통과 (= `tsc --noEmit`)
- [x] `pnpm lint` 통과
- [ ] dev 서버에서 라틴 덱 한 판 플레이:
  - [ ] 알파벳 입력 정상 (대/소문자 모두 lowercase로 처리)
  - [ ] 알파벳 외 키 입력 무시
  - [ ] correct/present/absent 색상 동일
  - [ ] 키보드 색상 누적 갱신 동일 (correct가 present 위에 덮어쓰기)
  - [ ] validWords 외 단어 입력 시 "단어 목록에 없는 단어입니다." 메시지 동일
- [ ] 덱 생성 시 알파벳 외 입력 → "단어는 영문자(a-z, A-Z)만 사용할 수 있습니다." (텍스트 변경 없이 그대로)
- [ ] 빈 단어 입력 → 기존 메시지 동일
