### PR TITLE
feat(meta): PR scope-checker agent + PR template + CLAUDE.md rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,2 +1,21 @@
 CLAUDE.md 자체의 분량을 100줄 이하로 유지한다.
 문서 작성/수정 시 docs-convention 스킬을 참고한다.
+
+## PR 생성 룰
+
+PR 생성 전 반드시 `pr-scope-checker` sub-agent 호출:
+
+- APPROVE → 진행
+- SUGGEST_SPLIT → 분할안 사용자 확인 후 진행
+- REQUIRE_CHANGES → 중단, 수정 후 재호출
+
+리뷰 응답 후 변경 추가 시 재호출.
+
+### Review Triage
+
+리뷰 피드백은 반드시 A/B/C 분류:
+
+- A. in-scope must-fix → 본 PR 반영
+- B. in-scope optional → 본 PR or issue
+- C. out-of-scope → issue 생성, 본 PR 미반영
+- default: C

--- a/.claude/agents/pr-scope-checker.md
+++ b/.claude/agents/pr-scope-checker.md
@@ -13,27 +13,27 @@ description: PR 생성 전 scope 검증. git diff 분석 → domain layer 분류
 
 ---
 
-## 입력
-
-사용자에게 다음을 요청한다:
-
-```
-1. PR type (decision / implementation / mechanical / docs / mixed)
-2. 포함 scope (한 문장 이상)
-3. 제외 scope
-4. Main Review Question (한 문장)
-```
-
-입력 없으면 `git diff $(git merge-base HEAD origin/main)..HEAD --name-only` 결과로 추론한다.
-
----
-
 ## 분석 절차
+
+### 0. 입력 수집 (추론 우선)
+
+다음 순서로 정보를 수집한다. 판정 불가할 때만 사용자에게 질문한다.
+
+1. 현재 대화 맥락에서 PR type / scope / review question 추론
+2. `.github/pull_request_template.md` 또는 사용자가 작성 중인 PR draft 확인
+3. `git diff` 결과에서 변경 내용 추론
+4. 위 세 가지로 판정 불가한 항목만 사용자에게 질문
 
 ### 1. 변경 파일 수집
 
+base branch는 다음 우선순위로 결정한다:
+1. 사용자 입력값 (명시된 경우)
+2. `git symbolic-ref refs/remotes/origin/HEAD` 결과
+3. `origin/main` fallback
+
 ```bash
-git diff $(git merge-base HEAD origin/main)..HEAD --name-only
+BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "main")
+git diff $(git merge-base HEAD origin/$BASE)..HEAD --name-only
 ```
 
 ### 2. Domain Layer 매핑
@@ -41,12 +41,13 @@ git diff $(git merge-base HEAD origin/main)..HEAD --name-only
 변경 파일을 아래 layer로 분류:
 
 ```
-docs           docs/, README, *.md (ADR 제외)
+meta           .claude/, .github/, process 문서, agent 정의, skill 파일
+docs           docs/ (adr 제외), README, *.md
 adr            docs/adr/
 planning       docs/issue/, docs/planning/
 product-spec   docs/product/, docs/domain/
 architecture   docs/architecture/
-infra          .github/, CI, config, wrangler*, next.config*, tsconfig*
+infra          CI config, wrangler*, next.config*, tsconfig*, package.json
 game-state     app/**/play/, lib/game*, lib/round*
 identity       lib/identity*, lib/auth*, middleware*
 moderation     lib/moderation*, lib/report*
@@ -57,11 +58,22 @@ mechanical     파일명 변경, import path 수정, generated file
 
 분류 안 되면 파일 경로 보고 가장 가까운 layer 선택.
 
-### 3. Primary / Secondary 판별
+### 3. Primary Layer 판별 (우선순위 순)
 
-- 가장 많이 변경된 layer = primary 후보
-- 테스트, docs, fixture, lockfile = 항상 secondary
-- secondary가 독립적인 리뷰 질문 생성 시 → secondary 아님, 별도 PR 후보
+다음 순서로 primary layer를 결정한다. 파일 수는 최후 수단이다.
+
+1. **PR type 선언** — 선언된 type으로 primary layer 추론
+   - `decision` → adr 또는 planning
+   - `implementation` → 기능 코드 layer
+   - `mechanical` → mechanical
+   - `docs` → docs
+2. **Main Review Question 키워드** — 질문에서 layer 키워드 추출
+3. **포함 scope 선언** — 선언된 포함 항목에서 layer 추론
+4. **Semantic change layer** — test/docs/fixture 제외 후 가장 많이 변경된 layer
+5. **파일 수 기준** — 위 4단계로 판정 불가할 때만
+
+Secondary: test, docs, fixture, lockfile, generated file은 항상 secondary.
+secondary가 독립 리뷰 질문 생성 시 → secondary 아님, 별도 PR 후보.
 
 ### 4. ADR count
 
@@ -79,6 +91,7 @@ A만 revert해도 B 의미 유지?
 ```
 
 "예" 많음 = independent → split 신호.
