### PR TITLE
fix: deleteLike에 user_id 필터 추가 — 본인 좋아요만 삭제

### DIFF
--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -16,9 +16,9 @@ export async function createLike(deckId: string): Promise<ActionResponse> {
       };
     }
 
-    const { data, error } = await supabase.from("likes").insert({ deck_id: deckId, user_id: user.id });
-    console.log("createLike", data, error);
-    
+    const { error } = await supabase.from("likes").insert({ deck_id: deckId, user_id: user.id });
+
+
     if (error) {
       return {
         success: false,
@@ -44,9 +44,13 @@ export async function deleteLike(deckId: string): Promise<ActionResponse> {
         message: "로그인이 필요합니다.",
       };
     }
-    const { data, error } = await supabase.from("likes").delete().eq("deck_id", deckId);
-    console.log("deleteLike", data, error);
-    
+    const { error } = await supabase
+      .from("likes")
+      .delete()
+      .eq("deck_id", deckId)
+      .eq("user_id", user.id);
+
+
     if (error) {
       return {
         success: false,


### PR DESCRIPTION
Fixes #81

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> deleteLike에 user_id 조건이 추가되어 타인의 like 삭제가 차단되는가?

## Scope

### 포함
- `app/actions/like.ts`
  - `deleteLike`: `.eq("user_id", user.id)` 추가 — deck_id만으로 삭제하던 #81 버그 수정. RLS가 막고 있었지만 정책 변경 시 바로 사고로 이어지는 구조였음
  - 같은 줄의 디버그 `console.log` 2건 제거 (#9의 like.ts 범위 — 별도 PR로 빼면 같은 줄 머지 충돌 발생)

### 제외
- **#81의 LikeManager 모듈 도입(리팩토링 부분)** — A안에 따라 T0(#43)에서 `likes` 테이블이 드랍되므로 반영하지 않음
- `createLike`의 중복 좋아요 확인 — 동일 사유로 미반영 (DB unique 제약 + RLS가 방어)

## Scope Check

```
verdict: APPROVE
primary layer: discovery (app/actions/like.ts — like/engagement)
secondary layers: mechanical (console.log 제거)
ADR count: 0
file count: 1
decision interlock: interlocked (단일 함수의 bug fix + 동반 debug log 정리)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- `pnpm typecheck` / `pnpm lint` 통과

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_