### PR TITLE
feat(scripts): 히브리어 어댑터 + RTL 그리드

### DIFF
--- a/components/games/WordleGrid.tsx
+++ b/components/games/WordleGrid.tsx
@@ -158,7 +158,7 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
           }
         }
       `}</style>
-      <div className="wordle-grid">
+      <div className="wordle-grid" dir={adapter.rtl ? 'rtl' : 'ltr'}>
         {rows}
       </div>
     </>

--- a/lib/scripts/__tests__/hebrew.test.ts
+++ b/lib/scripts/__tests__/hebrew.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hebrew } from '../hebrew';
+
+describe('hebrew.normalize', () => {
+  it('sofit → 일반형 (kaf/mem/nun/pe/tsadi)', () => {
+    assert.equal(hebrew.normalize('שלום'), 'שלומ'); // ם → מ
+    assert.equal(hebrew.normalize('מלך'), 'מלכ'); // ך → כ
+    assert.equal(hebrew.normalize('דין'), 'דינ'); // ן → נ
+    assert.equal(hebrew.normalize('כסף'), 'כספ'); // ף → פ
+    assert.equal(hebrew.normalize('עץ'), 'עצ'); // ץ → צ
+  });
+
+  it('이미 일반형인 문자는 그대로', () => {
+    assert.equal(hebrew.normalize('כמנפצ'), 'כמנפצ');
+  });
+
+  it('trim 적용', () => {
+    assert.equal(hebrew.normalize('  שלום  '), 'שלומ');
+  });
+});
+
+describe('hebrew.normalizeChar', () => {
+  it('sofit 단일 문자 매핑', () => {
+    assert.equal(hebrew.normalizeChar('ך'), 'כ');
+    assert.equal(hebrew.normalizeChar('ם'), 'מ');
+    assert.equal(hebrew.normalizeChar('ן'), 'נ');
+    assert.equal(hebrew.normalizeChar('ף'), 'פ');
+    assert.equal(hebrew.normalizeChar('ץ'), 'צ');
+  });
+});
+
+describe('hebrew.splitUnits', () => {
+  it('codepoint 단위 분리', () => {
+    assert.deepEqual(hebrew.splitUnits('שלום'), ['ש', 'ל', 'ו', 'ם']);
+  });
+});
+
+describe('hebrew.isAllowedChar / isAllowedWord', () => {
+  it('히브리 자모 허용 (sofit 포함)', () => {
+    assert.equal(hebrew.isAllowedChar('א'), true);
+    assert.equal(hebrew.isAllowedChar('ת'), true);
+    assert.equal(hebrew.isAllowedChar('ך'), true);
+    assert.equal(hebrew.isAllowedChar('ם'), true);
+  });
+
+  it('비히브리 거부', () => {
+    assert.equal(hebrew.isAllowedChar('a'), false);
+    assert.equal(hebrew.isAllowedChar('1'), false);
+    assert.equal(hebrew.isAllowedChar(' '), false);
+    assert.equal(hebrew.isAllowedWord('shalom'), false);
+    assert.equal(hebrew.isAllowedWord('שלום!'), false);
+  });
+
+  it('히브리 단어 허용 (sofit 포함)', () => {
+    assert.equal(hebrew.isAllowedWord('שלום'), true);
+    assert.equal(hebrew.isAllowedWord('מלך'), true);
+  });
+});
+
+describe('hebrew.keyId', () => {
+  it('sofit 입력도 일반형 키로 매핑', () => {
+    assert.equal(hebrew.keyId('ך'), 'כ');
+    assert.equal(hebrew.keyId('כ'), 'כ');
+  });
+});
+
+describe('hebrew adapter shape', () => {
+  it('rtl=true, id=hebrew', () => {
+    assert.equal(hebrew.id, 'hebrew');
+    assert.equal(hebrew.rtl, true);
+  });
+});

--- a/lib/scripts/hebrew.ts
+++ b/lib/scripts/hebrew.ts
@@ -1,0 +1,43 @@
+import type { ScriptAdapter } from './types';
+
+const SOFIT_MAP: Record<string, string> = {
+  'ך': 'כ',
+  'ם': 'מ',
+  'ן': 'נ',
+  'ף': 'פ',
+  'ץ': 'צ',
+};
+
+function foldSofit(word: string): string {
+  let out = '';
+  for (const ch of word) {
+    out += SOFIT_MAP[ch] ?? ch;
+  }
+  return out;
+}
+
+const HEBREW_RE = /^[א-ת]$/;
+const HEBREW_WORD_RE = /^[א-ת]+$/;
+
+const KEYBOARD_ROWS: string[][] = [
+  ['ק', 'ר', 'א', 'ט', 'ו', 'ן', 'ם', 'פ'],
+  ['ש', 'ד', 'ג', 'כ', 'ע', 'י', 'ח', 'ל', 'ך', 'ף'],
+  ['ENTER', 'ז', 'ס', 'ב', 'ה', 'נ', 'מ', 'צ', 'ת', 'ץ', 'BACKSPACE'],
+];
+
+export const hebrew: ScriptAdapter = {
+  id: 'hebrew',
+  rtl: true,
+  splitUnits: (word) => Array.from(word.normalize('NFC')),
+  normalize: (word) => foldSofit(word.trim().normalize('NFC')),
+  normalizeChar: (ch) => foldSofit(ch.normalize('NFC')),
+  isAllowedChar: (ch) => HEBREW_RE.test(foldSofit(ch.normalize('NFC'))),
+  isAllowedWord: (word) => HEBREW_WORD_RE.test(foldSofit(word.normalize('NFC'))),
+  keyboard: {
+    rows: KEYBOARD_ROWS,
+    enterLabel: 'ENTER',
+    backspaceLabel: 'BACKSPACE',
+  },
+  keyId: (ch) => foldSofit(ch.normalize('NFC')),
+  charDescription: '히브리 문자(א-ת)',
+};

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -1,7 +1,8 @@
 import { latin } from './latin';
+import { hebrew } from './hebrew';
 import type { ScriptAdapter, ScriptId } from './types';
 
-const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin };
+const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin, hebrew };
 
 export function getScriptAdapter(id: string): ScriptAdapter {
   const adapter = ADAPTERS[id as ScriptId];


### PR DESCRIPTION
## 요약

Phase 4a: 히브리어 어댑터 추가 + RTL(Right-to-Left) 그리드 인프라 도입.

- `lib/scripts/hebrew.ts` 신규 — `rtl: true` 어댑터, sofit 5글자(`ך/ם/ן/ף/ץ`) → 일반형(`כ/מ/נ/פ/צ`) 정규화, 표준 히브리 자판 레이아웃
- `lib/scripts/index.ts` — `hebrew` 어댑터 레지스트리 등록
- `components/games/WordleGrid.tsx` — `adapter.rtl === true`일 때 그리드 컨테이너에 `dir="rtl"` 적용 (첫 타일이 화면 우측)
- `lib/scripts/__tests__/hebrew.test.ts` — `node:test` 기반 단위 테스트 10케이스

## 설계 메모

- **자판 레이아웃**: LTR 그대로 유지 (히브리 표준 자판도 좌→우 키 순서). RTL 분기는 그리드/입력 흐름에만 적용.
- **sofit 정규화**: 매칭 단계뿐 아니라 `keyId`, `isAllowedChar/Word`에도 적용 — `ך` 입력 시 `כ` 키와 매칭되도록.
- **다음 PR(#27, 아랍어)을 위한 인프라**: `dir` 분기 로직이 그대로 재사용됨.

## 범위 외(의도적 스킵)

- `ALLOWED_SCRIPTS` 화이트리스트 / 덱 폼 스크립트 셀렉터 — 현재 `main`에 미존재 (Phase 1 #22 / Phase 2a #23 영역). 본 PR은 어댑터 + RTL 인프라에 집중.
- 자판 RTL 정렬 — 이슈 명시대로 불필요.
- 아랍어 어댑터 — Phase 4b (#27).

## 회귀 검증

- [x] `tsc --noEmit` 통과
- [x] `pnpm lint` 신규 경고 0
- [x] `tsx --test lib/scripts/__tests__/hebrew.test.ts` — 10/10 통과
- [x] 라틴 어댑터 시그니처/동작 변경 없음 (RTL 분기는 `adapter.rtl`로 게이팅)

## 테스트 플랜

- [ ] 히브리 덱(스크립트 컬럼 = `'hebrew'`)으로 그리드 RTL 표시 확인 (첫 타일 우측)
- [ ] sofit 동치 매칭: `ך`로 입력해도 `כ`와 매칭되는지
- [ ] 비히브리 입력 거부 확인
- [ ] 라틴/기존 덱 회귀 없음

Closes #26

---
_Generated by [Claude Code](https://claude.ai/code/session_015dKnZjPfPqnPiqauEsQaVf)_