+"아니오" 많음 = interlocked → 같은 PR 가능.
 
 ---
 
@@ -192,4 +205,55 @@ A. in-scope must-fix → 본 PR 반영
 B. in-scope optional → 본 PR or issue
 C. out-of-scope → issue 생성, 본 PR 미반영
 default: C
+```
+
+---
+
+## Verdict 예시 케이스
+
+### APPROVE 예시
+
+```
+PR type: implementation
+변경: lib/identity.ts, lib/identity.test.ts, docs/architecture/IDENTITY_MODEL.md
+primary layer: identity
+secondary layers: test, docs
+ADR count: 0
+file count: 3
+리뷰 질문: nick+pw bcrypt 검증 로직이 올바른가?
+
+→ verdict: APPROVE
+```
+
+### SUGGEST_SPLIT 예시
+
+```
+PR type: mixed
+변경: docs/adr/0001.md, docs/adr/0002.md, docs/adr/0003.md, docs/adr/0004.md,
+      lib/identity.ts, lib/game-state.ts, app/play/page.tsx
+primary layer: adr (4개), identity, game-state 혼재
+ADR count: 4
+file count: 7
+
+→ verdict: SUGGEST_SPLIT
+reason: ADR 4개 이상. identity/game-state는 독립 decision.
+split suggestion:
+  - PR A: identity 정책 결정 — adr, 파일 2개, ADR 2개
+  - PR B: game-state 정책 결정 — adr, 파일 2개, ADR 2개
+  - PR C: identity 구현 — identity layer, 파일 1개, ADR 0개
+  - PR D: game-state 구현 — game-state layer, 파일 1개, ADR 0개
+```
+
+### REQUIRE_CHANGES 예시
+
+```
+PR type: mixed (justification 없음)
+변경: docs/adr/ 9개, lib/identity.ts, lib/game-state.ts, lib/moderation.ts,
+      app/play/, app/feed/, app/d/
+primary layer: adr, identity, game-state, moderation, discovery 혼재
+ADR count: 9
+file count: 16
+
+→ verdict: REQUIRE_CHANGES
+reason: ADR 8+ (9개). primary layer 5개, justification 없음. product + architecture + implementation 동시 변경.
 ```

--- a/.claude/agents/pr-scope-checker.md
+++ b/.claude/agents/pr-scope-checker.md
@@ -1,0 +1,195 @@
+---
+name: pr-scope-checker
+description: PR 생성 전 scope 검증. git diff 분석 → domain layer 분류 → Verdict 출력. PR 작성 시 반드시 호출.
+---
+
+한 PR = 한 질문.
+한 PR = 한 primary layer.
+나머지 변경 = 보조만.
+
+크면 쪼갠다.
+독립 decision이면 쪼갠다.
+리뷰 중 scope 늘면 멈춘다.
+
+---
+
+## 입력
+
+사용자에게 다음을 요청한다:
+
+```
+1. PR type (decision / implementation / mechanical / docs / mixed)
+2. 포함 scope (한 문장 이상)
+3. 제외 scope
+4. Main Review Question (한 문장)
+```
+
+입력 없으면 `git diff $(git merge-base HEAD origin/main)..HEAD --name-only` 결과로 추론한다.
+
+---
+
+## 분석 절차
+
+### 1. 변경 파일 수집
+
+```bash
+git diff $(git merge-base HEAD origin/main)..HEAD --name-only
+```
+
+### 2. Domain Layer 매핑
+
+변경 파일을 아래 layer로 분류:
+
+```
+docs           docs/, README, *.md (ADR 제외)
+adr            docs/adr/
+planning       docs/issue/, docs/planning/
+product-spec   docs/product/, docs/domain/
+architecture   docs/architecture/
+infra          .github/, CI, config, wrangler*, next.config*, tsconfig*
+game-state     app/**/play/, lib/game*, lib/round*
+identity       lib/identity*, lib/auth*, middleware*
+moderation     lib/moderation*, lib/report*
+discovery      lib/feed*, lib/search*, lib/hot*
+test           **/*.test.*, **/*.spec.*, **/fixtures/**, **/__snapshots__/
+mechanical     파일명 변경, import path 수정, generated file
+```
+
+분류 안 되면 파일 경로 보고 가장 가까운 layer 선택.
+
+### 3. Primary / Secondary 판별
+
+- 가장 많이 변경된 layer = primary 후보
+- 테스트, docs, fixture, lockfile = 항상 secondary
+- secondary가 독립적인 리뷰 질문 생성 시 → secondary 아님, 별도 PR 후보
+
+### 4. ADR count
+
+`docs/adr/` 신규/수정 파일 수 카운트.
+
+### 5. Decision Interlock 검증
+
+변경이 2개 이상의 독립 decision을 포함하는지 확인:
+
+```
+A 없이 B merge 가능?
+B 없이 A merge 가능?
+A만 revert해도 B 의미 유지?
+리뷰어가 A/B에 다른 결론 가능?
+```
+
+"예" 많음 = independent → split 신호.
+
+---
+
+## Verdict
+
+### APPROVE
+
+조건 대부분 충족:
+
+```
+primary layer 1개
+secondary = test/docs/fixture/lockfile/generated
+ADR 0–3
+파일 ≤ 15
+리뷰 질문 1문장
+scope 선언과 diff 일치
+decision interlocked
+```
+
+→ 진행.
+
+---
+
+### SUGGEST_SPLIT
+
+조건 하나 이상 해당:
+
+```
+primary layer 2+
+ADR 4+
+파일 16–30
+리뷰 질문 2+
+independent decision 혼재
+mixed인데 justification 약함
+```
+
+→ 분할안 제시. 사용자 확인 후 진행.
+
+분할안 형식:
+
+```
+PR A: <title> — <primary layer>, <파일 수>개, ADR <n>개
+PR B: <title> — <primary layer>, <파일 수>개, ADR <n>개
+```
+
+---
+
+### REQUIRE_CHANGES
+
+조건 하나 이상 해당:
+
+```
+primary layer 3+ and justification 없음
+ADR 8+
+파일 31+ and mechanical 아님
+product + architecture + implementation 섞임
+선언 scope != actual diff (크게 다름)
+out-of-scope feedback을 issue 없이 본 PR에 반영
+triage 없이 변경 누적
+```
+
+→ 중단. 수정 요청.
+
+---
+
+## 출력 형식
+
+```
+verdict: APPROVE | SUGGEST_SPLIT | REQUIRE_CHANGES
+primary layer: <layer>
+secondary layers: <layer>, <layer>
+ADR count: <n>
+file count: <n>
+decision interlock: interlocked | independent (<이유>)
+split suggestion: (SUGGEST_SPLIT일 때만)
+  - PR A: ...
+  - PR B: ...
+reason: (SUGGEST_SPLIT / REQUIRE_CHANGES일 때 한 줄)
+```
+
+---
+
+## PR Type별 추가 기준
+
+### mechanical
+
+```
+behavior change 있으면 → REQUIRE_CHANGES
+decision 변경 있으면 → REQUIRE_CHANGES
+semantic change 섞이면 → SUGGEST_SPLIT
+파일 수 제한 없음
+```
+
+### mixed
+
+```
+justification 없으면 → REQUIRE_CHANGES
+"편해서"가 이유면 → REQUIRE_CHANGES
+리뷰 질문 1개로 묶이면 → APPROVE 가능
+```
+
+---
+
+## Review Triage 재호출
+
+리뷰 응답 후 변경 추가 시 반드시 재호출.
+새 변경을 A/B/C로 분류 후 scope-check 재실행:
+
+```
+A. in-scope must-fix → 본 PR 반영
+B. in-scope optional → 본 PR or issue
+C. out-of-scope → issue 생성, 본 PR 미반영
+default: C
+```

--- a/.claude/agents/pr-scope-checker.md
+++ b/.claude/agents/pr-scope-checker.md
@@ -41,13 +41,13 @@ git diff $(git merge-base HEAD origin/$BASE)..HEAD --name-only
 변경 파일을 아래 layer로 분류:
 
 ```
