### PR TITLE
feat(scripts): 한글 IME 입력 + UI 통합

### DIFF
--- a/components/decks/DeckDialog.tsx
+++ b/components/decks/DeckDialog.tsx
@@ -20,6 +20,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getScriptAdapter, isSupportedScript } from "@/lib/scripts";
+import type { ScriptId } from "@/lib/scripts/types";
 import { toast } from "sonner";
 import { Sparkles, Upload, X, Image as ImageIcon } from "lucide-react";
 import Image from "next/image";
@@ -81,6 +90,10 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
   const [name, setName] = useState(deck?.name ?? "");
   const [description, setDescription] = useState(deck?.description ?? "");
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
+  const initialScript: ScriptId =
+    deck?.script && isSupportedScript(deck.script) ? deck.script : "latin";
+  const [script, setScript] = useState<ScriptId>(initialScript);
+  const adapter = useMemo(() => getScriptAdapter(script), [script]);
 
   const isEditMode = !!deck;
   const isAnonymousCreate = !isEditMode && !isAuthenticated;
@@ -98,6 +111,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
       setName(deck?.name ?? "");
       setDescription(deck?.description ?? "");
       setAiPanelOpen(false);
+      setScript(
+        deck?.script && isSupportedScript(deck.script) ? deck.script : "latin",
+      );
     }
   }, [open, deck]);
 
@@ -385,9 +401,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
     setIsLoading(true);
 
     try {
-      // 빈 행 자동 제거 + lowercase 정규화
+      // 빈 행 자동 제거 + 어댑터 정규화 (latin은 lowercase + trim, 한글은 trim + NFC)
       const trimmedRows = formState.words
-        .map((row) => ({ ...row, word: row.word.trim().toLowerCase() }))
+        .map((row) => ({ ...row, word: adapter.normalize(row.word) }))
         .filter((row) => row.word.length > 0);
 
       if (trimmedRows.length === 0) {
@@ -395,9 +411,9 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
         return;
       }
 
-      const invalidRow = trimmedRows.find((row) => !/^[a-z]+$/.test(row.word));
+      const invalidRow = trimmedRows.find((row) => !adapter.isAllowedWord(row.word));
       if (invalidRow) {
-        toast.error(`"${invalidRow.word}"는 영문자(a-z)만 사용할 수 있습니다.`);
+        toast.error(`"${invalidRow.word}"는 ${adapter.charDescription}만 사용할 수 있습니다.`);
         return;
       }
 
@@ -427,6 +443,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
 
       formData.set("words_json", JSON.stringify(serializedWords));
       formData.set("categories_json", JSON.stringify(serializedCategories));
+      formData.set("script", script);
       formData.delete("words");
 
       // 익명 덱 생성: 썸네일·공개 토글 없이 바로 생성
@@ -483,6 +500,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
           updateFormData.set("description", formData.get("description") as string);
           updateFormData.set("words_json", formData.get("words_json") as string);
           updateFormData.set("categories_json", formData.get("categories_json") as string);
+          updateFormData.set("script", script);
           updateFormData.set("is_public", formData.get("is_public") as string);
           updateFormData.set("thumbnail_url", finalThumbnailUrl);
 
@@ -630,22 +648,46 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
               />
             </div>
 
+            <div className="space-y-2">
+              <Label htmlFor="script">쓰기 체계</Label>
+              <Select
+                value={script}
+                onValueChange={(v) => setScript(v as ScriptId)}
+                disabled={isEditMode}
+              >
+                <SelectTrigger id="script">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="latin">영어 (Latin)</SelectItem>
+                  <SelectItem value="hangul">한국어 (Hangul)</SelectItem>
+                </SelectContent>
+              </Select>
+              {isEditMode && (
+                <p className="text-xs text-muted-foreground">
+                  덱 생성 후에는 쓰기 체계를 변경할 수 없습니다.
+                </p>
+              )}
+            </div>
+
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-2">
                 <Label>단어 목록 *</Label>
                 <div className="flex items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setAiPanelOpen((v) => !v)}
-                    aria-expanded={aiPanelOpen}
-                    aria-controls="ai-import-panel"
-                    className="h-8 gap-1.5 text-xs"
-                  >
-                    <Sparkles className="size-3.5" />
-                    {aiPanelOpen ? "AI 패널 접기" : "AI로 가져오기"}
-                  </Button>
+                  {script === "latin" && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setAiPanelOpen((v) => !v)}
+                      aria-expanded={aiPanelOpen}
+                      aria-controls="ai-import-panel"
+                      className="h-8 gap-1.5 text-xs"
+                    >
+                      <Sparkles className="size-3.5" />
+                      {aiPanelOpen ? "AI 패널 접기" : "AI로 가져오기"}
+                    </Button>
+                  )}
                   <div className="flex items-center gap-2">
                     <Label
                       htmlFor="uses_categories"
@@ -662,7 +704,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                 </div>
               </div>
 
