### PR TITLE
ci: PR 검증 워크플로 추가 — lint / typecheck / test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm-workspace.yaml이 packages 없이 ignoredBuiltDependencies만 쓰는
+      # pnpm 10 형식이라 pnpm 9에서는 "packages field missing" 에러가 난다
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fixes #91

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> CI 워크플로(lint/typecheck/test) 구성이 적절한가? (build 제외가 타당한가?)

## Scope

### 포함
- `.github/workflows/ci.yml` 신규 — PR 및 main push에서 `pnpm lint` / `pnpm typecheck` / `pnpm test` 실행
- pnpm 9 + node 22 + pnpm 캐시

### 제외
- `pnpm build` — Supabase 환경변수(`NEXT_PUBLIC_SUPABASE_URL` 등) 의존으로 secrets 설정 필요. 추후 별도 검토
- 기존 `supabase-deploy.yml` 변경 없음

## Scope Check

```
verdict: APPROVE
primary layer: infra (.github/workflows/ci.yml)
secondary layers: 없음
ADR count: 0
file count: 1
decision interlock: interlocked (단일 CI 파이프라인 도입)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- 로컬에서 3개 명령 모두 통과 확인 (lint: 에러 0/경고 4, typecheck OK, 테스트 50개 통과)

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동화된 CI/CD 파이프러스트 구성이 추가되었습니다. 이제 코드 푸시 및 풀 리퀘스트 시 린트, 타입 체크, 테스트가 자동으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->