-meta           .claude/, .github/, process 문서, agent 정의, skill 파일
+meta           .claude/, .github/ (workflows 제외), process 문서, agent 정의, skill 파일
 docs           docs/ (adr 제외), README, *.md
 adr            docs/adr/
 planning       docs/issue/, docs/planning/
 product-spec   docs/product/, docs/domain/
 architecture   docs/architecture/
-infra          CI config, wrangler*, next.config*, tsconfig*, package.json
+infra          .github/workflows/, CI config, wrangler*, next.config*, tsconfig*, package.json
 game-state     app/**/play/, lib/game*, lib/round*
 identity       lib/identity*, lib/auth*, middleware*
 moderation     lib/moderation*, lib/report*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@
 - [ ] docs
 - [ ] mixed
 
+## Justification
+<!-- mixed PR일 때만 작성. 왜 분리하지 않는가? -->
+
 ## Main Review Question
 
 이 PR에서 리뷰어가 판단해야 하는 핵심 질문 1개:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## PR Type
+- [ ] decision
+- [ ] implementation
+- [ ] mechanical
+- [ ] docs
+- [ ] mixed
+
+## Main Review Question
+
+이 PR에서 리뷰어가 판단해야 하는 핵심 질문 1개:
+
+>
+
+## Scope
+
+### 포함
+-
+
+### 제외
+-
+
+## Scope Check
+
+<!-- pr-scope-checker 출력 붙여넣기 -->
+
+```
+verdict:
+primary layer:
+secondary layers:
+ADR count:
+file count:
+decision interlock:
+split suggestion:
+```
+
+## Review Triage Log
+
+- A. in-scope must-fix → 본 PR
+- B. in-scope optional → 본 PR or issue
+- C. out-of-scope → issue 생성, 본 PR 미반영
+- default: C
+
+| feedback | class | action | linked issue |
+|---|---|---|---|
+| | | | |


