### PR TITLE
fix+refactor(like): LikeManager 도입 및 deleteLike 소유권 버그 수정 (#81)

### DIFF
--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -5,6 +5,8 @@ import { ActionResponse } from "@/types/action";
 import { safeAction } from "@/lib/safe-action";
 import { toggleLike as _toggleLike } from "@/lib/likeManager";
 
+const LIKE_ACTION_FAILURE_MESSAGE = "요청 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+
 export async function toggleLike(
   deckId: string
 ): Promise<ActionResponse<{ isLiked: boolean }>> {
@@ -13,7 +15,8 @@ export async function toggleLike(
     const { isLiked, error } = await _toggleLike(deckId, supabase);
 
     if (error) {
-      return { success: false, message: error };
+      console.error("[like] 오류", { deckId, error });
+      return { success: false, message: LIKE_ACTION_FAILURE_MESSAGE };
     }
 
     return {
@@ -43,7 +46,8 @@ export async function createLike(deckId: string): Promise<ActionResponse> {
       .upsert({ deck_id: deckId, user_id: user.id }, { onConflict: "deck_id,user_id" });
 
     if (error) {
-      return { success: false, message: `좋아요 추가에 실패했습니다: ${error.message}` };
+      console.error("[like] 오류", { deckId, error });
+      return { success: false, message: LIKE_ACTION_FAILURE_MESSAGE };
     }
 
     return { success: true, message: "좋아요를 추가했습니다." };
@@ -71,7 +75,8 @@ export async function deleteLike(deckId: string): Promise<ActionResponse> {
       .eq("user_id", user.id);
 
     if (error) {
-      return { success: false, message: `좋아요 삭제에 실패했습니다: ${error.message}` };
+      console.error("[like] 오류", { deckId, error });
+      return { success: false, message: LIKE_ACTION_FAILURE_MESSAGE };
     }
 
     return { success: true, message: "좋아요를 취소했습니다." };

--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -28,15 +28,22 @@ export async function toggleLike(
 export async function createLike(deckId: string): Promise<ActionResponse> {
   return safeAction(async () => {
     const supabase = await createClient();
-    const { isLiked, error } = await _toggleLike(deckId, supabase);
 
-    if (error) {
-      return { success: false, message: error };
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, message: "로그인이 필요합니다." };
     }
 
-    if (!isLiked) {
-      // 이미 좋아요한 상태였으므로 다시 추가하지 않음
-      return { success: true, message: "이미 좋아요한 덱입니다." };
+    // toggleLike 경유 X — 직접 upsert (좋아요 추가 전용)
+    const { error } = await supabase
+      .from("likes")
+      .upsert({ deck_id: deckId, user_id: user.id }, { onConflict: "deck_id,user_id" });
+
+    if (error) {
+      return { success: false, message: `좋아요 추가에 실패했습니다: ${error.message}` };
     }
 
     return { success: true, message: "좋아요를 추가했습니다." };

--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -3,60 +3,70 @@
 import { createClient } from "@/lib/supabase-server";
 import { ActionResponse } from "@/types/action";
 import { safeAction } from "@/lib/safe-action";
+import { toggleLike as _toggleLike } from "@/lib/likeManager";
 
-export async function createLike(deckId: string): Promise<ActionResponse> {
+export async function toggleLike(
+  deckId: string
+): Promise<ActionResponse<{ isLiked: boolean }>> {
   return safeAction(async () => {
     const supabase = await createClient();
+    const { isLiked, error } = await _toggleLike(deckId, supabase);
 
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return {
-        success: false,
-        message: "로그인이 필요합니다.",
-      };
-    }
-
-    const { data, error } = await supabase.from("likes").insert({ deck_id: deckId, user_id: user.id });
-    console.log("createLike", data, error);
-    
     if (error) {
-      return {
-        success: false,
-        message: `좋아요 추가에 실패했습니다: ${error.message}`,
-      };
+      return { success: false, message: error };
     }
-    
+
     return {
       success: true,
-      message: "좋아요를 추가했습니다.",
+      message: isLiked ? "좋아요를 추가했습니다." : "좋아요를 취소했습니다.",
+      data: { isLiked },
     };
   });
 }
 
+/** @deprecated toggleLike 사용 권장 */
+export async function createLike(deckId: string): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const supabase = await createClient();
+    const { isLiked, error } = await _toggleLike(deckId, supabase);
+
+    if (error) {
+      return { success: false, message: error };
+    }
+
+    if (!isLiked) {
+      // 이미 좋아요한 상태였으므로 다시 추가하지 않음
+      return { success: true, message: "이미 좋아요한 덱입니다." };
+    }
+
+    return { success: true, message: "좋아요를 추가했습니다." };
+  });
+}
+
+/** @deprecated toggleLike 사용 권장 */
 export async function deleteLike(deckId: string): Promise<ActionResponse> {
   return safeAction(async () => {
     const supabase = await createClient();
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
     if (!user) {
-      return {
-        success: false,
-        message: "로그인이 필요합니다.",
-      };
+      return { success: false, message: "로그인이 필요합니다." };
     }
-    const { data, error } = await supabase.from("likes").delete().eq("deck_id", deckId);
-    console.log("deleteLike", data, error);
-    
+
+    // user_id 필터를 반드시 적용해 소유권 보장
+    const { error } = await supabase
+      .from("likes")
+      .delete()
+      .eq("deck_id", deckId)
+      .eq("user_id", user.id);
+
     if (error) {
-      return {
-        success: false,
-        message: `좋아요 삭제에 실패했습니다: ${error.message}`,
-      };
+      return { success: false, message: `좋아요 삭제에 실패했습니다: ${error.message}` };
     }
-    
-    return {
-      success: true,
-      message: "좋아요를 취소했습니다.",
-    };
+
+    return { success: true, message: "좋아요를 취소했습니다." };
   });
 }

--- a/components/decks/DeckDialog.tsx
+++ b/components/decks/DeckDialog.tsx
@@ -484,8 +484,10 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
             return;
           }
 
+          const deckId = createResponse.data.id;
+
           const uploadResponse = await actionWithToast(
-            () => uploadDeckThumbnail(selectedFile, createResponse.data?.id as string),
+            () => uploadDeckThumbnail(selectedFile, deckId),
             { showOnlyError: true }
           );
           if (!uploadResponse.success || !uploadResponse.data) {
@@ -505,7 +507,7 @@ export function DeckDialog({ deck, children }: DeckDialogProps) {
           updateFormData.set("thumbnail_url", finalThumbnailUrl);
 
           const updateResponse = await actionWithToast(
-            () => updateDeck(createResponse.data?.id as string, updateFormData)
+            () => updateDeck(deckId, updateFormData)
           );
           if (!updateResponse.success) {
             toast.error(updateResponse.message || "덱 업데이트에 실패했습니다.");

--- a/hooks/useOptimisticLike.ts
+++ b/hooks/useOptimisticLike.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useOptimistic, useState, startTransition } from "react";
-import { createLike, deleteLike } from "@/app/actions/like";
+import { toggleLike } from "@/app/actions/like";
 import { actionWithToast } from "@/lib/action-with-toast";
 import { Deck } from "@/types/decks";
 
@@ -11,59 +11,43 @@ export function useOptimisticLike(deck: Deck) {
   const deckId = deck.id;
 
   const [isLikedState, setIsLikedState] = useState<boolean>(isLiked);
-  const [isLoading, setIsLoading] = useState<boolean>(false); 
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const [optimisticIsLiked, toggleOptimisticIsLiked] = useOptimistic(
+  const [optimisticIsLiked, applyOptimistic] = useOptimistic(
     isLikedState,
-    (currentState) => {
-      return !currentState;
-    }
+    (_current: boolean, next: boolean) => next
   );
 
-  const toggleLike = async () => {
-    // 서버에 요청할 최종 상태를 결정합니다.
-    const newIsLiked = !optimisticIsLiked;
+  const handleToggleLike = async () => {
+    const next = !optimisticIsLiked;
     setIsLoading(true);
-    
-    // 1. 낙관적 업데이트 (Transition으로 감싸 자동 롤백 활성화)
+
     startTransition(() => {
-      toggleOptimisticIsLiked(newIsLiked);
-      console.log("toggleOptimisticIsLiked", newIsLiked);
+      applyOptimistic(next);
     });
 
     try {
-      // 2. 서버에 요청 전송 (showToast: false로 자동 toast 비활성화)
-      let response;
-      if (newIsLiked) {
-        response = await actionWithToast(
-          () => createLike(deckId),
-          { showToast: false }
-        );
-        console.log("createLike", response);
-      } else {
-        response = await actionWithToast(
-          () => deleteLike(deckId),
-          { showToast: false }
-        );
-        console.log("deleteLike", response);
-      }
+      const response = await actionWithToast(
+        () => toggleLike(deckId),
+        { showToast: false }
+      );
 
       if (!response.success) {
         throw new Error(response.message);
       }
 
-      // 3. 서버 요청 성공: 실제 상태를 최종 확정
+      // 서버에서 반환된 실제 상태로 확정
+      const confirmedIsLiked = response.data?.isLiked ?? next;
       startTransition(() => {
-        setIsLikedState(newIsLiked);
+        setIsLikedState(confirmedIsLiked);
       });
-      setIsLoading(false);
     } catch (error) {
-      // 4. 서버 요청 실패: useOptimistic이 자동으로 낙관적 상태를 초기 상태(likeState)로 롤백
       console.error("좋아요 처리 실패:", error);
       await actionWithToast(async () => ({
         success: false,
         message: error instanceof Error ? error.message : "좋아요 처리에 실패했습니다.",
       }));
+    } finally {
       setIsLoading(false);
     }
   };
@@ -73,7 +57,7 @@ export function useOptimisticLike(deck: Deck) {
   return {
     optimisticIsLiked,
     optimisticLikeCounts,
-    toggleLike,
+    toggleLike: handleToggleLike,
     isLoading,
   };
 }

--- a/hooks/useOptimisticLike.ts
+++ b/hooks/useOptimisticLike.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useOptimistic, useState, useCallback, startTransition } from "react";
+import { unstable_rethrow } from "next/navigation";
 import { toggleLike } from "@/app/actions/like";
 import { actionWithToast } from "@/lib/action-with-toast";
 import { Deck } from "@/types/decks";
@@ -20,6 +21,7 @@ export function useOptimisticLike(deck: Deck) {
 
   const handleToggleLike = useCallback(async () => {
     if (isLoading) return; // 이미 요청 중이면 재요청 방지 (낙관적 상태와 서버 상태가 꼬이는 상황 방지)
+    const previousIsLiked = isLikedState; // 롤백을 위해 원본 값 캡처
     const next = !optimisticIsLiked;
     setIsLoading(true);
 
@@ -34,6 +36,9 @@ export function useOptimisticLike(deck: Deck) {
       );
 
       if (!response.success) {
+        startTransition(() => {
+          setIsLikedState(previousIsLiked);
+        });
         throw new Error(response.message);
       }
 
@@ -43,6 +48,10 @@ export function useOptimisticLike(deck: Deck) {
         setIsLikedState(confirmedIsLiked);
       });
     } catch (error) {
+      unstable_rethrow(error);
+      startTransition(() => {
+        setIsLikedState(previousIsLiked);
+      });
       console.error("좋아요 처리 실패:", error);
       await actionWithToast(async () => ({
         success: false,
@@ -51,7 +60,7 @@ export function useOptimisticLike(deck: Deck) {
     } finally {
       setIsLoading(false);
     }
-  }, [isLoading, optimisticIsLiked, deckId]);
+  }, [isLoading, isLikedState, optimisticIsLiked, deckId]);
 
   const optimisticLikeCounts = otherUsersLikeCount + (optimisticIsLiked ? 1 : 0);
 

--- a/hooks/useOptimisticLike.ts
+++ b/hooks/useOptimisticLike.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useOptimistic, useState, startTransition } from "react";
+import { useOptimistic, useState, useCallback, startTransition } from "react";
 import { toggleLike } from "@/app/actions/like";
 import { actionWithToast } from "@/lib/action-with-toast";
 import { Deck } from "@/types/decks";
@@ -18,7 +18,8 @@ export function useOptimisticLike(deck: Deck) {
     (_current: boolean, next: boolean) => next
   );
 
-  const handleToggleLike = async () => {
+  const handleToggleLike = useCallback(async () => {
+    if (isLoading) return; // 이미 요청 중이면 재요청 방지 (낙관적 상태와 서버 상태가 꼬이는 상황 방지)
     const next = !optimisticIsLiked;
     setIsLoading(true);
 
@@ -50,7 +51,7 @@ export function useOptimisticLike(deck: Deck) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [isLoading, optimisticIsLiked, deckId]);
 
   const optimisticLikeCounts = otherUsersLikeCount + (optimisticIsLiked ? 1 : 0);
 

--- a/lib/likeManager.ts
+++ b/lib/likeManager.ts
@@ -4,6 +4,11 @@ import { Database } from "@/types/database";
 /**
  * 좋아요 토글: 이미 좋아요한 경우 삭제, 아니면 upsert.
  * 소유권 필터(user_id)를 항상 적용하므로 타인의 좋아요를 건드리지 않습니다.
+ *
+ * @note Race condition 주의
+ * select 후 insert/delete 사이에 동시 요청이 들어오면 최종 상태가 의도와 다를 수 있습니다.
+ * - DB unique constraint가 중복 insert를 방어하지만, 동시 delete는 방어하지 못합니다.
+ * - 향후 DB RPC(stored procedure)로 atomic하게 처리하는 것을 고려할 수 있습니다.
  */
 export async function toggleLike(
   deckId: string,

--- a/lib/likeManager.ts
+++ b/lib/likeManager.ts
@@ -1,0 +1,55 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/database";
+
+/**
+ * 좋아요 토글: 이미 좋아요한 경우 삭제, 아니면 upsert.
+ * 소유권 필터(user_id)를 항상 적용하므로 타인의 좋아요를 건드리지 않습니다.
+ */
+export async function toggleLike(
+  deckId: string,
+  supabase: SupabaseClient<Database>
+): Promise<{ isLiked: boolean; error?: string }> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { isLiked: false, error: "로그인이 필요합니다." };
+  }
+
+  // 현재 좋아요 여부 확인
+  const { data: existing, error: selectError } = await supabase
+    .from("likes")
+    .select("deck_id")
+    .eq("deck_id", deckId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (selectError) {
+    return { isLiked: false, error: selectError.message };
+  }
+
+  if (existing) {
+    // 이미 좋아요 → 삭제 (user_id 필터 명시)
+    const { error: deleteError } = await supabase
+      .from("likes")
+      .delete()
+      .eq("deck_id", deckId)
+      .eq("user_id", user.id);
+
+    if (deleteError) {
+      return { isLiked: true, error: deleteError.message };
+    }
+    return { isLiked: false };
+  } else {
+    // 좋아요 없음 → upsert (중복 방지)
+    const { error: upsertError } = await supabase
+      .from("likes")
+      .upsert({ deck_id: deckId, user_id: user.id }, { onConflict: "deck_id,user_id" });
+
+    if (upsertError) {
+      return { isLiked: false, error: upsertError.message };
+    }
+    return { isLiked: true };
+  }
+}

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -1,9 +1,10 @@
+import { unstable_rethrow } from "next/navigation";
 import { ActionResponse } from "@/types/action";
 
 /**
  * 서버 액션을 안전하게 실행하는 헬퍼 함수
  * try-catch로 감싸서 에러를 자동으로 처리하고 ActionResponse 형식으로 반환합니다.
- * 
+ *
  * @template T - 성공 시 반환할 데이터의 타입
  * @param actionFn - 실행할 서버 액션 로직
  * @returns ActionResponse<T> 형식의 결과
@@ -13,36 +14,12 @@ export async function safeAction<T = void>(
   actionFn: () => Promise<ActionResponse<T>>
 ): Promise<ActionResponse<T>> {
   try {
-    // 실제 서버 액션 로직 실행
     return await actionFn();
-  } catch (error) {
-    // Next.js의 redirect()와 notFound()는 정상 동작이므로 다시 던짐
-    // digest가 NEXT_REDIRECT 또는 NEXT_NOT_FOUND로 시작하는 에러는 Next.js가 처리해야 함
-    if (
-      error &&
-      typeof error === "object" &&
-      "digest" in error &&
-      typeof error.digest === "string" &&
-      (error.digest.startsWith("NEXT_REDIRECT") || error.digest.startsWith("NEXT_NOT_FOUND"))
-    ) {
-      throw error;
-    }
-    
-    // 오류 포착 및 로깅
-    console.error("[Server Action Error]", error);
-    
-    // 일반 Error 처리
-    if (error instanceof Error) {
-      return {
-        success: false,
-        message: error.message,
-      };
-    }
-    
-    // 알 수 없는 오류
+  } catch (e) {
+    unstable_rethrow(e); // Next.js redirect/notFound 에러는 여기서 re-throw
     return {
       success: false,
-      message: "알 수 없는 서버 오류가 발생했습니다.",
+      message: e instanceof Error ? e.message : "알 수 없는 서버 오류가 발생했습니다.",
     };
   }
 }


### PR DESCRIPTION
## Summary

- **버그 수정**: `deleteLike()`에 `user_id` 필터 추가 — 기존에는 다른 사용자의 좋아요도 삭제 가능했음
- `lib/likeManager.ts` 신규 생성: `toggleLike(deckId, supabase)` — 존재 여부 확인 후 upsert/delete 처리, 소유권 보장
- `app/actions/like.ts`: 새 `toggleLike` 서버 액션 추가, 기존 `createLike`/`deleteLike` `@deprecated` 마킹
- `hooks/useOptimisticLike.ts`: 상태 변수 3개 → 2개로 축소, 단일 `toggleLike` 호출로 단순화

## Test plan

- [ ] 좋아요 버튼 클릭 시 즉시 낙관적 업데이트 확인
- [ ] 좋아요 취소 시 본인 좋아요만 삭제되는지 확인 (다른 사용자 데이터 영향 없음)
- [ ] 동일 덱 좋아요 중복 생성 불가 확인
- [ ] 서버 응답 실패 시 낙관적 업데이트 롤백 확인

Closes #81

https://claude.ai/code/session_01JEPYeSRkwRJ7LMtfX9yyxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEPYeSRkwRJ7LMtfX9yyxa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 좋아요 토글 작업이 하나로 통합되어 한 번의 동작으로 좋아요/취소를 처리합니다.
* **개선**
  * 낙관적 업데이트 흐름이 재작업되어 로딩 상태 관리와 최종 상태 동기화가 더 안정적입니다.
  * 서버 응답에 따라 정확한 좋아요 상태를 확인하고 사용자에게 명확한 성공/실패 메시지를 제공합니다.
* **버그 수정**
  * 좋아요 생성/삭제가 인증된 사용자 기준으로 안전하게 처리되어 권한·중복 문제를 해결했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanana3679/wordle-share/pull/86)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->