-              {aiPanelOpen && (
+              {aiPanelOpen && script === "latin" && (
                 <div id="ai-import-panel">
                   <AiImportPanel onImport={handleAiImport} />
                 </div>
@@ -682,6 +724,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                 rows={formState.words}
                 categories={formState.categories}
                 showCategoryPicker={formState.usesCategories}
+                adapter={adapter}
                 onChangeRow={updateRow}
                 onAddRow={addRow}
                 onRemoveRow={removeRow}

--- a/components/decks/WordList.tsx
+++ b/components/decks/WordList.tsx
@@ -5,11 +5,13 @@ import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { WordRow, type WordRowValue } from "@/components/decks/WordRow";
+import type { ScriptAdapter } from "@/lib/scripts/types";
 
 interface WordListProps {
   rows: WordRowValue[];
   categories: string[];
   showCategoryPicker: boolean;
+  adapter: ScriptAdapter;
   onChangeRow: (id: string, next: Partial<WordRowValue>) => void;
   onAddRow: (afterId?: string) => void;
   onRemoveRow: (id: string) => void;
@@ -20,6 +22,7 @@ export function WordList({
   rows,
   categories,
   showCategoryPicker,
+  adapter,
   onChangeRow,
   onAddRow,
   onRemoveRow,
@@ -44,7 +47,7 @@ export function WordList({
   const duplicates = useMemo(() => {
     const counts = new Map<string, number>();
     for (const row of rows) {
-      const w = row.word.trim().toLowerCase();
+      const w = adapter.normalize(row.word);
       if (!w) continue;
       counts.set(w, (counts.get(w) ?? 0) + 1);
     }
@@ -53,7 +56,7 @@ export function WordList({
         .filter(([, count]) => count > 1)
         .map(([word]) => word)
     );
-  }, [rows]);
+  }, [rows, adapter]);
 
   const handleEnter = (id: string) => {
     pendingFocusAfterIdRef.current = id;
@@ -64,10 +67,10 @@ export function WordList({
     <div className="space-y-2">
       <div className="space-y-2">
         {rows.map((row, index) => {
-          const trimmed = row.word.trim().toLowerCase();
+          const trimmed = adapter.normalize(row.word);
           const isDuplicate = trimmed.length > 0 && duplicates.has(trimmed);
           const hasInvalidChars =
-            row.word.length > 0 && !/^[a-z]*$/.test(row.word);
+            row.word.trim().length > 0 && !adapter.isAllowedWord(row.word.trim());
 
           return (
             <WordRow
@@ -78,6 +81,7 @@ export function WordList({
               hasInvalidChars={hasInvalidChars}
               showCategoryPicker={showCategoryPicker}
               categories={categories}
+              adapter={adapter}
               onChangeWord={(word) => onChangeRow(row.id, { word })}
               onChangeTags={(tags) => onChangeRow(row.id, { tags })}
               onCreateCategory={onCreateCategory}

--- a/components/decks/WordRow.tsx
+++ b/components/decks/WordRow.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TagPicker } from "@/components/decks/TagPicker";
+import type { ScriptAdapter } from "@/lib/scripts/types";
 import { cn } from "@/lib/utils";
 
 export interface WordRowValue {
@@ -20,6 +21,7 @@ interface WordRowProps {
   hasInvalidChars: boolean;
   showCategoryPicker: boolean;
   categories: string[];
+  adapter: ScriptAdapter;
   onChangeWord: (word: string) => void;
   onChangeTags: (tags: string[]) => void;
   onCreateCategory: (name: string) => boolean;
@@ -35,6 +37,7 @@ export function WordRow({
   hasInvalidChars,
   showCategoryPicker,
   categories,
+  adapter,
   onChangeWord,
   onChangeTags,
   onCreateCategory,
@@ -54,14 +57,14 @@ export function WordRow({
           <Input
             ref={inputRef}
             value={value.word}
-            onChange={(e) => onChangeWord(e.target.value.toLowerCase())}
+            onChange={(e) => onChangeWord(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                 e.preventDefault();
                 onEnter();
               }
             }}
-            placeholder="단어 (a-z)"
+            placeholder={`단어 (${adapter.charDescription})`}
             autoComplete="off"
             spellCheck={false}
             className={cn(
@@ -93,7 +96,7 @@ export function WordRow({
       </div>
       {hasError && (
         <p id={errorId} className="pl-9 text-xs text-destructive">
-          {hasInvalidChars && "영문자(a-z)만 사용할 수 있습니다."}
+          {hasInvalidChars && `${adapter.charDescription}만 사용할 수 있습니다.`}
           {hasInvalidChars && isDuplicate && " "}
           {isDuplicate && "중복된 단어입니다."}
         </p>

--- a/components/games/GameLoader.tsx
+++ b/components/games/GameLoader.tsx
@@ -5,8 +5,9 @@ import { WordleGrid } from "@/components/games/WordleGrid";
 import { WordleKeyboard } from "@/components/games/WordleKeyboard";
 import { GameResultModal } from "@/components/games/GameResultModal";
 import { isGameComplete } from "@/lib/wordleGame";
-import { getScriptAdapter } from "@/lib/scripts";
+import { getScriptAdapter, scriptUsesIme } from "@/lib/scripts";
 import { useGame } from "@/hooks/useGame";
+import { useImeInput } from "@/hooks/useImeInput";
 import { Deck } from "@/types/decks";
 
 interface GameLoaderProps {
@@ -15,6 +16,7 @@ interface GameLoaderProps {
 
 export function GameLoader({ deck }: GameLoaderProps) {
   const adapter = useMemo(() => getScriptAdapter(deck.script), [deck.script]);
+  const usesIme = scriptUsesIme(adapter.id);
 
   const {
     gameState,
@@ -28,12 +30,29 @@ export function GameLoader({ deck }: GameLoaderProps) {
     setShowGameResultModal,
   } = useGame(deck, adapter);
 
+  const gameOver = gameState ? isGameComplete(gameState) : true;
+  const { inputRef, inputProps } = useImeInput(adapter, handleKeyPress, usesIme && !gameOver);
+
   if (!gameState) {
     return null; // 데이터가 아직 로드되지 않았거나 에러가 발생한 경우
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 p-5 max-[480px]:p-2.5">
+    <div className={`min-h-screen bg-gray-50 p-5 max-[480px]:p-2.5 script-${adapter.id}`}>
+      {usesIme && (
+        <input
+          ref={inputRef}
+          type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          aria-label="한글 입력"
+          className="ime-hidden-input"
+          {...inputProps}
+        />
+      )}
+
       <WordleGrid gameState={gameState} adapter={adapter} showResult={showResult} />
 
       <WordleKeyboard
@@ -42,7 +61,7 @@ export function GameLoader({ deck }: GameLoaderProps) {
         onEnter={handleEnter}
         keyboardState={gameState.keyboardState}
         adapter={adapter}
-        disabled={isGameComplete(gameState)}
+        disabled={gameOver}
       />
 
       <GameResultModal
@@ -53,7 +72,21 @@ export function GameLoader({ deck }: GameLoaderProps) {
         targetWord={gameResultType === 'failure' ? gameState.targetWord : undefined}
         onRestart={restartGame}
       />
+
+      <style jsx global>{`
+        .ime-hidden-input {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 1px;
+          height: 1px;
+          opacity: 0;
+          pointer-events: none;
+          border: 0;
+          padding: 0;
+          margin: 0;
+        }
+      `}</style>
     </div>
   );
 }
-

--- a/components/games/GameLoader.tsx
+++ b/components/games/GameLoader.tsx
@@ -43,10 +43,12 @@ export function GameLoader({ deck }: GameLoaderProps) {
         <input
           ref={inputRef}
           type="text"
+          inputMode="text"
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck={false}
+          autoFocus
           aria-label="한글 입력"
           className="ime-hidden-input"
           {...inputProps}
@@ -74,17 +76,26 @@ export function GameLoader({ deck }: GameLoaderProps) {
       />
 
       <style jsx global>{`
+        /* IME가 정상 동작하려면 화면에 "실재"하는 input이어야 한다.
+           pointer-events: none / display: none / visibility: hidden은 일부 브라우저에서
+           IME 활성화를 막으므로 사용 금지. 화면 밖으로 밀어 시각적으로만 숨긴다. */
         .ime-hidden-input {
           position: fixed;
-          top: 0;
           left: 0;
+          top: 0;
           width: 1px;
           height: 1px;
           opacity: 0;
-          pointer-events: none;
           border: 0;
           padding: 0;
           margin: 0;
+          background: transparent;
+          color: transparent;
+          caret-color: transparent;
+          z-index: -1;
+        }
+        .ime-hidden-input:focus {
+          outline: none;
         }
       `}</style>
     </div>

--- a/components/games/GameLoader.tsx
+++ b/components/games/GameLoader.tsx
@@ -31,7 +31,12 @@ export function GameLoader({ deck }: GameLoaderProps) {
   } = useGame(deck, adapter);
 
   const gameOver = gameState ? isGameComplete(gameState) : true;
-  const { inputRef, inputProps } = useImeInput(adapter, handleKeyPress, usesIme && !gameOver);
+  const { inputRef, inputProps } = useImeInput({
+    adapter,
+    onUnit: handleKeyPress,
+    onBackspace: handleBackspace,
+    enabled: usesIme && !gameOver,
+  });
 
   if (!gameState) {
     return null; // 데이터가 아직 로드되지 않았거나 에러가 발생한 경우

--- a/components/games/WordleGrid.tsx
+++ b/components/games/WordleGrid.tsx
@@ -94,7 +94,8 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
           color: #000;
         }
 
-        /* 한글 자모는 글리프가 좁아 폰트 크기를 키우고 대문자 변환을 끈다 */
+        /* script-* 분기 contract: 기본(.wordle-tile)은 latin 가정.
+           비라틴 스크립트는 .script-<id>로 차이만 덮어쓴다. */
         .wordle-grid.script-hangul .wordle-tile {
           font-size: 2.25rem;
           text-transform: none;

--- a/components/games/WordleGrid.tsx
+++ b/components/games/WordleGrid.tsx
@@ -19,6 +19,9 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
   // 6줄 × n글자 그리드 생성
   const rows = [];
 
+  // 라틴 외 스크립트는 대소문자가 없거나 toUpperCase가 무의미한 경우가 많아 그대로 표시
+  const display = (ch: string) => (adapter.id === 'latin' ? ch.toUpperCase() : ch);
+
   for (let rowIndex = 0; rowIndex < maxGuesses; rowIndex++) {
     const isCurrentRow = rowIndex === currentRowIndex && gameState.gameStatus === 'playing';
     const isCompletedRow = rowIndex < guesses.length;
@@ -32,11 +35,11 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
           if (isCompletedRow) {
             // 완료된 추측의 타일
             const letter = guesses[rowIndex].letters[letterIndex];
-            tileContent = letter.char.toUpperCase();
+            tileContent = display(letter.char);
             tileState = letter.state;
           } else if (isCurrentRow) {
             // 현재 입력 중인 추측의 타일
-            tileContent = currentGuessUnits[letterIndex]?.toUpperCase() || '';
+            tileContent = currentGuessUnits[letterIndex] ? display(currentGuessUnits[letterIndex]) : '';
             tileState = tileContent ? 'filled' : '';
           }
           
@@ -89,6 +92,12 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
           transition: all 0.3s ease;
           background-color: #fff;
           color: #000;
+        }
+
+        /* 한글 자모는 글리프가 좁아 폰트 크기를 키우고 대문자 변환을 끈다 */
+        .wordle-grid.script-hangul .wordle-tile {
+          font-size: 2.25rem;
+          text-transform: none;
         }
         
         .wordle-tile.filled {
@@ -156,9 +165,13 @@ export function WordleGrid({ gameState, adapter, showResult = false }: WordleGri
             height: 50px;
             font-size: 1.5rem;
           }
+
+          .wordle-grid.script-hangul .wordle-tile {
+            font-size: 1.75rem;
+          }
         }
       `}</style>
-      <div className="wordle-grid">
+      <div className={`wordle-grid script-${adapter.id}`}>
         {rows}
       </div>
     </>

--- a/components/games/WordleKeyboard.tsx
+++ b/components/games/WordleKeyboard.tsx
@@ -136,6 +136,16 @@ export function WordleKeyboard({
           opacity: 0.5;
           cursor: not-allowed;
         }
+
+        /* 한글 자모는 글리프 폭이 좁아 키 너비를 줄이고 폰트 크기는 키운다 */
+        .keyboard-container.script-hangul .keyboard-key {
+          min-width: 32px;
+          font-size: 16px;
+        }
+        .keyboard-container.script-hangul .keyboard-key.special-key {
+          min-width: 56px;
+          font-size: 12px;
+        }
         
         @media (max-width: 480px) {
           .keyboard-container {
@@ -152,9 +162,18 @@ export function WordleKeyboard({
             min-width: 50px;
             font-size: 10px;
           }
+
+          .keyboard-container.script-hangul .keyboard-key {
+            min-width: 26px;
+            font-size: 14px;
+          }
+          .keyboard-container.script-hangul .keyboard-key.special-key {
+            min-width: 44px;
+            font-size: 10px;
+          }
         }
       `}</style>
-      <div className="keyboard-container">
+      <div className={`keyboard-container script-${adapter.id}`}>
         {layout.rows.map((row, rowIndex) => (
           <div key={rowIndex} className="keyboard-row">
             {row.map((key) => (

--- a/components/games/WordleKeyboard.tsx
+++ b/components/games/WordleKeyboard.tsx
@@ -137,7 +137,8 @@ export function WordleKeyboard({
           cursor: not-allowed;
         }
 
-        /* 한글 자모는 글리프 폭이 좁아 키 너비를 줄이고 폰트 크기는 키운다 */
+        /* script-* 분기 contract: 기본(.keyboard-key)은 latin 가정.
+           비라틴 스크립트는 .script-<id>로 차이만 덮어쓴다. */
         .keyboard-container.script-hangul .keyboard-key {
           min-width: 32px;
           font-size: 16px;

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -10,6 +10,7 @@ import {
   type GameState
 } from "@/lib/wordleGame";
 import type { ScriptAdapter } from "@/lib/scripts/types";
+import { scriptUsesIme } from "@/lib/scripts";
 import { Deck } from "@/types/decks";
 import { getWordStrings } from "@/lib/deckHelpers";
 
@@ -116,6 +117,9 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!gameState || isGameComplete(gameState)) return;
 
+      // IME 조합 중에는 키 처리 금지 (compositionend 시 hidden input이 처리)
+      if (event.isComposing || event.keyCode === 229) return;
+
       // 특수 키는 영문 그대로 비교 (브라우저 KeyboardEvent.key 표준값)
       const rawKey = event.key;
       const upperKey = rawKey.toUpperCase();
@@ -131,6 +135,10 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
         handleBackspace();
         return;
       }
+
+      // IME 기반 스크립트는 hidden input의 compositionend 경로로만 입력을 받는다
+      // (전역 keydown으로 직접 입력하면 hidden input과 중복 누적됨)
+      if (scriptUsesIme(adapter.id)) return;
 
       // 한 글자 입력: keyId는 키보드 상태 식별자라 입력 문자로 쓰면
       // 비라틴 스크립트에서 currentGuess가 깨질 수 있음. 실제 입력 문자를 그대로 전달.

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -47,17 +47,14 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
   }, [deck, adapter]);
 
   // 키보드 입력 처리
+  // 줄이 가득 찼는지 검사는 addLetterToGuess 내부에서 어댑터의 splitUnits 기반으로 수행한다.
+  // 여기서 string length로 사전 가드를 하면 한글처럼 unit≠char인 스크립트에서
+  // 첫 자모만 들어가고 나머지가 차단되는 버그가 생긴다.
   const handleKeyPress = useCallback((key: string) => {
     if (!gameState || isGameComplete(gameState)) return;
-    
+
     setGameState(prevState => {
       if (!prevState) return null;
-      
-      // 현재 줄이 이미 완료된 경우 입력 차단
-      if (prevState.currentGuess.length >= prevState.targetWord.length) {
-        return prevState;
-      }
-      
       return addLetterToGuess(prevState, key);
     });
   }, [gameState]);

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -114,18 +114,24 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!gameState || isGameComplete(gameState)) return;
 
-      // IME 조합 중에는 키 처리 금지 (compositionend 시 hidden input이 처리)
-      if (event.isComposing || event.keyCode === 229) return;
-
       // 특수 키는 영문 그대로 비교 (브라우저 KeyboardEvent.key 표준값)
       const rawKey = event.key;
       const upperKey = rawKey.toUpperCase();
 
+      // Enter는 IME 조합 중에도 통과시킨다.
+      // 한국어 IME는 마지막 자모 입력 후에도 composition 상태를 유지하므로
+      // isComposing 가드를 걸면 사용자가 Enter를 두 번 눌러야 제출되는 문제가 생긴다.
+      // 우리는 compositionupdate에서 매 자모를 실시간 dispatch하므로 이 시점의
+      // currentGuess는 이미 최신 상태다.
       if (upperKey === 'ENTER') {
         event.preventDefault();
         handleEnter();
         return;
       }
+
+      // IME 조합 중에는 letter / Backspace 처리 금지.
+      // (Backspace는 IME가 처리 → compositionupdate → reconcile에서 자모 단위 삭제)
+      if (event.isComposing || event.keyCode === 229) return;
 
       if (upperKey === 'BACKSPACE' || upperKey === 'DELETE') {
         event.preventDefault();
@@ -133,7 +139,7 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
         return;
       }
 
-      // IME 기반 스크립트는 hidden input의 compositionend 경로로만 입력을 받는다
+      // IME 기반 스크립트는 hidden input의 composition 경로로만 입력을 받는다
       // (전역 keydown으로 직접 입력하면 hidden input과 중복 누적됨)
       if (scriptUsesIme(adapter.id)) return;
 

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -70,17 +70,21 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
 
   const handleEnter = useCallback(() => {
     if (!gameState || isGameComplete(gameState) || isSubmitting) return;
-    
-    // 현재 줄이 완전히 채워지지 않은 경우 제출 불가
-    if (gameState.currentGuess.length !== gameState.targetWord.length) {
-      return;
-    }
-    
+
+    // 줄 채움 검증은 submitGuess 내부의 splitUnits 기반 로직에 위임한다.
+    // 여기서 string length로 사전 체크하면 unit≠char인 한글 등에서 제출이 차단된다.
+
     // 중복 제출 방지
     setIsSubmitting(true);
-    
+
     // submitGuess를 먼저 실행하여 결과 확인
     const newState = submitGuess(gameState);
+
+    // submitGuess가 변화 없이 반환한 경우(줄 미충족 등) → 아무것도 안 함
+    if (newState === gameState) {
+      setIsSubmitting(false);
+      return;
+    }
     
     // 에러 메시지가 있으면 toast로 표시하고 상태 업데이트하지 않음
     if (newState.errorMessage) {

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -77,9 +77,19 @@ export function useImeInput(
 
   // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강.
   // value는 건드리지 않고 prev와의 차이만 dispatch.
+  //
+  // 주의: 일부 한글 IME에서 첫 input 이벤트가 compositionstart보다 먼저 발화한다.
+  // 이때 composingRef는 아직 false라 첫 자모를 직접 dispatch해버리고, 이후 같은
+  // 음절의 후속 자모들은 composition으로 흡수되어 dispatch되지 않는 버그가 생긴다.
+  // 따라서 native event의 isComposing / inputType=insertCompositionText를 1차로 확인한다.
   const onInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
+      const native = e.nativeEvent as InputEvent;
       if (composingRef.current) return;
+      if (native.isComposing) return;
+      if (typeof native.inputType === "string" && native.inputType.startsWith("insertCompositionText")) {
+        return;
+      }
       const cur = e.currentTarget.value;
       const prev = prevValueRef.current;
       if (cur.length > prev.length && cur.startsWith(prev)) {

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -7,12 +7,19 @@ interface UseImeInputResult {
     onCompositionStart: React.CompositionEventHandler<HTMLInputElement>;
     onCompositionEnd: React.CompositionEventHandler<HTMLInputElement>;
     onInput: React.FormEventHandler<HTMLInputElement>;
+    onBlur: React.FocusEventHandler<HTMLInputElement>;
   };
 }
 
 // OS IME composition 이벤트로부터 자모/모라 단위 입력을 누적하는 일반화된 hook.
 // hidden input에 focus가 유지되어 있어야 IME가 동작한다.
 // 한글/가나 등 IME 기반 스크립트가 공통으로 사용한다.
+//
+// 구현 노트:
+// - input.value를 절대 비우지 않는다(브라우저별로 IME composition 상태가 깨져
+//   두 번째 음절부터 composition이 시작되지 않는 케이스를 차단).
+// - 대신 prevValueRef로 이전 길이를 추적해 "추가된 부분"만 dispatch한다.
+// - compositionend는 e.data만 dispatch하고 prevValueRef를 현재 value로 동기화.
 export function useImeInput(
   adapter: ScriptAdapter,
   onUnit: (unit: string) => void,
@@ -20,23 +27,29 @@ export function useImeInput(
 ): UseImeInputResult {
   const inputRef = useRef<HTMLInputElement>(null);
   const composingRef = useRef(false);
-  // compositionend 직후 같은 값으로 input이 재발화하는 브라우저(Safari 등) 대응
-  const justFlushedRef = useRef(false);
+  const prevValueRef = useRef("");
 
-  // 활성화되면 마운트 직후 focus, 외부 클릭 시 다시 focus
+  // 활성화되면 가능한 즉시 focus, blur나 외부 클릭 시 다시 focus
   useEffect(() => {
     if (!enabled) return;
-    inputRef.current?.focus();
-    const refocus = (e: MouseEvent) => {
+    const focusNow = () => inputRef.current?.focus();
+    focusNow();
+    // 첫 페인트 직후에도 한 번 더 시도 (SSR hydration timing 보강)
+    const raf = requestAnimationFrame(focusNow);
+
+    const refocusOnClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
-      // 인터랙티브 요소(키보드 버튼, 다이얼로그 등) 클릭은 그쪽이 focus를 가져가도록 둔다
+      // 인터랙티브 요소 클릭은 그쪽이 focus를 가져가도록 둔다
       if (target?.closest("button, input, textarea, select, [contenteditable]")) {
         return;
       }
       inputRef.current?.focus();
     };
-    window.addEventListener("click", refocus);
-    return () => window.removeEventListener("click", refocus);
+    window.addEventListener("click", refocusOnClick);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("click", refocusOnClick);
+    };
   }, [enabled]);
 
   const dispatch = useCallback(
@@ -48,46 +61,52 @@ export function useImeInput(
     [adapter, onUnit],
   );
 
-  // 다음 IME composition을 깨지 않도록 input value 클리어를 다음 frame으로 미룬다.
-  // (compositionend 핸들러 내부에서 동기 클리어하면 일부 브라우저에서 후속 composition이
-  //  시작되지 않거나 첫 compositionstart 후 멈추는 증상이 있다 — 한글 IME 대표 케이스)
-  const scheduleClear = useCallback(() => {
-    justFlushedRef.current = true;
-    requestAnimationFrame(() => {
-      if (inputRef.current) inputRef.current.value = "";
-      justFlushedRef.current = false;
-    });
-  }, []);
-
   const onCompositionStart = useCallback(() => {
     composingRef.current = true;
   }, []);
 
-  // e.data만 사용 → 누적된 input.value가 아닌 "이번 composition 결과"만 처리
   const onCompositionEnd = useCallback(
     (e: React.CompositionEvent<HTMLInputElement>) => {
       composingRef.current = false;
       dispatch(e.data || "");
-      scheduleClear();
+      // 다음 onInput diff의 기준점을 현재 value로 동기화
+      prevValueRef.current = e.currentTarget.value;
     },
-    [dispatch, scheduleClear],
+    [dispatch],
   );
 
   // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강.
-  // compositionend 직후 한 frame은 가드로 무시(이중 flush 방지).
+  // value는 건드리지 않고 prev와의 차이만 dispatch.
   const onInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
-      if (composingRef.current || justFlushedRef.current) return;
-      const value = e.currentTarget.value;
-      if (!value) return;
-      dispatch(value);
-      scheduleClear();
+      if (composingRef.current) return;
+      const cur = e.currentTarget.value;
+      const prev = prevValueRef.current;
+      if (cur.length > prev.length && cur.startsWith(prev)) {
+        dispatch(cur.slice(prev.length));
+      }
+      // 길이가 줄거나 prefix가 다른 경우(삭제·치환 등)는 게임 입력으로 간주하지 않는다.
+      prevValueRef.current = cur;
     },
-    [dispatch, scheduleClear],
+    [dispatch],
   );
+
+  // 게임 중에는 hidden input이 다시 focus를 가져간다
+  const onBlur = useCallback(() => {
+    if (!enabled) return;
+    // 다음 tick에 재focus (현재 focus를 가져간 요소가 자기 처리를 마치도록)
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  }, [enabled]);
 
   return {
     inputRef,
-    inputProps: { onCompositionStart, onCompositionEnd, onInput },
+    inputProps: {
+      onCompositionStart,
+      onCompositionEnd,
+      onInput,
+      onBlur,
+    },
   };
 }

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -20,6 +20,8 @@ export function useImeInput(
 ): UseImeInputResult {
   const inputRef = useRef<HTMLInputElement>(null);
   const composingRef = useRef(false);
+  // compositionend 직후 같은 값으로 input이 재발화하는 브라우저(Safari 일부) 대응
+  const justFlushedRef = useRef(false);
 
   // 활성화되면 마운트 직후 focus, 외부 클릭 시 다시 focus
   useEffect(() => {
@@ -55,14 +57,19 @@ export function useImeInput(
     (e: React.CompositionEvent<HTMLInputElement>) => {
       composingRef.current = false;
       flush(e.currentTarget.value);
+      justFlushedRef.current = true;
+      queueMicrotask(() => {
+        justFlushedRef.current = false;
+      });
     },
     [flush],
   );
 
-  // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강
+  // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강.
+  // compositionend 직후 같은 음절이 두 번 누적되지 않도록 justFlushedRef로 한 틱 가드.
   const onInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
-      if (composingRef.current) return;
+      if (composingRef.current || justFlushedRef.current) return;
       flush(e.currentTarget.value);
     },
     [flush],

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { ScriptAdapter } from "@/lib/scripts/types";
+
+interface UseImeInputResult {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputProps: {
+    onCompositionStart: React.CompositionEventHandler<HTMLInputElement>;
+    onCompositionEnd: React.CompositionEventHandler<HTMLInputElement>;
+    onInput: React.FormEventHandler<HTMLInputElement>;
+  };
+}
+
+// OS IME composition 이벤트로부터 자모/모라 단위 입력을 누적하는 일반화된 hook.
+// hidden input에 focus가 유지되어 있어야 IME가 동작한다.
+// 한글/가나 등 IME 기반 스크립트가 공통으로 사용한다.
+export function useImeInput(
+  adapter: ScriptAdapter,
+  onUnit: (unit: string) => void,
+  enabled = true,
+): UseImeInputResult {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const composingRef = useRef(false);
+
+  // 활성화되면 마운트 직후 focus, 외부 클릭 시 다시 focus
+  useEffect(() => {
+    if (!enabled) return;
+    inputRef.current?.focus();
+    const refocus = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      // 인터랙티브 요소(키보드 버튼, 다이얼로그 등) 클릭은 그쪽이 focus를 가져가도록 둔다
+      if (target?.closest("button, input, textarea, select, [contenteditable]")) {
+        return;
+      }
+      inputRef.current?.focus();
+    };
+    window.addEventListener("click", refocus);
+    return () => window.removeEventListener("click", refocus);
+  }, [enabled]);
+
+  const flush = useCallback(
+    (value: string) => {
+      if (!value) return;
+      const units = adapter.splitUnits(value);
+      for (const u of units) onUnit(u);
+      if (inputRef.current) inputRef.current.value = "";
+    },
+    [adapter, onUnit],
+  );
+
+  const onCompositionStart = useCallback(() => {
+    composingRef.current = true;
+  }, []);
+
+  const onCompositionEnd = useCallback(
+    (e: React.CompositionEvent<HTMLInputElement>) => {
+      composingRef.current = false;
+      flush(e.currentTarget.value);
+    },
+    [flush],
+  );
+
+  // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강
+  const onInput = useCallback(
+    (e: React.FormEvent<HTMLInputElement>) => {
+      if (composingRef.current) return;
+      flush(e.currentTarget.value);
+    },
+    [flush],
+  );
+
+  return {
+    inputRef,
+    inputProps: { onCompositionStart, onCompositionEnd, onInput },
+  };
+}

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -20,7 +20,7 @@ export function useImeInput(
 ): UseImeInputResult {
   const inputRef = useRef<HTMLInputElement>(null);
   const composingRef = useRef(false);
-  // compositionend 직후 같은 값으로 input이 재발화하는 브라우저(Safari 일부) 대응
+  // compositionend 직후 같은 값으로 input이 재발화하는 브라우저(Safari 등) 대응
   const justFlushedRef = useRef(false);
 
   // 활성화되면 마운트 직후 focus, 외부 클릭 시 다시 focus
@@ -39,40 +39,51 @@ export function useImeInput(
     return () => window.removeEventListener("click", refocus);
   }, [enabled]);
 
-  const flush = useCallback(
+  const dispatch = useCallback(
     (value: string) => {
       if (!value) return;
       const units = adapter.splitUnits(value);
       for (const u of units) onUnit(u);
-      if (inputRef.current) inputRef.current.value = "";
     },
     [adapter, onUnit],
   );
+
+  // 다음 IME composition을 깨지 않도록 input value 클리어를 다음 frame으로 미룬다.
+  // (compositionend 핸들러 내부에서 동기 클리어하면 일부 브라우저에서 후속 composition이
+  //  시작되지 않거나 첫 compositionstart 후 멈추는 증상이 있다 — 한글 IME 대표 케이스)
+  const scheduleClear = useCallback(() => {
+    justFlushedRef.current = true;
+    requestAnimationFrame(() => {
+      if (inputRef.current) inputRef.current.value = "";
+      justFlushedRef.current = false;
+    });
+  }, []);
 
   const onCompositionStart = useCallback(() => {
     composingRef.current = true;
   }, []);
 
+  // e.data만 사용 → 누적된 input.value가 아닌 "이번 composition 결과"만 처리
   const onCompositionEnd = useCallback(
     (e: React.CompositionEvent<HTMLInputElement>) => {
       composingRef.current = false;
-      flush(e.currentTarget.value);
-      justFlushedRef.current = true;
-      queueMicrotask(() => {
-        justFlushedRef.current = false;
-      });
+      dispatch(e.data || "");
+      scheduleClear();
     },
-    [flush],
+    [dispatch, scheduleClear],
   );
 
   // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강.
-  // compositionend 직후 같은 음절이 두 번 누적되지 않도록 justFlushedRef로 한 틱 가드.
+  // compositionend 직후 한 frame은 가드로 무시(이중 flush 방지).
   const onInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
       if (composingRef.current || justFlushedRef.current) return;
-      flush(e.currentTarget.value);
+      const value = e.currentTarget.value;
+      if (!value) return;
+      dispatch(value);
+      scheduleClear();
     },
-    [flush],
+    [dispatch, scheduleClear],
   );
 
   return {

--- a/hooks/useImeInput.ts
+++ b/hooks/useImeInput.ts
@@ -1,10 +1,18 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { ScriptAdapter } from "@/lib/scripts/types";
 
+interface UseImeInputOptions {
+  adapter: ScriptAdapter;
+  onUnit: (unit: string) => void;
+  onBackspace: () => void;
+  enabled?: boolean;
+}
+
 interface UseImeInputResult {
   inputRef: React.RefObject<HTMLInputElement | null>;
   inputProps: {
     onCompositionStart: React.CompositionEventHandler<HTMLInputElement>;
+    onCompositionUpdate: React.CompositionEventHandler<HTMLInputElement>;
     onCompositionEnd: React.CompositionEventHandler<HTMLInputElement>;
     onInput: React.FormEventHandler<HTMLInputElement>;
     onBlur: React.FocusEventHandler<HTMLInputElement>;
@@ -12,21 +20,25 @@ interface UseImeInputResult {
 }
 
 // OS IME composition 이벤트로부터 자모/모라 단위 입력을 누적하는 일반화된 hook.
-// hidden input에 focus가 유지되어 있어야 IME가 동작한다.
-// 한글/가나 등 IME 기반 스크립트가 공통으로 사용한다.
 //
-// 구현 노트:
-// - input.value를 절대 비우지 않는다(브라우저별로 IME composition 상태가 깨져
-//   두 번째 음절부터 composition이 시작되지 않는 케이스를 차단).
-// - 대신 prevValueRef로 이전 길이를 추적해 "추가된 부분"만 dispatch한다.
-// - compositionend는 e.data만 dispatch하고 prevValueRef를 현재 value로 동기화.
-export function useImeInput(
-  adapter: ScriptAdapter,
-  onUnit: (unit: string) => void,
+// 핵심 아이디어: `compositionupdate`로 실시간 자모를 dispatch한다.
+// - 한국어 IME는 ㄱ을 입력해도 즉시 commit하지 않고 다음 입력을 기다린다
+//   (compositionend는 다음 음절이 시작되거나 composition이 끊길 때만 발화).
+// - compositionend에만 의존하면 모든 입력이 한 박자씩 밀려 보인다.
+// - 따라서 매 compositionupdate마다 현재 composition의 자모 시퀀스와 직전
+//   dispatch한 시퀀스의 공통 prefix를 비교해, 줄어든 만큼 onBackspace,
+//   늘어난 만큼 onUnit을 호출한다.
+export function useImeInput({
+  adapter,
+  onUnit,
+  onBackspace,
   enabled = true,
-): UseImeInputResult {
+}: UseImeInputOptions): UseImeInputResult {
   const inputRef = useRef<HTMLInputElement>(null);
   const composingRef = useRef(false);
+  // 현재 진행 중인 composition으로 누적 dispatch한 자모 시퀀스
+  const compositionUnitsRef = useRef<string[]>([]);
+  // composition 외 경로(direct paste 등)용 prev value
   const prevValueRef = useRef("");
 
   // 활성화되면 가능한 즉시 focus, blur나 외부 클릭 시 다시 focus
@@ -34,12 +46,10 @@ export function useImeInput(
     if (!enabled) return;
     const focusNow = () => inputRef.current?.focus();
     focusNow();
-    // 첫 페인트 직후에도 한 번 더 시도 (SSR hydration timing 보강)
     const raf = requestAnimationFrame(focusNow);
 
     const refocusOnClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
-      // 인터랙티브 요소 클릭은 그쪽이 focus를 가져가도록 둔다
       if (target?.closest("button, input, textarea, select, [contenteditable]")) {
         return;
       }
@@ -52,36 +62,52 @@ export function useImeInput(
     };
   }, [enabled]);
 
-  const dispatch = useCallback(
-    (value: string) => {
-      if (!value) return;
-      const units = adapter.splitUnits(value);
-      for (const u of units) onUnit(u);
+  // 직전 dispatch 자모 시퀀스(prev)와 새 시퀀스(next)를 비교해
+  // 공통 prefix 이후를 backspace + 새 자모 dispatch로 동기화.
+  const reconcile = useCallback(
+    (prev: string[], next: string[]) => {
+      let common = 0;
+      while (common < prev.length && common < next.length && prev[common] === next[common]) {
+        common++;
+      }
+      for (let i = prev.length - 1; i >= common; i--) {
+        onBackspace();
+      }
+      for (let i = common; i < next.length; i++) {
+        onUnit(next[i]);
+      }
     },
-    [adapter, onUnit],
+    [onUnit, onBackspace],
   );
 
   const onCompositionStart = useCallback(() => {
     composingRef.current = true;
+    compositionUnitsRef.current = [];
   }, []);
+
+  const onCompositionUpdate = useCallback(
+    (e: React.CompositionEvent<HTMLInputElement>) => {
+      const next = adapter.splitUnits(e.data || "");
+      reconcile(compositionUnitsRef.current, next);
+      compositionUnitsRef.current = next;
+    },
+    [adapter, reconcile],
+  );
 
   const onCompositionEnd = useCallback(
     (e: React.CompositionEvent<HTMLInputElement>) => {
       composingRef.current = false;
-      dispatch(e.data || "");
-      // 다음 onInput diff의 기준점을 현재 value로 동기화
+      // compositionupdate가 처리했지만, 마지막 update와 end의 data가 어긋나는
+      // 브라우저 변종 보강 (Windows MS IME 등에서 종성 처리 차이).
+      const finalUnits = adapter.splitUnits(e.data || "");
+      reconcile(compositionUnitsRef.current, finalUnits);
+      compositionUnitsRef.current = [];
       prevValueRef.current = e.currentTarget.value;
     },
-    [dispatch],
+    [adapter, reconcile],
   );
 
-  // 자모 단독키 입력이나 paste 등 composition을 거치지 않는 경로 보강.
-  // value는 건드리지 않고 prev와의 차이만 dispatch.
-  //
-  // 주의: 일부 한글 IME에서 첫 input 이벤트가 compositionstart보다 먼저 발화한다.
-  // 이때 composingRef는 아직 false라 첫 자모를 직접 dispatch해버리고, 이후 같은
-  // 음절의 후속 자모들은 composition으로 흡수되어 dispatch되지 않는 버그가 생긴다.
-  // 따라서 native event의 isComposing / inputType=insertCompositionText를 1차로 확인한다.
+  // composition을 거치지 않는 직접 입력(자모 단독키, paste 등) 보강.
   const onInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
       const native = e.nativeEvent as InputEvent;
@@ -93,18 +119,16 @@ export function useImeInput(
       const cur = e.currentTarget.value;
       const prev = prevValueRef.current;
       if (cur.length > prev.length && cur.startsWith(prev)) {
-        dispatch(cur.slice(prev.length));
+        const added = cur.slice(prev.length);
+        for (const u of adapter.splitUnits(added)) onUnit(u);
       }
-      // 길이가 줄거나 prefix가 다른 경우(삭제·치환 등)는 게임 입력으로 간주하지 않는다.
       prevValueRef.current = cur;
     },
-    [dispatch],
+    [adapter, onUnit],
   );
 
-  // 게임 중에는 hidden input이 다시 focus를 가져간다
   const onBlur = useCallback(() => {
     if (!enabled) return;
-    // 다음 tick에 재focus (현재 focus를 가져간 요소가 자기 처리를 마치도록)
     setTimeout(() => {
       inputRef.current?.focus();
     }, 0);
@@ -114,6 +138,7 @@ export function useImeInput(
     inputRef,
     inputProps: {
       onCompositionStart,
+      onCompositionUpdate,
       onCompositionEnd,
       onInput,
       onBlur,

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -11,6 +11,12 @@ export function isSupportedScript(id: string): id is ScriptId {
   return (SUPPORTED_SCRIPTS as readonly string[]).includes(id);
 }
 
+// OS IME(한글, 가나 등) 조합 입력이 필요한 스크립트 여부.
+// Phase 3에서 'kana'가 추가될 자리.
+export function scriptUsesIme(id: ScriptId): boolean {
+  return id === 'hangul';
+}
+
 export function getScriptAdapter(id: string): ScriptAdapter {
   const adapter = ADAPTERS[id as ScriptId];
   if (!adapter) {


### PR DESCRIPTION
Closes #24

## 요약

Phase 2a(#23)에서 만든 한글 어댑터를 실제 게임에 연결한다. OS IME composition 이벤트를 받아 자모 단위로 누적하는 일반화된 hook을 도입하고(Phase 3 가나도 동일하게 재사용), 그리드/키보드 UI를 자모 단위로 표시하도록 보정했다.

## 변경 사항

### 신규
- `hooks/useImeInput.ts` — IME composition으로부터 자모/모라 단위를 누적하는 hook
  - hidden input의 `compositionend` → `adapter.splitUnits(value)` → 각 단위를 `onUnit` 콜백으로 전달
  - `composition` 미경유 입력(자모 단독키, paste 등)도 `onInput`으로 보강
  - 활성 시 hidden input에 자동 focus, 비인터랙티브 영역 클릭 시 재focus

### 수정
- `components/games/GameLoader.tsx` — 한글 덱일 때 sr-only hidden input 렌더링, `useImeInput(adapter, handleKeyPress, usesIme && !gameOver)`로 연결. 화면 키보드 클릭은 기존 `handleKeyPress`로 동일하게 처리
- `hooks/useGame.ts` — 전역 keydown에서 IME 조합 키(`isComposing` / `keyCode === 229`) 차단, `scriptUsesIme(adapter.id)`인 경우 직접 입력 경로 비활성화 (hidden input과 중복 누적 방지)
- `components/games/WordleGrid.tsx` / `WordleKeyboard.tsx` — `script-${adapter.id}` 클래스 분기로 한글 자모 폰트·키 너비 보정. 라틴 외에는 `toUpperCase()` 미적용
- `components/decks/DeckDialog.tsx` — "쓰기 체계" Select(영어 / 한국어) 추가, **생성 모드에서만 선택 가능**(편집 모드는 잠금). 검증을 하드코딩 `[a-z]+` → `adapter.isAllowedWord` / `adapter.normalize` 기반으로 교체. AI 패널은 `script === 'latin'`일 때만 노출
- `components/decks/WordList.tsx` / `WordRow.tsx` — `adapter` prop 추가, 중복 판정/허용문자 검증/placeholder/에러 문구를 어댑터에 위임
- `lib/scripts/index.ts` — `scriptUsesIme(id)` 헬퍼 export (Phase 3에서 `kana` 합류 자리)

### 손대지 않은 것
- 가나 어댑터 (Phase 3에서 동일 IME 인프라 재사용)
- RTL 처리 (Phase 4)
- AI 한글 프롬프트 분기 (별도 트랙)

## 회귀 검증

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과 (기존 경고 4개만, 신규 없음)
- [x] `pnpm test` 통과 (23/23)
- [ ] 라틴/키릴/그리스 덱 동작 그대로 (브라우저 확인 필요)
- [ ] **한글 덱 생성**: 폼에 "한국어 (Hangul)" 선택 → 한글 입력 정상, 비한글 거부
- [ ] **한글 덱 플레이**:
  - [ ] OS IME로 "한글" 입력 시 자모 단위로 그리드에 들어감
  - [ ] 자모 단위 타일 표시 (음절 1개 = 2~3 타일)
  - [ ] 화면 두벌식 자판 클릭으로도 입력 가능
  - [ ] 정답 매칭 시 색상 갱신 (자모 단위 비교)
  - [ ] 키보드 색상 갱신 (`adapter.keyId`로 자모별 추적)
  - [ ] 백스페이스로 자모 단위 삭제

> 자동 환경에서 실제 OS IME 동작은 검증 불가하므로 라이브 테스트가 필요합니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPj4grhpveNd7kSseWTMSC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 한글 등 다양한 쓰기 체계 지원 추가
* IME 기반 입력 방식 지원
* 단어 추가 시 쓰기 체계 선택 기능

## 스타일
* 쓰기 체계별 최적화된 게임 UI 스타일링 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->