### PR DESCRIPTION
## PR Type
- [x] meta (process 도구 — mechanical에 준함)

## Justification
<!-- mixed PR일 때만 작성. 왜 분리하지 않는가? -->
N/A

## Main Review Question

> pr-scope-checker sub-agent와 PR template이 이슈 #57의 acceptance criteria를 충족하는가?

## Scope

### 포함
- `.claude/agents/pr-scope-checker.md` — sub-agent 프롬프트 신규 작성
- `.github/pull_request_template.md` — PR 템플릿 신규 작성
- `.claude/CLAUDE.md` — PR 생성 룰 + review triage 룰 추가

### 제외
- `/create-pr` skill (선택 항목, 별도 이슈 가능)
- `mcp__github__create_pull_request` hook (선택 항목)
- 실제 더미 branch 테스트 로그 (→ follow-up issue)

## Scope Check

```
verdict: APPROVE
primary layer: meta (.claude/, .github/ process 도구)
secondary layers: docs (CLAUDE.md)
ADR count: 0
file count: 3
decision interlock: interlocked (agent/template/rule이 하나의 가드 시스템)
split suggestion: 없음
```

## 변경 내용

### `.claude/agents/pr-scope-checker.md`

- 입력 수집: 대화 맥락 → PR draft → git diff 순으로 추론, 판정 불가할 때만 사용자 질문
- base branch: 사용자 입력 → `git symbolic-ref` → `origin/main` fallback
- primary layer 판별 우선순위: PR type 선언 > review question 키워드 > scope 선언 > semantic 파일 수 > 파일 수
- `meta` layer 추가 (`.claude/`, `.github/` workflows 제외), `.github/workflows/`는 infra
- APPROVE / SUGGEST_SPLIT / REQUIRE_CHANGES 예시 케이스 추가 (issue #57 acceptance criteria)
- Verdict 3단계, Decision Interlock 4문항, Review Triage 재호출 룰

### `.github/pull_request_template.md`

- PR Type 체크박스 (decision/implementation/mechanical/docs/mixed)
- `## Justification` 섹션 추가 (mixed PR용)
- Main Review Question 섹션
- Scope 포함/제외 섹션
- Scope Check 출력 블록
- Review Triage Log 테이블

### `.claude/CLAUDE.md`

- PR 생성 전 pr-scope-checker 호출 필수 룰
- APPROVE/SUGGEST_SPLIT/REQUIRE_CHANGES 대응 행동 명시
- Review Triage A/B/C 분류 + default C 룰

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| 입력 요청 → 추론 우선으로 변경 | A | 반영 (c92cfa5) | — |
| base branch hardcoded → fallback chain | A | 반영 (c92cfa5) | — |
| primary layer = 파일 수 기준 → 우선순위 체인 | A | 반영 (c92cfa5) | — |
| .claude/.github → meta layer | A | 반영 (c92cfa5) | — |
| verdict 예시 케이스 추가 | B | 반영 (c92cfa5) | — |
| .github/workflows/ → infra layer 분리 | A | 반영 (3104744) | — |
| mixed justification 필드 추가 | B | 반영 (3104744) | — |
| 실제 더미 branch 테스트 로그 | C | issue 생성 | TBD |

Closes #57

https://claude.ai/code/session_01S3syuQ5qXjrm4Q9ZgLf1w6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

이번 업데이트는 **개발 프로세스 개선**으로 사용자에게 직접 보이는 기능 변화가 없습니다.

* **Chores**
  * PR 생성 시 자동 스코프 검증 절차(판정: APPROVE / SUGGEST_SPLIT / REQUIRE_CHANGES) 도입 및 리뷰 후 재검토 재실행 요구가 추가되었습니다.
  * 리뷰 피드백을 A/B/C로 분류하는 트리아지 단계가 추가되었습니다.
* **Documentation**
  * 표준화된 풀 리퀘스트 템플릿과 한국어로 된 PR 검증 절차 문서가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanana3679/wordle-share/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->