### PR TITLE
fix(security): 썸네일 업로드/삭제에 덱 소유권 검증 추가

### DIFF
--- a/app/actions/storage.ts
+++ b/app/actions/storage.ts
@@ -3,18 +3,53 @@
 import { createClient } from "@/lib/supabase-server";
 import { ActionResponse } from "@/types/action";
 import { safeAction } from "@/lib/safe-action";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+// 익명 세션도 authenticated로 취급되므로, 인증 여부만으로는 부족하고
+// 해당 덱의 소유자인지 반드시 확인해야 한다.
+async function verifyDeckOwnership(
+  supabase: SupabaseClient<Database>,
+  deckId: string,
+  userId: string
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const { data: deck, error } = await supabase
+    .from("decks")
+    .select("creator_id")
+    .eq("id", deckId)
+    .single();
+
+  if (error || !deck) {
+    return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+
+  // 익명 덱(creator_id가 null)은 소유자를 확인할 수 없으므로 거부 (updateDeck과 동일 정책)
+  if (deck.creator_id !== userId) {
+    return { ok: false, message: "이 덱의 썸네일을 변경할 권한이 없습니다." };
+  }
+
+  return { ok: true };
+}
 
 export async function uploadDeckThumbnail(file: File, deckId: string): Promise<ActionResponse<string>> {
   return safeAction(async () => {
     const supabase = await createClient();
-    
+
     // 현재 사용자 정보 가져오기
     const { data: { user }, error: userError } = await supabase.auth.getUser();
-    
+
     if (userError || !user) {
       return {
         success: false,
         message: "로그인이 필요합니다.",
+      };
+    }
+
+    const ownership = await verifyDeckOwnership(supabase, deckId, user.id);
+    if (!ownership.ok) {
+      return {
+        success: false,
+        message: ownership.message,
       };
     }
 
@@ -61,7 +96,25 @@ export async function uploadDeckThumbnail(file: File, deckId: string): Promise<A
 export async function deleteDeckThumbnail(deckId: string): Promise<ActionResponse> {
   return safeAction(async () => {
     const supabase = await createClient();
-    
+
+    // 현재 사용자 정보 가져오기
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const ownership = await verifyDeckOwnership(supabase, deckId, user.id);
+    if (!ownership.ok) {
+      return {
+        success: false,
+        message: ownership.message,
+      };
+    }
+
     // 파일 삭제 (확장자가 다를 수 있으므로 패턴 매칭으로 삭제)
     const { data: files, error: listError } = await supabase.storage
       .from('deck-thumbnails')


### PR DESCRIPTION
Fixes #90

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> 익명 세션이 authenticated로 취급되는 환경에서 덱 소유권 검증(`creator_id === user.id`, 익명 덱 거부)이 올바른 정책인가?

## Scope

### 포함
- `app/actions/storage.ts`
  - `verifyDeckOwnership` 헬퍼 추가 (`decks.creator_id === user.id` 확인)
  - `uploadDeckThumbnail`: 소유권 검증 추가 — 기존엔 인증만 확인해 deckId만 알면 타인 덱 썸네일 덮어쓰기 가능(`upsert: true`)
  - `deleteDeckThumbnail`: **인증 확인 + 소유권 검증 추가** — 기존엔 인증 확인조차 없었음
  - 익명 덱(creator_id null)은 소유자 확인 수단이 없으므로 거부 (`updateDeck`과 동일 정책)

### 제외
- Storage RLS 정책 강화 — T0(#43)에서 `deck-thumbnails` 버킷 자체가 드랍 예정이라 server action 레벨 방어로 한정
- 익명 덱 비밀번호 기반 소유권 확인 — T1b(#69) identity lib에서 다룸

## Scope Check

```
verdict: APPROVE
primary layer: identity
secondary layers: (없음)
ADR count: 0
file count: 1
decision interlock: interlocked (upload/delete 모두 동일한 소유권 검증 정책 — 분리 시 한쪽에 권한 우회 취약점 잔존)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- `pnpm typecheck` / `pnpm lint` 통과

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_