### PR TITLE
feat(scripts): 키릴/그리스 어댑터 + 덱 폼 script 셀렉터

### DIFF
--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -15,6 +15,18 @@ import { ActionResponse } from "@/types/action";
 import { Deck } from "@/types/decks";
 import { safeAction } from "@/lib/safe-action";
 
+const ALLOWED_SCRIPTS = ["latin", "cyrillic", "greek"] as const;
+type AllowedScript = (typeof ALLOWED_SCRIPTS)[number];
+
+function readScript(formData: FormData): AllowedScript | null {
+  const raw = formData.get("script");
+  if (raw == null || raw === "") return "latin";
+  if (typeof raw !== "string") return null;
+  return (ALLOWED_SCRIPTS as readonly string[]).includes(raw)
+    ? (raw as AllowedScript)
+    : null;
+}
+
 const ANON_HANDLE_MIN = 2;
 const ANON_HANDLE_MAX = 20;
 const ANON_PASSWORD_MIN = 4;
@@ -276,7 +288,16 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<Dec
       };
     }
 
-    const parsed = parseDeckPayload(formData);
+    const script = readScript(formData);
+    if (!script) {
+      return {
+        success: false,
+        message: "지원하지 않는 쓰기체계입니다.",
+        fieldErrors: { script: ["지원하지 않는 쓰기체계입니다."] },
+      };
+    }
+
+    const parsed = parseDeckPayload(formData, script);
     if (!parsed.ok) {
       return {
         success: false,
@@ -292,6 +313,7 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<Dec
         description: description || null,
         words: parsed.words,
         categories: parsed.categories,
+        script,
         is_public: isPublic,
         creator_id: user.id,
         thumbnail_url: thumbnailUrl || null,
@@ -353,7 +375,16 @@ export async function createAnonymousDeck(formData: FormData): Promise<ActionRes
       };
     }
 
-    const parsed = parseDeckPayload(formData);
+    const script = readScript(formData);
+    if (!script) {
+      return {
+        success: false,
+        message: "지원하지 않는 쓰기체계입니다.",
+        fieldErrors: { script: ["지원하지 않는 쓰기체계입니다."] },
+      };
+    }
+
+    const parsed = parseDeckPayload(formData, script);
     if (!parsed.ok) {
       return {
         success: false,
@@ -371,6 +402,7 @@ export async function createAnonymousDeck(formData: FormData): Promise<ActionRes
         description: description || null,
         words: parsed.words,
         categories: parsed.categories,
+        script,
         is_public: true,
         creator_id: null,
         author_handle: authorHandle,
@@ -432,19 +464,10 @@ export async function updateDeck(id: string, formData: FormData): Promise<Action
       };
     }
 
-    const parsed = parseDeckPayload(formData);
-    if (!parsed.ok) {
-      return {
-        success: false,
-        message: parsed.message,
-        fieldErrors: parsed.fieldErrors,
-      };
-    }
-
-    // 먼저 덱이 존재하는지 확인
+    // 먼저 덱이 존재하는지 확인 (script는 기존 값 유지)
     const { data: existingDeck, error: checkError } = await supabase
       .from("decks")
-      .select("id, creator_id, name, updated_at")
+      .select("id, creator_id, name, updated_at, script")
       .eq("id", id)
       .single();
 
@@ -469,6 +492,21 @@ export async function updateDeck(id: string, formData: FormData): Promise<Action
       return {
         success: false,
         message: "이 덱을 수정할 권한이 없습니다.",
+      };
+    }
+
+    const existingScript =
+      typeof existingDeck.script === "string" &&
+      (ALLOWED_SCRIPTS as readonly string[]).includes(existingDeck.script)
+        ? (existingDeck.script as AllowedScript)
+        : "latin";
+
+    const parsed = parseDeckPayload(formData, existingScript);
+    if (!parsed.ok) {
+      return {
+        success: false,
+        message: parsed.message,
+        fieldErrors: parsed.fieldErrors,
       };
     }
 

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -6,7 +6,7 @@ import { redirect } from "next/navigation";
 import bcrypt from "bcryptjs";
 import { validateDeckWords } from "@/lib/wordConstraints";
 import { MAX_TAGS_PER_WORD, normalizeCategories } from "@/lib/deckCategories";
-import { getScriptAdapter } from "@/lib/scripts";
+import { getScriptAdapter, isSupportedScript, type ScriptId } from "@/lib/scripts";
 import type { DeckWord } from "@/types/decks";
 import { getUserInfo } from "@/app/actions/user";
 import { User } from "@supabase/supabase-js";
