### PR TITLE
refactor(game): useGame에서 GameEngine 순수 모듈 분리 (#79)

### DIFF
--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import { isGameComplete, type GameState } from "@/lib/wordleGame";
-import { createGameEngine, createGameEngineFromState, type GameEngine } from "@/lib/gameEngine";
+import { createGameEngine, type GameEngine } from "@/lib/gameEngine";
 import type { ScriptAdapter } from "@/lib/scripts/types";
 import { scriptUsesIme } from "@/lib/scripts";
 import { Deck } from "@/types/decks";
@@ -57,8 +57,8 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
 
     const { engine: next, result } = engineRef.current.submitGuess();
 
-    // 줄 미충족 (invalid with empty reason) — 아무것도 안 함
-    if (result.type === 'invalid' && result.reason === '') {
+    // 줄 미충족 — 아무것도 안 함
+    if (result.type === 'incomplete') {
       setIsSubmitting(false);
       return;
     }

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -1,18 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { toast } from "sonner";
-import {
-  initializeGame,
-  addLetterToGuess,
-  removeLetterFromGuess,
-  submitGuess,
-  selectRandomWord,
-  isGameComplete,
-  type GameState
-} from "@/lib/wordleGame";
+import { isGameComplete, type GameState } from "@/lib/wordleGame";
+import { createGameEngine, createGameEngineFromState, type GameEngine } from "@/lib/gameEngine";
 import type { ScriptAdapter } from "@/lib/scripts/types";
 import { scriptUsesIme } from "@/lib/scripts";
 import { Deck } from "@/types/decks";
-import { getWordStrings } from "@/lib/deckHelpers";
 
 export interface UseGameReturn {
   gameState: GameState | null;
@@ -27,6 +19,7 @@ export interface UseGameReturn {
 }
 
 export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
+  const engineRef = useRef<GameEngine | null>(null);
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [showResult, setShowResult] = useState(false);
   const [showGameResultModal, setShowGameResultModal] = useState(false);
@@ -35,78 +28,62 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
 
   // 게임 초기화
   useEffect(() => {
-    const wordList = getWordStrings(deck);
-    if (wordList.length === 0) {
-      throw new Error('이 덱에는 단어가 없습니다.');
-    }
-
-    // 랜덤 단어 선택 및 게임 초기화
-    const targetWord = selectRandomWord(wordList);
-    const initialGameState = initializeGame(targetWord, 6, wordList, adapter);
-    setGameState(initialGameState);
+    const engine = createGameEngine(deck, adapter.id);
+    engineRef.current = engine;
+    setGameState(engine.state);
   }, [deck, adapter]);
 
   // 키보드 입력 처리
-  // 줄이 가득 찼는지 검사는 addLetterToGuess 내부에서 어댑터의 splitUnits 기반으로 수행한다.
-  // 여기서 string length로 사전 가드를 하면 한글처럼 unit≠char인 스크립트에서
-  // 첫 자모만 들어가고 나머지가 차단되는 버그가 생긴다.
   const handleKeyPress = useCallback((key: string) => {
-    if (!gameState || isGameComplete(gameState)) return;
+    if (!engineRef.current || !gameState || isGameComplete(gameState)) return;
 
-    setGameState(prevState => {
-      if (!prevState) return null;
-      return addLetterToGuess(prevState, key);
-    });
+    const next = engineRef.current.addLetter(key);
+    engineRef.current = next;
+    setGameState(next.state);
   }, [gameState]);
 
   const handleBackspace = useCallback(() => {
-    if (!gameState || isGameComplete(gameState)) return;
-    
-    setGameState(prevState => {
-      if (!prevState) return null;
-      return removeLetterFromGuess(prevState);
-    });
+    if (!engineRef.current || !gameState || isGameComplete(gameState)) return;
+
+    const next = engineRef.current.removeLetter();
+    engineRef.current = next;
+    setGameState(next.state);
   }, [gameState]);
 
   const handleEnter = useCallback(() => {
-    if (!gameState || isGameComplete(gameState) || isSubmitting) return;
+    if (!engineRef.current || !gameState || isGameComplete(gameState) || isSubmitting) return;
 
-    // 줄 채움 검증은 submitGuess 내부의 splitUnits 기반 로직에 위임한다.
-    // 여기서 string length로 사전 체크하면 unit≠char인 한글 등에서 제출이 차단된다.
-
-    // 중복 제출 방지
     setIsSubmitting(true);
 
-    // submitGuess를 먼저 실행하여 결과 확인
-    const newState = submitGuess(gameState);
+    const { engine: next, result } = engineRef.current.submitGuess();
 
-    // submitGuess가 변화 없이 반환한 경우(줄 미충족 등) → 아무것도 안 함
-    if (newState === gameState) {
+    // 줄 미충족 (invalid with empty reason) — 아무것도 안 함
+    if (result.type === 'invalid' && result.reason === '') {
       setIsSubmitting(false);
       return;
     }
-    
-    // 에러 메시지가 있으면 toast로 표시하고 상태 업데이트하지 않음
-    if (newState.errorMessage) {
-      toast.error(newState.errorMessage);
-      // 에러가 있을 때만 상태 업데이트 (errorMessage는 포함하지 않음)
-      setGameState(newState);
+
+    // 유효 단어 검사 실패 — toast + 상태 반영
+    if (result.type === 'invalid') {
+      toast.error(result.reason);
+      engineRef.current = next;
+      setGameState(next.state);
       setIsSubmitting(false);
       return;
     }
-    
-    // 정상적인 경우 상태 업데이트
-    setGameState(newState);
+
+    // 정상 제출
+    engineRef.current = next;
+    setGameState(next.state);
     setIsSubmitting(false);
-    
-    // 게임이 끝났다면 결과 애니메이션 표시
-    if (isGameComplete(newState)) {
+
+    // 게임 종료 처리
+    if (isGameComplete(next.state)) {
       setTimeout(() => setShowResult(true), 600);
-      // 게임 결과 모달 표시
-      if (newState.gameStatus === 'won') {
+      if (next.state.gameStatus === 'won') {
         setGameResultType('success');
         setTimeout(() => setShowGameResultModal(true), 1200);
-      } else if (newState.gameStatus === 'lost') {
+      } else if (next.state.gameStatus === 'lost') {
         setGameResultType('failure');
         setTimeout(() => setShowGameResultModal(true), 1200);
       }
@@ -118,15 +95,10 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!gameState || isGameComplete(gameState)) return;
 
-      // 특수 키는 영문 그대로 비교 (브라우저 KeyboardEvent.key 표준값)
       const rawKey = event.key;
       const upperKey = rawKey.toUpperCase();
 
       // Enter는 IME 조합 중에도 통과시킨다.
-      // 한국어 IME는 마지막 자모 입력 후에도 composition 상태를 유지하므로
-      // isComposing 가드를 걸면 사용자가 Enter를 두 번 눌러야 제출되는 문제가 생긴다.
-      // 우리는 compositionupdate에서 매 자모를 실시간 dispatch하므로 이 시점의
-      // currentGuess는 이미 최신 상태다.
       if (upperKey === 'ENTER') {
         event.preventDefault();
         handleEnter();
@@ -134,7 +106,6 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
       }
 
       // IME 조합 중에는 letter / Backspace 처리 금지.
-      // (Backspace는 IME가 처리 → compositionupdate → reconcile에서 자모 단위 삭제)
       if (event.isComposing || event.keyCode === 229) return;
 
       if (upperKey === 'BACKSPACE' || upperKey === 'DELETE') {
@@ -144,18 +115,14 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
       }
 
       // IME 기반 스크립트는 hidden input의 composition 경로로만 입력을 받는다
-      // (전역 keydown으로 직접 입력하면 hidden input과 중복 누적됨)
       if (scriptUsesIme(adapter.id)) return;
 
-      // 한 글자 입력: keyId는 키보드 상태 식별자라 입력 문자로 쓰면
-      // 비라틴 스크립트에서 currentGuess가 깨질 수 있음. 실제 입력 문자를 그대로 전달.
       if (rawKey.length === 1 && adapter.isAllowedChar(rawKey)) {
         event.preventDefault();
         handleKeyPress(rawKey);
         return;
       }
 
-      // 다른 모든 키 차단
       if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
         event.preventDefault();
       }
@@ -167,12 +134,9 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
 
   // 게임 재시작
   const restartGame = useCallback(() => {
-    const wordList = getWordStrings(deck);
-    if (wordList.length === 0) return;
-
-    const targetWord = selectRandomWord(wordList);
-    const newGameState = initializeGame(targetWord, 6, wordList, adapter);
-    setGameState(newGameState);
+    const engine = createGameEngine(deck, adapter.id);
+    engineRef.current = engine;
+    setGameState(engine.state);
     setShowResult(false);
     setShowGameResultModal(false);
     setGameResultType(null);
@@ -191,4 +155,3 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
     setShowGameResultModal,
   };
 }
-

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -31,7 +31,7 @@ export function useGame(deck: Deck, adapter: ScriptAdapter): UseGameReturn {
     const engine = createGameEngine(deck, adapter.id);
     engineRef.current = engine;
     setGameState(engine.state);
-  }, [deck, adapter]);
+  }, [deck, adapter.id]);
 
   // 키보드 입력 처리
   const handleKeyPress = useCallback((key: string) => {

--- a/lib/gameEngine.ts
+++ b/lib/gameEngine.ts
@@ -1,0 +1,181 @@
+// GameEngine: 순수 게임 로직을 캡슐화한 불변 모듈
+// getScriptAdapter는 createGameEngine() 호출 시 한 번만 실행됩니다.
+
+import { getScriptAdapter } from './scripts';
+import type { ScriptId } from './scripts/types';
+import type { Deck } from '@/types/decks';
+import { getWordStrings } from './deckHelpers';
+import {
+  initializeGame,
+  selectRandomWord,
+  evaluateGuess as _evaluateGuess,
+  type GameState,
+  type Guess,
+  type Letter,
+  type LetterState,
+} from './wordleGame';
+
+export type { GameState, LetterState, Guess } from './wordleGame';
+
+export type TileState = LetterState;
+
+export type GuessResult =
+  | { type: 'invalid'; reason: string }
+  | { type: 'correct' }
+  | { type: 'wrong'; tileStates: TileState[] }
+  | { type: 'game_over' };
+
+export interface GameEngine {
+  addLetter(letter: string): GameEngine;
+  removeLetter(): GameEngine;
+  submitGuess(): { engine: GameEngine; result: GuessResult };
+  readonly state: GameState;
+}
+
+// 내부 구현: 어댑터 인스턴스를 인스턴스 변수로 고정하여 매 호출마다 재조회하지 않음
+class GameEngineImpl implements GameEngine {
+  readonly state: GameState;
+  private readonly _adapter: ReturnType<typeof getScriptAdapter>;
+
+  constructor(state: GameState, adapter: ReturnType<typeof getScriptAdapter>) {
+    this.state = state;
+    this._adapter = adapter;
+  }
+
+  private get adapter() {
+    return this._adapter;
+  }
+
+  addLetter(letter: string): GameEngine {
+    const { state, adapter } = this;
+    if (state.gameStatus !== 'playing') return this;
+
+    const targetUnits = adapter.splitUnits(state.targetWord);
+    const currentUnits = adapter.splitUnits(state.currentGuess);
+    if (currentUnits.length >= targetUnits.length) return this;
+    if (!adapter.isAllowedChar(letter)) return this;
+
+    return new GameEngineImpl({
+      ...state,
+      currentGuess: state.currentGuess + adapter.normalizeChar(letter),
+      errorMessage: undefined,
+    }, adapter);
+  }
+
+  removeLetter(): GameEngine {
+    const { state, adapter } = this;
+    if (state.gameStatus !== 'playing') return this;
+
+    const units = adapter.splitUnits(state.currentGuess);
+    if (units.length === 0) return this;
+
+    return new GameEngineImpl({
+      ...state,
+      currentGuess: units.slice(0, -1).join(''),
+    }, adapter);
+  }
+
+  submitGuess(): { engine: GameEngine; result: GuessResult } {
+    const { state, adapter } = this;
+
+    if (state.gameStatus !== 'playing') {
+      return { engine: this, result: { type: 'game_over' } };
+    }
+
+    const targetUnits = adapter.splitUnits(state.targetWord);
+    const currentUnits = adapter.splitUnits(state.currentGuess);
+
+    // 줄 미충족 — invalid (이유 없이 동일 상태 반환)
+    if (currentUnits.length !== targetUnits.length) {
+      return {
+        engine: this,
+        result: { type: 'invalid', reason: '' },
+      };
+    }
+
+    // 유효 단어 검사
+    if (state.validWords && state.validWords.length > 0) {
+      const normalized = adapter.normalize(state.currentGuess);
+      if (!state.validWords.includes(normalized)) {
+        const invalidState = { ...state, errorMessage: '단어 목록에 없는 단어입니다.' };
+        return {
+          engine: new GameEngineImpl(invalidState, adapter),
+          result: { type: 'invalid', reason: invalidState.errorMessage },
+        };
+      }
+    }
+
+    // 추측 평가
+    const newGuess = _evaluateGuess(currentUnits, targetUnits);
+    const newGuesses = [...state.guesses, newGuess];
+
+    // 키보드 상태 업데이트
+    const newKeyboardState = { ...state.keyboardState };
+    newGuess.letters.forEach((letter: Letter) => {
+      if (letter.char && letter.state !== 'empty') {
+        const keyId = adapter.keyId(letter.char);
+        const current = newKeyboardState[keyId];
+        if (
+          !current ||
+          (current === 'absent' && letter.state !== 'absent') ||
+          (current === 'present' && letter.state === 'correct')
+        ) {
+          newKeyboardState[keyId] = letter.state;
+        }
+      }
+    });
+
+    // 게임 결과 판정
+    let gameStatus: GameState['gameStatus'] = 'playing';
+    const isCorrect = adapter.normalize(state.currentGuess) === state.targetWord;
+    if (isCorrect) {
+      gameStatus = 'won';
+    } else if (newGuesses.length >= state.maxGuesses) {
+      gameStatus = 'lost';
+    }
+
+    const newState: GameState = {
+      ...state,
+      guesses: newGuesses,
+      currentGuess: '',
+      gameStatus,
+      keyboardState: newKeyboardState,
+      errorMessage: undefined,
+    };
+
+    const nextEngine = new GameEngineImpl(newState, adapter);
+
+    if (isCorrect) {
+      return { engine: nextEngine, result: { type: 'correct' } };
+    }
+    if (gameStatus === 'lost') {
+      return { engine: nextEngine, result: { type: 'game_over' } };
+    }
+
+    const tileStates = newGuess.letters.map((l: Letter) => l.state);
+    return { engine: nextEngine, result: { type: 'wrong', tileStates } };
+  }
+}
+
+/**
+ * 어댑터를 한 번만 조회하여 GameEngine 인스턴스를 생성합니다.
+ */
+export function createGameEngine(deck: Deck, adapterId: ScriptId): GameEngine {
+  const adapter = getScriptAdapter(adapterId);
+  const wordList = getWordStrings(deck);
+  if (wordList.length === 0) throw new Error('이 덱에는 단어가 없습니다.');
+
+  const targetWord = selectRandomWord(wordList);
+  const state = initializeGame(targetWord, 6, wordList, adapter);
+  return new GameEngineImpl(state, adapter);
+}
+
+/**
+ * 기존 GameState로부터 GameEngine을 복원합니다 (테스트나 SSR 직렬화 복원 등에서 활용).
+ */
+export function createGameEngineFromState(state: GameState): GameEngine {
+  const adapter = getScriptAdapter(state.adapterId);
+  return new GameEngineImpl(state, adapter);
+}
+
+// wordleGame.ts는 파일 유지 — selectRandomWord, initializeGame, evaluateGuess 등 유틸 공유

--- a/lib/gameEngine.ts
+++ b/lib/gameEngine.ts
@@ -39,7 +39,7 @@ class GameEngineImpl implements GameEngine {
   private readonly _adapter: ReturnType<typeof getScriptAdapter>;
 
   constructor(state: GameState, adapter: ReturnType<typeof getScriptAdapter>) {
-    this.state = state;
+    this.state = structuredClone(state);
     this._adapter = adapter;
   }
 
@@ -73,6 +73,7 @@ class GameEngineImpl implements GameEngine {
     return new GameEngineImpl({
       ...state,
       currentGuess: units.slice(0, -1).join(''),
+      errorMessage: undefined,
     }, adapter);
   }
 

--- a/lib/gameEngine.ts
+++ b/lib/gameEngine.ts
@@ -20,6 +20,7 @@ export type { GameState, LetterState, Guess } from './wordleGame';
 export type TileState = LetterState;
 
 export type GuessResult =
+  | { type: 'incomplete' }
   | { type: 'invalid'; reason: string }
   | { type: 'correct' }
   | { type: 'wrong'; tileStates: TileState[] }
@@ -85,11 +86,11 @@ class GameEngineImpl implements GameEngine {
     const targetUnits = adapter.splitUnits(state.targetWord);
     const currentUnits = adapter.splitUnits(state.currentGuess);
 
-    // 줄 미충족 — invalid (이유 없이 동일 상태 반환)
+    // 줄 미충족 — 글자 수가 채워지지 않은 경우
     if (currentUnits.length !== targetUnits.length) {
       return {
         engine: this,
-        result: { type: 'invalid', reason: '' },
+        result: { type: 'incomplete' },
       };
     }
 
@@ -127,7 +128,7 @@ class GameEngineImpl implements GameEngine {
 
     // 게임 결과 판정
     let gameStatus: GameState['gameStatus'] = 'playing';
-    const isCorrect = adapter.normalize(state.currentGuess) === state.targetWord;
+    const isCorrect = adapter.normalize(state.currentGuess) === adapter.normalize(state.targetWord);
     if (isCorrect) {
       gameStatus = 'won';
     } else if (newGuesses.length >= state.maxGuesses) {
@@ -172,6 +173,10 @@ export function createGameEngine(deck: Deck, adapterId: ScriptId): GameEngine {
 
 /**
  * 기존 GameState로부터 GameEngine을 복원합니다 (테스트나 SSR 직렬화 복원 등에서 활용).
+ *
+ * 전제조건:
+ * - `state.targetWord`는 해당 스크립트 어댑터(state.adapterId)로 이미 정규화된 값이어야 합니다.
+ * - `state.validWords`가 존재하는 경우 각 항목도 동일한 어댑터로 정규화된 값이어야 합니다.
  */
 export function createGameEngineFromState(state: GameState): GameEngine {
   const adapter = getScriptAdapter(state.adapterId);

--- a/lib/wordleGame.ts
+++ b/lib/wordleGame.ts
@@ -131,7 +131,7 @@ export function submitGuess(gameState: GameState): GameState {
   };
 }
 
-function evaluateGuess(guessUnits: string[], targetUnits: string[]): Guess {
+export function evaluateGuess(guessUnits: string[], targetUnits: string[]): Guess {
   const result: Letter[] = [];
 
   // 첫 번째 패스: 정확한 위치의 글자 확인


### PR DESCRIPTION
## Summary

- `lib/gameEngine.ts` 신규 생성: 어댑터를 `createGameEngine()` 호출 시 한 번만 조회하는 불변 `GameEngineImpl` 클래스
- `submitGuess()` → `{ engine, result: GuessResult }` 판별 유니언 반환으로 변경
- `hooks/useGame.ts`: `engineRef`로 엔진 보유, 각 액션 후 새 인스턴스로 교체 (외부 인터페이스 불변)
- `lib/wordleGame.ts`: `evaluateGuess` export 추가 (gameEngine 공유 유틸)

## Test plan

- [ ] 게임 플레이 정상 동작 확인 (글자 입력 → 제출 → 결과 표시)
- [ ] 정답 맞췄을 때 승리 모달 표시 확인
- [ ] 최대 시도 초과 시 패배 모달 표시 확인
- [ ] 유효하지 않은 단어 제출 시 토스트 에러 표시 확인
- [ ] 한글/일본어 IME 입력 정상 동작 확인

Closes #79

https://claude.ai/code/session_01JEPYeSRkwRJ7LMtfX9yyxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEPYeSRkwRJ7LMtfX9yyxa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 순수 게임 엔진 모듈 추가로 게임 상태 복원 및 엔진 기반 진행 지원
  * 게임 평가 함수가 외부로 공개되어 재사용 가능성 향상

* **리팩토링**
  * 플레이 로직이 엔진 중심으로 재구성되어 안정성 및 유지보수성 향상
  * 전역 키 입력 처리 개선: 대문자 정규화, IME(조합 문자) 동작 보장, Enter/백스페이스 처리 일원화
  * 재시작 시 게임 상태와 UI 플래그가 올바르게 초기화됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanana3679/wordle-share/pull/84)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->