### PR TITLE
feat(scripts): add kana adapter with hiragana-normalized matching

### DIFF
--- a/components/decks/DeckDialog.tsx
+++ b/components/decks/DeckDialog.tsx
@@ -661,6 +661,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
                 <SelectContent>
                   <SelectItem value="latin">영어 (Latin)</SelectItem>
                   <SelectItem value="hangul">한국어 (Hangul)</SelectItem>
+                  <SelectItem value="kana">日本語 (Kana)</SelectItem>
                 </SelectContent>
               </Select>
               {isEditMode && (

--- a/lib/scripts/__tests__/kana.test.ts
+++ b/lib/scripts/__tests__/kana.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { kana } from '../kana';
+import { getScriptAdapter, scriptUsesIme } from '../index';
+
+describe('kana.splitUnits', () => {
+  it('단순 모라', () => {
+    expect(kana.splitUnits('あいうえお')).toEqual(['あ', 'い', 'う', 'え', 'お']);
+    expect(kana.splitUnits('かきくけこ')).toEqual(['か', 'き', 'く', 'け', 'こ']);
+  });
+
+  it('요음 묶기 — ゃゅょ', () => {
+    expect(kana.splitUnits('きゃ')).toEqual(['きゃ']);
+    expect(kana.splitUnits('しゅ')).toEqual(['しゅ']);
+    expect(kana.splitUnits('ちょこ')).toEqual(['ちょ', 'こ']);
+    expect(kana.splitUnits('きょうりゅう')).toEqual(['きょ', 'う', 'りゅ', 'う']);
+  });
+
+  it('요음 묶기 — 가타카나 ャュョ', () => {
+    expect(kana.splitUnits('キャ')).toEqual(['キャ']);
+    expect(kana.splitUnits('チョコ')).toEqual(['チョ', 'コ']);
+  });
+
+  it('탁점 결합 형태는 1 모라', () => {
+    expect(kana.splitUnits('がぎ')).toEqual(['が', 'ぎ']);
+    expect(kana.splitUnits('ばびぶべぼ')).toEqual(['ば', 'び', 'ぶ', 'べ', 'ぼ']);
+  });
+
+  it('반탁점 결합 형태도 1 모라', () => {
+    expect(kana.splitUnits('ぱぴぷぺぽ')).toEqual(['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ']);
+  });
+
+  it('탁점 분리 형태(NFD)도 NFC로 결합 후 처리', () => {
+    // 'か' (U+304B) + '゛' (U+3099) → NFC: 'が'
+    const nfd = 'が';
+    expect(kana.splitUnits(nfd)).toEqual(['が']);
+  });
+
+  it('촉음(っ)은 단독 1 모라', () => {
+    expect(kana.splitUnits('がっこう')).toEqual(['が', 'っ', 'こ', 'う']);
+  });
+
+  it('장음 부호(ー)도 1 모라', () => {
+    expect(kana.splitUnits('カード')).toEqual(['カ', 'ー', 'ド']);
+  });
+
+  it('비가나 문자(ASCII/한글 등)는 무시', () => {
+    expect(kana.splitUnits('あa')).toEqual(['あ']);
+    expect(kana.splitUnits('あ い')).toEqual(['あ', 'い']);
+    expect(kana.splitUnits('あ가')).toEqual(['あ']);
+  });
+
+  it('맨 앞에 작은 가나가 와도 안전 (직전 모라 없음)', () => {
+    expect(kana.splitUnits('ゃ')).toEqual(['ゃ']);
+  });
+});
+
+describe('kana.isAllowedChar', () => {
+  it('히라가나 허용', () => {
+    expect(kana.isAllowedChar('あ')).toBe(true);
+    expect(kana.isAllowedChar('が')).toBe(true);
+    expect(kana.isAllowedChar('ぱ')).toBe(true);
+    expect(kana.isAllowedChar('ゃ')).toBe(true);
+    expect(kana.isAllowedChar('っ')).toBe(true);
+  });
+
+  it('가타카나 허용', () => {
+    expect(kana.isAllowedChar('ア')).toBe(true);
+    expect(kana.isAllowedChar('ガ')).toBe(true);
+    expect(kana.isAllowedChar('ャ')).toBe(true);
+  });
+
+  it('장음 부호 허용', () => {
+    expect(kana.isAllowedChar('ー')).toBe(true);
+  });
+
+  it('가나 외 거부', () => {
+    expect(kana.isAllowedChar('a')).toBe(false);
+    expect(kana.isAllowedChar('한')).toBe(false);
+    expect(kana.isAllowedChar('漢')).toBe(false);
+    expect(kana.isAllowedChar('1')).toBe(false);
+    expect(kana.isAllowedChar(' ')).toBe(false);
+  });
+});
+
+describe('kana.isAllowedWord', () => {
+  it('가나로만 구성된 단어 허용', () => {
+    expect(kana.isAllowedWord('ことのは')).toBe(true);
+    expect(kana.isAllowedWord('きょうりゅう')).toBe(true);
+    expect(kana.isAllowedWord('カード')).toBe(true);
+    expect(kana.isAllowedWord('がっこう')).toBe(true);
+  });
+
+  it('비가나 포함 거부', () => {
+    expect(kana.isAllowedWord('hello')).toBe(false);
+    expect(kana.isAllowedWord('あa')).toBe(false);
+    expect(kana.isAllowedWord('한글')).toBe(false);
+    expect(kana.isAllowedWord('漢字')).toBe(false);
+  });
+
+  it('빈 문자열 거부', () => {
+    expect(kana.isAllowedWord('')).toBe(false);
+  });
+});
+
+describe('kana.normalize / normalizeChar', () => {
+  it('normalize는 trim + NFC', () => {
+    expect(kana.normalize('  ことのは  ')).toBe('ことのは');
+    // NFD 'か'+'゛' → NFC 'が'
+    expect(kana.normalize('が')).toBe('が');
+  });
+
+  it('normalizeChar는 NFC 적용', () => {
+    expect(kana.normalizeChar('あ')).toBe('あ');
+    expect(kana.normalizeChar('が')).toBe('が');
+  });
+});
+
+describe('kana.keyId', () => {
+  it('가나를 그대로 키 식별자로 사용', () => {
+    expect(kana.keyId('あ')).toBe('あ');
+    expect(kana.keyId('が')).toBe('が');
+    expect(kana.keyId('ャ')).toBe('ャ');
+  });
+});
+
+describe('kana adapter 기본 속성', () => {
+  it('id, rtl, charDescription', () => {
+    expect(kana.id).toBe('kana');
+    expect(kana.rtl).toBe(false);
+    expect(kana.charDescription).toBe('가나(히라가나/가타카나)');
+  });
+
+  it('50음 가나표 자판', () => {
+    expect(kana.keyboard.rows.length).toBeGreaterThanOrEqual(5);
+    // 첫 행에 あ-단 가나 포함
+    expect(kana.keyboard.rows[0]).toContain('あ');
+    // 마지막 행에 ENTER/BACKSPACE 포함
+    const lastRow = kana.keyboard.rows[kana.keyboard.rows.length - 1];
+    expect(lastRow).toContain('ENTER');
+    expect(lastRow).toContain('BACKSPACE');
+  });
+});
+
+describe('registry 등록', () => {
+  it('getScriptAdapter("kana")가 kana 어댑터를 반환', () => {
+    expect(getScriptAdapter('kana')).toBe(kana);
+  });
+
+  it('scriptUsesIme(kana) === true', () => {
+    expect(scriptUsesIme('kana')).toBe(true);
+  });
+
+  it('latin/hangul 회귀 없음', () => {
+    expect(getScriptAdapter('latin').id).toBe('latin');
+    expect(getScriptAdapter('hangul').id).toBe('hangul');
+  });
+});

--- a/lib/scripts/__tests__/kana.test.ts
+++ b/lib/scripts/__tests__/kana.test.ts
@@ -2,55 +2,65 @@ import { describe, it, expect } from 'vitest';
 import { kana } from '../kana';
 import { getScriptAdapter, scriptUsesIme } from '../index';
 
+// 정책: "한 타일 = 한 정규화 문자". 가타카나 → 히라가나 정규화. 모라 결합 없음. (issue #38)
 describe('kana.splitUnits', () => {
-  it('단순 모라', () => {
+  it('히라가나 한 글자 = 한 단위', () => {
     expect(kana.splitUnits('あいうえお')).toEqual(['あ', 'い', 'う', 'え', 'お']);
     expect(kana.splitUnits('かきくけこ')).toEqual(['か', 'き', 'く', 'け', 'こ']);
   });
 
-  it('요음 묶기 — ゃゅょ', () => {
-    expect(kana.splitUnits('きゃ')).toEqual(['きゃ']);
-    expect(kana.splitUnits('しゅ')).toEqual(['しゅ']);
-    expect(kana.splitUnits('ちょこ')).toEqual(['ちょ', 'こ']);
-    expect(kana.splitUnits('きょうりゅう')).toEqual(['きょ', 'う', 'りゅ', 'う']);
+  it('요음(ゃゅょ)도 독립 칸 — 모라 결합 없음', () => {
+    expect(kana.splitUnits('きゃ')).toEqual(['き', 'ゃ']);
+    expect(kana.splitUnits('ちょこ')).toEqual(['ち', 'ょ', 'こ']);
+    expect(kana.splitUnits('きょうりゅう')).toEqual(['き', 'ょ', 'う', 'り', 'ゅ', 'う']);
   });
 
-  it('요음 묶기 — 가타카나 ャュョ', () => {
-    expect(kana.splitUnits('キャ')).toEqual(['キャ']);
-    expect(kana.splitUnits('チョコ')).toEqual(['チョ', 'コ']);
+  it('작은 가나(ぁぃぅぇぉ)도 독립 칸', () => {
+    expect(kana.splitUnits('ふぉーく')).toEqual(['ふ', 'ぉ', 'ー', 'く']);
+    expect(kana.splitUnits('でぃなー')).toEqual(['で', 'ぃ', 'な', 'ー']);
+    expect(kana.splitUnits('うぃ')).toEqual(['う', 'ぃ']);
   });
 
-  it('탁점 결합 형태는 1 모라', () => {
+  it('가타카나는 히라가나로 정규화되어 분해', () => {
+    expect(kana.splitUnits('カード')).toEqual(['か', 'ー', 'ど']);
+    expect(kana.splitUnits('フォーク')).toEqual(['ふ', 'ぉ', 'ー', 'く']);
+    expect(kana.splitUnits('ディナー')).toEqual(['で', 'ぃ', 'な', 'ー']);
+    expect(kana.splitUnits('キャ')).toEqual(['き', 'ゃ']);
+  });
+
+  it('카타카나/히라가나 동등성: 같은 단위 배열', () => {
+    expect(kana.splitUnits('カード')).toEqual(kana.splitUnits('かーど'));
+    expect(kana.splitUnits('フォーク')).toEqual(kana.splitUnits('ふぉーく'));
+  });
+
+  it('탁점 결합 형태는 1 문자', () => {
     expect(kana.splitUnits('がぎ')).toEqual(['が', 'ぎ']);
     expect(kana.splitUnits('ばびぶべぼ')).toEqual(['ば', 'び', 'ぶ', 'べ', 'ぼ']);
   });
 
-  it('반탁점 결합 형태도 1 모라', () => {
+  it('반탁점 결합 형태도 1 문자', () => {
     expect(kana.splitUnits('ぱぴぷぺぽ')).toEqual(['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ']);
   });
 
   it('탁점 분리 형태(NFD)도 NFC로 결합 후 처리', () => {
     // 'か' (U+304B) + '゛' (U+3099) → NFC: 'が'
-    const nfd = 'が';
+    const nfd = 'が';
     expect(kana.splitUnits(nfd)).toEqual(['が']);
   });
 
-  it('촉음(っ)은 단독 1 모라', () => {
+  it('촉음(っ)은 독립 칸', () => {
     expect(kana.splitUnits('がっこう')).toEqual(['が', 'っ', 'こ', 'う']);
+    expect(kana.splitUnits('ガッコウ')).toEqual(['が', 'っ', 'こ', 'う']);
   });
 
-  it('장음 부호(ー)도 1 모라', () => {
-    expect(kana.splitUnits('カード')).toEqual(['カ', 'ー', 'ド']);
+  it('장음 부호(ー)도 독립 칸', () => {
+    expect(kana.splitUnits('カード')).toEqual(['か', 'ー', 'ど']);
   });
 
-  it('비가나 문자(ASCII/한글 등)는 무시', () => {
+  it('비가나 문자는 무시', () => {
     expect(kana.splitUnits('あa')).toEqual(['あ']);
     expect(kana.splitUnits('あ い')).toEqual(['あ', 'い']);
     expect(kana.splitUnits('あ가')).toEqual(['あ']);
-  });
-
-  it('맨 앞에 작은 가나가 와도 안전 (직전 모라 없음)', () => {
-    expect(kana.splitUnits('ゃ')).toEqual(['ゃ']);
   });
 });
 
@@ -60,13 +70,15 @@ describe('kana.isAllowedChar', () => {
     expect(kana.isAllowedChar('が')).toBe(true);
     expect(kana.isAllowedChar('ぱ')).toBe(true);
     expect(kana.isAllowedChar('ゃ')).toBe(true);
+    expect(kana.isAllowedChar('ぉ')).toBe(true);
     expect(kana.isAllowedChar('っ')).toBe(true);
   });
 
-  it('가타카나 허용', () => {
+  it('가타카나 허용 (덱 작성 시점)', () => {
     expect(kana.isAllowedChar('ア')).toBe(true);
     expect(kana.isAllowedChar('ガ')).toBe(true);
     expect(kana.isAllowedChar('ャ')).toBe(true);
+    expect(kana.isAllowedChar('ォ')).toBe(true);
   });
 
   it('장음 부호 허용', () => {
@@ -83,11 +95,11 @@ describe('kana.isAllowedChar', () => {
 });
 
 describe('kana.isAllowedWord', () => {
-  it('가나로만 구성된 단어 허용', () => {
+  it('가나로만 구성된 단어 허용 (히라가나/가타카나 혼용 가능)', () => {
     expect(kana.isAllowedWord('ことのは')).toBe(true);
-    expect(kana.isAllowedWord('きょうりゅう')).toBe(true);
     expect(kana.isAllowedWord('カード')).toBe(true);
     expect(kana.isAllowedWord('がっこう')).toBe(true);
+    expect(kana.isAllowedWord('フォーク')).toBe(true);
   });
 
   it('비가나 포함 거부', () => {
@@ -103,23 +115,33 @@ describe('kana.isAllowedWord', () => {
 });
 
 describe('kana.normalize / normalizeChar', () => {
-  it('normalize는 trim + NFC', () => {
+  it('normalize: trim + NFC + 가타카나 → 히라가나', () => {
     expect(kana.normalize('  ことのは  ')).toBe('ことのは');
+    expect(kana.normalize('カード')).toBe('かーど');
+    expect(kana.normalize('フォーク')).toBe('ふぉーく');
     // NFD 'か'+'゛' → NFC 'が'
-    expect(kana.normalize('が')).toBe('が');
+    expect(kana.normalize('が')).toBe('が');
   });
 
-  it('normalizeChar는 NFC 적용', () => {
+  it('normalizeChar: 가타카나 → 히라가나, 그 외 그대로', () => {
+    expect(kana.normalizeChar('カ')).toBe('か');
+    expect(kana.normalizeChar('ガ')).toBe('が');
+    expect(kana.normalizeChar('ャ')).toBe('ゃ');
     expect(kana.normalizeChar('あ')).toBe('あ');
-    expect(kana.normalizeChar('が')).toBe('が');
+    expect(kana.normalizeChar('ー')).toBe('ー');
+  });
+
+  it('히라가나/가타카나 매칭 동등성: 같은 normalize 결과', () => {
+    expect(kana.normalize('カード')).toBe(kana.normalize('かーど'));
   });
 });
 
 describe('kana.keyId', () => {
-  it('가나를 그대로 키 식별자로 사용', () => {
+  it('키 식별자도 히라가나로 정규화 (키보드 상태 통일)', () => {
     expect(kana.keyId('あ')).toBe('あ');
     expect(kana.keyId('が')).toBe('が');
-    expect(kana.keyId('ャ')).toBe('ャ');
+    expect(kana.keyId('カ')).toBe('か');
+    expect(kana.keyId('ガ')).toBe('が');
   });
 });
 
@@ -132,9 +154,7 @@ describe('kana adapter 기본 속성', () => {
 
   it('50음 가나표 자판', () => {
     expect(kana.keyboard.rows.length).toBeGreaterThanOrEqual(5);
-    // 첫 행에 あ-단 가나 포함
     expect(kana.keyboard.rows[0]).toContain('あ');
-    // 마지막 행에 ENTER/BACKSPACE 포함
     const lastRow = kana.keyboard.rows[kana.keyboard.rows.length - 1];
     expect(lastRow).toContain('ENTER');
     expect(lastRow).toContain('BACKSPACE');

--- a/lib/scripts/index.ts
+++ b/lib/scripts/index.ts
@@ -1,8 +1,9 @@
 import { hangul } from './hangul';
+import { kana } from './kana';
 import { latin } from './latin';
 import type { ScriptAdapter, ScriptId } from './types';
 
-const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin, hangul };
+const ADAPTERS: Partial<Record<ScriptId, ScriptAdapter>> = { latin, hangul, kana };
 
 // 현재 등록된 어댑터의 id 목록 (server whitelist 등에서 참조)
 export const SUPPORTED_SCRIPTS: readonly ScriptId[] = Object.keys(ADAPTERS) as ScriptId[];
@@ -12,9 +13,8 @@ export function isSupportedScript(id: string): id is ScriptId {
 }
 
 // OS IME(한글, 가나 등) 조합 입력이 필요한 스크립트 여부.
-// Phase 3에서 'kana'가 추가될 자리.
 export function scriptUsesIme(id: ScriptId): boolean {
-  return id === 'hangul';
+  return id === 'hangul' || id === 'kana';
 }
 
 export function getScriptAdapter(id: string): ScriptAdapter {

--- a/lib/scripts/kana.ts
+++ b/lib/scripts/kana.ts
@@ -1,18 +1,51 @@
 import type { ScriptAdapter } from './types';
 
-// 가나(히라가나/가타카나) 어댑터 — ことのはたんご 레퍼런스
+// 가나(히라가나/가타카나) 어댑터
 //
-// Contract:
-// - 모라 단위 분해. 기본은 가나 1자 = 1 모라
-// - 요음(ゃゅょ/ャュョ)은 직전 모라에 합쳐 1 단위로 묶는다 (예: 'きゃ' → ['きゃ'])
-// - 탁점·반탁점은 결합 형태(が, ぱ 등)를 1 모라로 본다 (NFC 가정)
-//   분리 형태(か + ゛)로 들어와도 normalize/splitUnits가 NFC로 합성 후 처리
-// - 가타카나 ↔ 히라가나 자동 변환은 하지 않는다 (덱 작성자 의도 보존)
-// - 장음 부호(ー)도 1 모라로 허용
-const SMALL_YA_RE = /[ゃゅょャュョ]/;
+// 정책 (issue #38 확정):
+// - "한 타일 = 한 정규화 문자" 규칙. 모라 단위가 아니라 가나 문자 단위로 분해한다.
+// - 가타카나는 게임 내에서 히라가나로 정규화 (`カ` === `か`).
+//   덱 작성 시점에는 둘 다 입력 허용 (작성자 의도 보존은 표시 단계가 아니라 저장 형태로만).
+// - 요음(`ゃゅょ`), 작은 가나(`ぁぃぅぇぉゎ`), 촉음(`っ`), 장음(`ー`), 발음(`ん`) 모두 독립 칸.
+// - NFC 정규화로 분리된 탁점/반탁점(`か` + `゛`)은 결합 형태(`が`)로 합쳐서 1 문자로 본다.
+const HIRAGANA_BASE = 0x3041; // ぁ
+const HIRAGANA_END = 0x3096; // ゖ
+const KATAKANA_BASE = 0x30a1; // ァ
+const KATAKANA_HIRAGANA_END = 0x30f6; // ヶ — 이 범위까지 히라가나에 1:1 대응 (-0x60)
+const KATAKANA_END = 0x30fa; // ヺ — 입력 허용 범위. ヷヸヹヺ는 히라가나 대응 없음
+const PROLONGED_SOUND_MARK = 0x30fc; // ー
 
-const KANA_CHAR_RE = /^[ぁ-ゖァ-ヺー]$/;
-const KANA_WORD_RE = /^[ぁ-ゖァ-ヺー]+$/;
+const KATAKANA_TO_HIRAGANA_OFFSET = 0x60;
+
+function toHiragana(s: string): string {
+  let result = '';
+  for (const ch of s) {
+    const code = ch.codePointAt(0)!;
+    if (code >= KATAKANA_BASE && code <= KATAKANA_HIRAGANA_END) {
+      result += String.fromCodePoint(code - KATAKANA_TO_HIRAGANA_OFFSET);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+function isKanaCodePoint(code: number): boolean {
+  return (
+    (code >= HIRAGANA_BASE && code <= HIRAGANA_END) ||
+    (code >= KATAKANA_BASE && code <= KATAKANA_END) ||
+    code === PROLONGED_SOUND_MARK
+  );
+}
+
+function isKanaChar(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  return code !== undefined && isKanaCodePoint(code);
+}
+
+function normalize(word: string): string {
+  return toHiragana(word.trim().normalize('NFC'));
+}
 
 // ことのはたんご 자판: 50음 가나표 (gojuon 행 기준 가로 배치) + 탁/반탁 + 작은 가나/장음
 const KEYBOARD_ROWS: string[][] = [
@@ -30,27 +63,24 @@ const KEYBOARD_ROWS: string[][] = [
 export const kana: ScriptAdapter = {
   id: 'kana',
   rtl: false,
-  splitUnits: (word) => {
-    const result: string[] = [];
-    for (const ch of word.normalize('NFC')) {
-      if (!KANA_CHAR_RE.test(ch)) continue;
-      if (SMALL_YA_RE.test(ch) && result.length > 0) {
-        result[result.length - 1] += ch;
-      } else {
-        result.push(ch);
-      }
-    }
-    return result;
+  splitUnits: (word) => Array.from(normalize(word)).filter(isKanaChar),
+  normalize,
+  normalizeChar: (ch) => toHiragana(ch.normalize('NFC')),
+  // 입력 단계에서는 가타카나/히라가나 모두 허용 (덱 작성 자유도 유지)
+  isAllowedChar: (ch) => {
+    const c = ch.normalize('NFC');
+    return Array.from(c).every(isKanaChar) && c.length > 0;
   },
-  normalize: (word) => word.trim().normalize('NFC'),
-  normalizeChar: (ch) => ch.normalize('NFC'),
-  isAllowedChar: (ch) => KANA_CHAR_RE.test(ch.normalize('NFC')),
-  isAllowedWord: (word) => KANA_WORD_RE.test(word.normalize('NFC')),
+  isAllowedWord: (word) => {
+    const w = word.normalize('NFC');
+    if (w.length === 0) return false;
+    return Array.from(w).every(isKanaChar);
+  },
   keyboard: {
     rows: KEYBOARD_ROWS,
     enterLabel: 'ENTER',
     backspaceLabel: 'BACKSPACE',
   },
-  keyId: (ch) => ch,
+  keyId: (ch) => toHiragana(ch),
   charDescription: '가나(히라가나/가타카나)',
 };

--- a/lib/scripts/kana.ts
+++ b/lib/scripts/kana.ts
@@ -1,0 +1,56 @@
+import type { ScriptAdapter } from './types';
+
+// 가나(히라가나/가타카나) 어댑터 — ことのはたんご 레퍼런스
+//
+// Contract:
+// - 모라 단위 분해. 기본은 가나 1자 = 1 모라
+// - 요음(ゃゅょ/ャュョ)은 직전 모라에 합쳐 1 단위로 묶는다 (예: 'きゃ' → ['きゃ'])
+// - 탁점·반탁점은 결합 형태(が, ぱ 등)를 1 모라로 본다 (NFC 가정)
+//   분리 형태(か + ゛)로 들어와도 normalize/splitUnits가 NFC로 합성 후 처리
+// - 가타카나 ↔ 히라가나 자동 변환은 하지 않는다 (덱 작성자 의도 보존)
+// - 장음 부호(ー)도 1 모라로 허용
+const SMALL_YA_RE = /[ゃゅょャュョ]/;
+
+const KANA_CHAR_RE = /^[ぁ-ゖァ-ヺー]$/;
+const KANA_WORD_RE = /^[ぁ-ゖァ-ヺー]+$/;
+
+// ことのはたんご 자판: 50음 가나표 (gojuon 행 기준 가로 배치) + 탁/반탁 + 작은 가나/장음
+const KEYBOARD_ROWS: string[][] = [
+  ['あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ'],
+  ['い', 'き', 'し', 'ち', 'に', 'ひ', 'み', 'り', 'を'],
+  ['う', 'く', 'す', 'つ', 'ぬ', 'ふ', 'む', 'ゆ', 'る', 'ん'],
+  ['え', 'け', 'せ', 'て', 'ね', 'へ', 'め', 'れ'],
+  ['お', 'こ', 'そ', 'と', 'の', 'ほ', 'も', 'よ', 'ろ'],
+  ['が', 'ぎ', 'ぐ', 'げ', 'ご', 'ざ', 'じ', 'ず', 'ぜ', 'ぞ'],
+  ['だ', 'ぢ', 'づ', 'で', 'ど', 'ば', 'び', 'ぶ', 'べ', 'ぼ'],
+  ['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ', 'ゃ', 'ゅ', 'ょ', 'っ', 'ー'],
+  ['ENTER', 'BACKSPACE'],
+];
+
+export const kana: ScriptAdapter = {
+  id: 'kana',
+  rtl: false,
+  splitUnits: (word) => {
+    const result: string[] = [];
+    for (const ch of word.normalize('NFC')) {
+      if (!KANA_CHAR_RE.test(ch)) continue;
+      if (SMALL_YA_RE.test(ch) && result.length > 0) {
+        result[result.length - 1] += ch;
+      } else {
+        result.push(ch);
+      }
+    }
+    return result;
+  },
+  normalize: (word) => word.trim().normalize('NFC'),
+  normalizeChar: (ch) => ch.normalize('NFC'),
+  isAllowedChar: (ch) => KANA_CHAR_RE.test(ch.normalize('NFC')),
+  isAllowedWord: (word) => KANA_WORD_RE.test(word.normalize('NFC')),
+  keyboard: {
+    rows: KEYBOARD_ROWS,
+    enterLabel: 'ENTER',
+    backspaceLabel: 'BACKSPACE',
+  },
+  keyId: (ch) => ch,
+  charDescription: '가나(히라가나/가타카나)',
+};


### PR DESCRIPTION
Closes #25
Refs #38

## 요약

가나(히라가나/가타카나) 어댑터를 신규 추가합니다. 정책은 후속 논의(#38)에 따라 **"한 타일 = 한 정규화 문자"**로 확정 — 가타카나는 게임 내에서 히라가나로 정규화하고, 그 외에는 가나 문자 단위로 분해/판정합니다. 모라 결합 로직은 사용하지 않습니다. Phase 2b(#24)의 `useImeInput` 인프라를 그대로 재사용합니다.

> 본 PR은 두 커밋으로 구성됩니다:
> - `0db7650` 가나 어댑터 신규(모라 분해 v1, #25 원안)
> - `8d73ff3` 정책 단순화(가타카나→히라가나 정규화 + 문자 단위 분해, #38 결정)

## 최종 정책

| 항목 | 결정 |
|---|---|
| 가타카나 ↔ 히라가나 | 게임 내 동일 취급 (가타카나 → 히라가나로 정규화) |
| 요음 `ゃゅょ` | **독립 칸** (모라 결합 없음) |
| 작은 가나 `ぁぃぅぇぉゎ` 등 | **독립 칸** |
| 촉음 `っ`, 장음 `ー`, 발음 `ん` | 독립 칸 |
| 덱 작성 입력 허용 | 가타카나/히라가나 둘 다 (작성자 자유도 유지) |

### 예시

```ts
adapter.splitUnits('カード')   // ['か', 'ー', 'ど']
adapter.splitUnits('フォーク') // ['ふ', 'ぉ', 'ー', 'く']
adapter.splitUnits('ディナー') // ['で', 'ぃ', 'な', 'ー']
adapter.splitUnits('きゃく')   // ['き', 'ゃ', 'く']
adapter.splitUnits('がっこう') // ['が', 'っ', 'こ', 'う']

adapter.splitUnits('カード') === adapter.splitUnits('かーど')  // 동일 units
adapter.normalizeChar('カ') === 'か'
```

## 변경 사항

- **`lib/scripts/kana.ts`** (신규)
  - `toHiragana(s)` 헬퍼: U+30A1 – U+30F6 → −0x60
  - `normalize`/`normalizeChar`: trim + NFC + 가타카나 → 히라가나
  - `splitUnits = Array.from(normalize(input)).filter(isKanaChar)` — 모라 결합 로직 없음
  - `keyId`도 히라가나로 정규화 (키보드 상태 통일)
  - `isAllowedChar`/`isAllowedWord`: 히라가나/가타카나 둘 다 허용 (덱 작성 자유도)
  - 50음 가나표 자판 (히라가나 위주)
- **`lib/scripts/index.ts`**: registry에 `kana` 등록, `scriptUsesIme`에 `kana` 추가
- **`components/decks/DeckDialog.tsx`**: 폼 셀렉터에 `日本語 (Kana)` 옵션 추가
- **`lib/scripts/__tests__/kana.test.ts`** (신규): 27 케이스

## IME 통합

Phase 2b의 `useImeInput` 훅이 `scriptUsesIme(adapter.id)` 분기로 자동 재사용됩니다. 일본어 IME composition → `compositionend` 시 정규화된 가나 문자열이 game state에 누적됩니다.

## 화이트리스트

이슈 #25에서 언급한 `ALLOWED_SCRIPTS`는 현 코드베이스에서 `SUPPORTED_SCRIPTS`로 구현되어 있고 registry(`ADAPTERS`)에서 자동 파생됩니다. `kana` 어댑터 등록만으로 server action 화이트리스트가 갱신됩니다.

## 정책 변경 이력 (참고)

이슈 #25 원안은 ことのはたんご 레퍼런스를 따라 모라 결합(`きゃ` → `['きゃ']`)을 적용했으나, 실제 사용 중 두 문제가 드러나 #38에서 정책을 재논의:

1. IME가 외래어(`fo`/`vo`/`wi` 등)를 작은 가나로 결합해 보내는데, 모라 기반 정책은 이를 "1 모라인데 두 칸"으로 만들어 어색
2. `あ`/`ア`를 다른 글자로 취급하면 IME 입력 모드에 따라 정답이 absent로 떨어지는 혼란

→ 모라 단위 결합 로직을 전부 제거하고 **"한 타일 = 한 정규화 문자"** 규칙으로 단순화. UI/판정/공유 결과/테스트가 모두 단순해짐.

## 별도 작업으로 분리

- **#40** — 일본어 모드 도움말/튜토리얼 노출. 새 정책이 일본어 음운/모라 직관과 어긋나므로 게임 시작 전 규칙 안내가 필요. 본 PR 범위 외.

## 회귀 검증

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 신규 경고 없음 (기존 4 warning은 본 PR과 무관)
- [x] `pnpm test` 50/50 통과 (kana 27 + hangul 23)
- [x] 라틴/한글 어댑터 회귀 없음 (registry 테스트로 확인)

## Test plan

- [ ] 덱 작성 폼에서 `日本語 (Kana)` 선택 → 히라가나/가타카나 둘 다 입력 허용, 비가나 거부
- [ ] 가나 덱 플레이:
  - [ ] OS 일본어 IME 입력 → 가나 문자 단위로 그리드 누적
  - [ ] `カード` 덱에서 `かーど`/`カード` 둘 다 정답 처리
  - [ ] `フォーク` 덱에서 `ふぉ`가 두 타일에 표시됨 (정책)
  - [ ] `がっこう`의 촉음 `っ`이 한 타일 차지
  - [ ] 50음 자판 클릭 입력 정상
  - [ ] 정답 매칭 (`カ === か`, `カ === カ`)
- [ ] 라틴/한글 덱 동작 그대로

## 참고

- 브랜치명: 시스템 지시(작업 브랜치 고정)에 따라 #25 원안의 `claude/script-kana` 대신 `claude/wordle-share-feature-d1EQA` 사용
- 정책 결정: #38 댓글 [#issuecomment-4348798646](https://github.com/nanana3679/wordle-share/issues/38#issuecomment-4348798646)
- 도움말/튜토리얼: #40으로 분리

https://claude.ai/code/session_01TGegB9rT6jeD9wEqUgNBZu