@@ -15,16 +15,10 @@ import { ActionResponse } from "@/types/action";
 import { Deck } from "@/types/decks";
 import { safeAction } from "@/lib/safe-action";
 
-const ALLOWED_SCRIPTS = ["latin", "cyrillic", "greek"] as const;
-type AllowedScript = (typeof ALLOWED_SCRIPTS)[number];
-
-function readScript(formData: FormData): AllowedScript | null {
+function readScript(formData: FormData): ScriptId | null {
   const raw = formData.get("script");
   if (raw == null || raw === "") return "latin";
-  if (typeof raw !== "string") return null;
-  return (ALLOWED_SCRIPTS as readonly string[]).includes(raw)
-    ? (raw as AllowedScript)
-    : null;
+  return isSupportedScript(raw) ? raw : null;
 }
 
 const ANON_HANDLE_MIN = 2;
@@ -495,11 +489,9 @@ export async function updateDeck(id: string, formData: FormData): Promise<Action
       };
     }
 
-    const existingScript =
-      typeof existingDeck.script === "string" &&
-      (ALLOWED_SCRIPTS as readonly string[]).includes(existingDeck.script)
-        ? (existingDeck.script as AllowedScript)
-        : "latin";
+    const existingScript: ScriptId = isSupportedScript(existingDeck.script)
+      ? existingDeck.script
+      : "latin";
 
     const parsed = parseDeckPayload(formData, existingScript);
     if (!parsed.ok) {

--- a/components/decks/DeckDialog.tsx
+++ b/components/decks/DeckDialog.tsx
@@ -29,6 +29,20 @@ import { WordList } from "@/components/decks/WordList";
 import type { WordRowValue } from "@/components/decks/WordRow";
 import { AiImportPanel } from "@/components/decks/AiImportPanel";
 import type { ParsedAiDeck } from "@/lib/parseAiDeckResponse";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getScriptAdapter, type ScriptId } from "@/lib/scripts";
+
+const SCRIPT_OPTIONS: { value: ScriptId; label: string }[] = [
+  { value: "latin", label: "영어 (Latin)" },
+  { value: "cyrillic", label: "русский (Cyrillic)" },
+  { value: "greek", label: "Ελληνικά (Greek)" },
+];
 
 interface DeckDialogProps {
   deck?: Deck; // deck이 있으면 수정 모드, 없으면 생성 모드
@@ -81,6 +95,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
   const [name, setName] = useState(deck?.name ?? "");
   const [description, setDescription] = useState(deck?.description ?? "");
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
+  const [script, setScript] = useState<ScriptId>(
+    (deck?.script as ScriptId) ?? "latin"
+  );
 
   const isEditMode = !!deck;
   const isAnonymousCreate = !isEditMode && !isAuthenticated;
@@ -98,6 +115,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
       setName(deck?.name ?? "");
       setDescription(deck?.description ?? "");
       setAiPanelOpen(false);
+      setScript((deck?.script as ScriptId) ?? "latin");
     }
   }, [open, deck]);
 
@@ -385,9 +403,11 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
     setIsLoading(true);
 
     try {
-      // 빈 행 자동 제거 + lowercase 정규화
+      const adapter = getScriptAdapter(script);
+
+      // 빈 행 자동 제거 + 어댑터 기반 정규화
       const trimmedRows = formState.words
-        .map((row) => ({ ...row, word: row.word.trim().toLowerCase() }))
+        .map((row) => ({ ...row, word: adapter.normalize(row.word) }))
         .filter((row) => row.word.length > 0);
 
       if (trimmedRows.length === 0) {
@@ -395,9 +415,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
         return;
       }
 
-      const invalidRow = trimmedRows.find((row) => !/^[a-z]+$/.test(row.word));
+      const invalidRow = trimmedRows.find((row) => !adapter.isAllowedWord(row.word));
       if (invalidRow) {
-        toast.error(`"${invalidRow.word}"는 영문자(a-z)만 사용할 수 있습니다.`);
+        toast.error(`"${invalidRow.word}"는 ${adapter.charDescription}만 사용할 수 있습니다.`);
         return;
       }
 
@@ -427,6 +447,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
 
       formData.set("words_json", JSON.stringify(serializedWords));
       formData.set("categories_json", JSON.stringify(serializedCategories));
+      formData.set("script", script);
       formData.delete("words");
 
       // 익명 덱 생성: 썸네일·공개 토글 없이 바로 생성
@@ -619,6 +640,31 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
             )}
 
             <div className="space-y-2">
+              <Label htmlFor="script">쓰기체계</Label>
+              <Select
+                value={script}
+                onValueChange={(value) => setScript(value as ScriptId)}
+                disabled={isEditMode}
+              >
+                <SelectTrigger id="script" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SCRIPT_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {isEditMode && (
+                <p className="text-xs text-muted-foreground">
+                  쓰기체계는 덱 생성 후에는 변경할 수 없습니다.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="description">설명</Label>
               <Textarea
                 id="description"
@@ -638,7 +684,15 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                     type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => setAiPanelOpen((v) => !v)}
+                    onClick={() => {
+                      if (script !== "latin") {
+                        toast.error(
+                          "AI 가져오기는 현재 영어 덱에서만 지원됩니다."
+                        );
+                        return;
+                      }
+                      setAiPanelOpen((v) => !v);
+                    }}
                     aria-expanded={aiPanelOpen}
                     aria-controls="ai-import-panel"
                     className="h-8 gap-1.5 text-xs"
@@ -662,7 +716,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                 </div>
               </div>
 
-              {aiPanelOpen && (
+              {aiPanelOpen && script === "latin" && (
                 <div id="ai-import-panel">
                   <AiImportPanel onImport={handleAiImport} />
                 </div>

--- a/components/decks/DeckDialog.tsx
+++ b/components/decks/DeckDialog.tsx
@@ -36,13 +36,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getScriptAdapter, type ScriptId } from "@/lib/scripts";
+import {
+  getScriptAdapter,
+  isSupportedScript,
+  SUPPORTED_SCRIPTS,
+  type ScriptId,
+} from "@/lib/scripts";
 
-const SCRIPT_OPTIONS: { value: ScriptId; label: string }[] = [
-  { value: "latin", label: "영어 (Latin)" },
-  { value: "cyrillic", label: "русский (Cyrillic)" },
-  { value: "greek", label: "Ελληνικά (Greek)" },
-];
+const SCRIPT_LABELS: Record<ScriptId, string> = {
+  latin: "영어 (Latin)",
+  cyrillic: "русский (Cyrillic)",
+  greek: "Ελληνικά (Greek)",
+  hangul: "한국어 (Hangul)",
+  kana: "日本語 (Kana)",
+  hebrew: "עברית (Hebrew)",
+  arabic: "العربية (Arabic)",
+};
 
 interface DeckDialogProps {
   deck?: Deck; // deck이 있으면 수정 모드, 없으면 생성 모드
@@ -96,7 +105,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
   const [description, setDescription] = useState(deck?.description ?? "");
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [script, setScript] = useState<ScriptId>(
-    (deck?.script as ScriptId) ?? "latin"
+    isSupportedScript(deck?.script) ? deck.script : "latin"
   );
 
   const isEditMode = !!deck;
@@ -115,7 +124,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
       setName(deck?.name ?? "");
       setDescription(deck?.description ?? "");
       setAiPanelOpen(false);
-      setScript((deck?.script as ScriptId) ?? "latin");
+      setScript(isSupportedScript(deck?.script) ? deck.script : "latin");
     }
   }, [open, deck]);
 
@@ -447,7 +456,10 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
 
       formData.set("words_json", JSON.stringify(serializedWords));
       formData.set("categories_json", JSON.stringify(serializedCategories));
-      formData.set("script", script);
+      // 수정 모드에서는 서버가 기존 deck.script를 사용하므로 전송하지 않음
+      if (!isEditMode) {
+        formData.set("script", script);
+      }
       formData.delete("words");
 
       // 익명 덱 생성: 썸네일·공개 토글 없이 바로 생성
@@ -650,9 +662,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {SCRIPT_OPTIONS.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
+                  {SUPPORTED_SCRIPTS.map((id) => (
+                    <SelectItem key={id} value={id}>
+                      {SCRIPT_LABELS[id]}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -680,26 +692,27 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
               <div className="flex items-center justify-between gap-2">
                 <Label>단어 목록 *</Label>
                 <div className="flex items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      if (script !== "latin") {
-                        toast.error(
-                          "AI 가져오기는 현재 영어 덱에서만 지원됩니다."
-                        );
-                        return;
-                      }
-                      setAiPanelOpen((v) => !v);
-                    }}
-                    aria-expanded={aiPanelOpen}
-                    aria-controls="ai-import-panel"
-                    className="h-8 gap-1.5 text-xs"
+                  <span
+                    title={
+                      script !== "latin"
+                        ? "AI 가져오기는 현재 영어 덱에서만 지원됩니다."
+                        : undefined
+                    }
                   >
-                    <Sparkles className="size-3.5" />
-                    {aiPanelOpen ? "AI 패널 접기" : "AI로 가져오기"}
-                  </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setAiPanelOpen((v) => !v)}
+                      disabled={script !== "latin"}
+                      aria-expanded={aiPanelOpen}
+                      aria-controls="ai-import-panel"
+                      className="h-8 gap-1.5 text-xs"
+                    >
+                      <Sparkles className="size-3.5" />
+                      {aiPanelOpen ? "AI 패널 접기" : "AI로 가져오기"}
+                    </Button>
+                  </span>
                   <div className="flex items-center gap-2">
                     <Label
                       htmlFor="uses_categories"

--- a/lib/scripts/cyrillic.ts
+++ b/lib/scripts/cyrillic.ts
@@ -1,0 +1,30 @@
+import type { ScriptAdapter } from './types';
+
+const KEYBOARD_ROWS: string[][] = [
+  ['Й', 'Ц', 'У', 'К', 'Е', 'Н', 'Г', 'Ш', 'Щ', 'З', 'Х', 'Ъ'],
+  ['Ф', 'Ы', 'В', 'А', 'П', 'Р', 'О', 'Л', 'Д', 'Ж', 'Э'],
+  ['ENTER', 'Я', 'Ч', 'С', 'М', 'И', 'Т', 'Ь', 'Б', 'Ю', 'BACKSPACE'],
+];
+
+const normalizeWord = (word: string) =>
+  word.trim().toLowerCase().replace(/ё/g, 'е');
+
+const normalizeSingleChar = (ch: string) =>
+  ch.toLowerCase().replace(/ё/g, 'е');
+
+export const cyrillic: ScriptAdapter = {
+  id: 'cyrillic',
+  rtl: false,
+  splitUnits: (word) => Array.from(word.normalize('NFC')),
+  normalize: normalizeWord,
+  normalizeChar: normalizeSingleChar,
+  isAllowedChar: (ch) => /^[а-я]$/.test(normalizeSingleChar(ch)),
+  isAllowedWord: (word) => /^[а-я]+$/.test(normalizeWord(word)),
+  keyboard: {
+    rows: KEYBOARD_ROWS,
+    enterLabel: 'ENTER',
+    backspaceLabel: 'BACKSPACE',
+  },
+  keyId: (ch) => ch.toUpperCase(),
+  charDescription: '키릴 문자(а-я)',
+};

--- a/lib/scripts/greek.ts
+++ b/lib/scripts/greek.ts
@@ -1,0 +1,34 @@
+import type { ScriptAdapter } from './types';
+
+const KEYBOARD_ROWS: string[][] = [
+  ['Ε', 'Ρ', 'Τ', 'Υ', 'Θ', 'Ι', 'Ο', 'Π'],
+  ['Α', 'Σ', 'Δ', 'Φ', 'Γ', 'Η', 'Ξ', 'Κ', 'Λ'],
+  ['ENTER', 'Ζ', 'Χ', 'Ψ', 'Ω', 'Β', 'Ν', 'Μ', 'BACKSPACE'],
+];
+
+const TONE_MARKS = /[̀-ͯ]/g;
+
+const stripTones = (s: string) => s.normalize('NFD').replace(TONE_MARKS, '').normalize('NFC');
+
+const normalizeWord = (word: string) =>
+  stripTones(word.trim().toLowerCase()).replace(/ς/g, 'σ');
+
+const normalizeSingleChar = (ch: string) =>
+  stripTones(ch.toLowerCase()).replace(/ς/g, 'σ');
+
+export const greek: ScriptAdapter = {
+  id: 'greek',
+  rtl: false,
+  splitUnits: (word) => Array.from(stripTones(word)),
+  normalize: normalizeWord,
+  normalizeChar: normalizeSingleChar,
+  isAllowedChar: (ch) => /^[α-ω]$/.test(normalizeSingleChar(ch)),
+  isAllowedWord: (word) => /^[α-ω]+$/.test(normalizeWord(word)),
+  keyboard: {
+    rows: KEYBOARD_ROWS,
+    enterLabel: 'ENTER',
+    backspaceLabel: 'BACKSPACE',
+  },
+  keyId: (ch) => ch.toUpperCase(),
+  charDescription: '그리스 문자(α-ω)',
+};

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -1,7 +1,13 @@
+import { cyrillic } from './cyrillic';
+import { greek } from './greek';
 import { latin } from './latin';
 import type { ScriptAdapter, ScriptId } from './types';
 
-const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin };
+const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = {
+  latin,
+  cyrillic,
+  greek,
+};
 
 export function getScriptAdapter(id: string): ScriptAdapter {
   const adapter = ADAPTERS[id as ScriptId];

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -9,6 +9,12 @@ const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = {
   greek,
 };
 
+export const SUPPORTED_SCRIPTS = Object.keys(ADAPTERS) as ScriptId[];
+
+export function isSupportedScript(id: unknown): id is ScriptId {
+  return typeof id === 'string' && (SUPPORTED_SCRIPTS as string[]).includes(id);
+}
+
 export function getScriptAdapter(id: string): ScriptAdapter {
   const adapter = ADAPTERS[id as ScriptId];
   if (!adapter) {
@@ -21,3 +27,4 @@ export function getScriptAdapter(id: string): ScriptAdapter {
 }
 
 export type { ScriptAdapter, ScriptId, KeyboardLayout } from './types';
+


### PR DESCRIPTION
## 요약

multi-script Phase 1: IME가 필요 없는 단일 codepoint 스크립트(키릴·그리스) 어댑터를 도입하고, 덱 생성/수정 폼에 `script` 셀렉터를 추가합니다. 후속 어댑터 PR이 registry에만 등록하면 UI/서버 양쪽이 자동 반영되도록 인프라를 단일화했습니다.

### 어댑터

- **키릴 어댑터** (`lib/scripts/cyrillic.ts`): ЙЦУКЕН 자판, `ё→е` 정규화, `[а-я]` 검증
- **그리스 어댑터** (`lib/scripts/greek.ts`): 표준 그리스 자판, NFD 톤 마크(`̀-ͯ`) 제거 + 끝-시그마 `ς→σ` 정규화, `[α-ω]` 검증
- **레지스트리** (`lib/scripts/index.ts`): 두 어댑터 등록 + `SUPPORTED_SCRIPTS` / `isSupportedScript()` export

### 폼·검증·가드

- **덱 폼** (`components/decks/DeckDialog.tsx`): shadcn `Select`로 영어 / русский / Ελληνικά 선택. **수정 모드에서는 disabled** (단어 검증 정합성 깨짐 방지)
- **클라이언트 검증**: 하드코드된 `/^[a-z]+$/`·`toLowerCase()`를 어댑터의 `normalize` / `isAllowedWord` / `charDescription`로 위임
- **서버** (`app/actions/deck.ts`): `isSupportedScript()` 가드. 생성 시 `script` 저장, 수정 시에는 기존 `deck.script`로 잠가 검증
- **AI 가져오기 가드**: `script !== 'latin'`일 때 버튼 `disabled` + hover tooltip(`'AI 가져오기는 현재 영어 덱에서만 지원됩니다.'`)

### 리뷰 후속 반영 (2차 커밋)

- 🔴 **`ALLOWED_SCRIPTS` 하드코딩 제거**: `SUPPORTED_SCRIPTS = Object.keys(ADAPTERS)`로 단일화 — 후속 어댑터(한글/히브리/…) PR이 registry에만 등록하면 셀렉터·서버 화이트리스트가 자동 반영
- 🔴 **`deck?.script as ScriptId` 무검증 캐스팅 제거**: `isSupportedScript()` 가드 + latin fallback
- 🟡 **수정 모드에서 `formData.set('script', ...)` 생략**: 서버는 기존 `deck.script` 사용
- 🟡 **AI import UX**: toast 거부 → 버튼 disabled + tooltip

### 보류 (별도 PR)

- 🟢 cyrillic/greek unit test — PR #30(Phase 2a 한글)에서 vitest 도입 예정, 같은 도구로 통일

## 손대지 않은 것

- 한글/가나/RTL 어댑터 (Phase 2+)
- AI 프롬프트의 키릴/그리스 지원 (별도 트랙)
- 폼 레이아웃 대규모 개편 (셀렉터 한 줄만 추가)

## 회귀 검증

- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과 (기존 워닝 4건은 본 변경과 무관)
- [ ] **라틴 덱**: 변경 전과 동일 (생성·플레이·키보드·메시지)
- [ ] **키릴 덱 생성**: "русский" 선택 시 라틴 입력 거부 (`'단어는 키릴 문자(а-я)만 사용할 수 있습니다.'`)
- [ ] **키릴 덱 플레이**: ЙЦУКЕН 자판, 색상 갱신, `ё`↔`е` 동치 매칭
- [ ] **그리스 덱 생성**: "Ελληνικά" 선택 시 그리스 외 거부
- [ ] **그리스 덱 플레이**: 그리스 자판, `ά`↔`α` 동치
- [ ] **AI 가져오기**: 라틴만 가능, 다른 script 선택 시 버튼 disabled + tooltip
- [ ] **수정 모드**: script 셀렉터 disabled, formData에 script 미전송

Closes #22