### PR TITLE
feat(schema): [T1a] 신규 decks/words 테이블 마이그레이션

### DIFF
--- a/supabase/migrations/20260612000002_t1_decks_words.sql
+++ b/supabase/migrations/20260612000002_t1_decks_words.sql
@@ -1,0 +1,52 @@
+-- [T1a] 신규 도메인 스키마: decks + words (#68)
+-- T0(#43)에서 구 테이블이 drop된 greenfield 상태 위에 생성한다.
+-- ADR 0001: anon_id(auth.uid) + 단일 nick/pw — creator_id·creator_nick·creator_pw_hash 모두 필수
+-- ADR 0010: word 영구 ID + active soft-delete + UNIQUE(deck_id, text)
+-- ADR 0014: text는 NFC 정규화된 canonical form으로 저장 (정규화는 app 레벨)
+
+-- 1. decks
+CREATE TABLE IF NOT EXISTS public.decks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL CHECK (char_length(name) BETWEEN 1 AND 100),
+  script text NOT NULL DEFAULT 'latin' CHECK (script IN ('latin', 'hangul', 'kana')),
+  -- anon_id. auth.users FK를 걸지 않는다: 익명 유저가 정리(GC)되어도
+  -- 덱은 nick/pw 자격증명으로 영구 접근 가능해야 한다 (ADR 0001)
+  creator_id uuid NOT NULL,
+  -- nick에 '#' 불허 — 표시 형식 {nick}#{anon_id 앞 4hex}와 충돌 방지 (ADR 0001)
+  creator_nick text NOT NULL
+    CHECK (char_length(creator_nick) BETWEEN 1 AND 20 AND creator_nick NOT LIKE '%#%'),
+  -- bcrypt 해시 형식 강제 (평문 저장 사고 방지)
+  creator_pw_hash text NOT NULL
+    CHECK (creator_pw_hash ~ '^\$2[aby]\$\d{2}\$.{53}$'),
+  like_count integer NOT NULL DEFAULT 0 CHECK (like_count >= 0),
+  hidden boolean NOT NULL DEFAULT false,
+  report_count integer NOT NULL DEFAULT 0 CHECK (report_count >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. words (영구 ID + soft-delete, ADR 0010)
+CREATE TABLE IF NOT EXISTS public.words (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  deck_id uuid NOT NULL REFERENCES public.decks(id) ON DELETE CASCADE,
+  text text NOT NULL CHECK (char_length(text) BETWEEN 1 AND 50),
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- 같은 덱 안에서 동일 text는 단일 row 영구 보유 (재추가 = active toggle)
+  CONSTRAINT words_deck_id_text_unique UNIQUE (deck_id, text)
+);
+
+-- 활성 단어 집합 조회용 (WHERE deck_id = ? AND active = true)
+CREATE INDEX IF NOT EXISTS words_deck_id_active_idx
+  ON public.words (deck_id) WHERE active;
+
+-- 3. RLS — SELECT 전체 공개 (hidden 필터는 app 레벨, 이슈 #68 명세).
+--    쓰기 정책 없음: 모든 mutation은 server action에서 service_role로 수행한다.
+ALTER TABLE public.decks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.words ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "decks_select_all" ON public.decks;
+CREATE POLICY "decks_select_all" ON public.decks FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "words_select_all" ON public.words;
+CREATE POLICY "words_select_all" ON public.words FOR SELECT USING (true);

--- a/types/database.ts
+++ b/types/database.ts
@@ -16,71 +16,71 @@ export type Database = {
     Tables: {
       decks: {
         Row: {
-          author_handle: string | null
-          author_password_hash: string | null
-          categories: string[]
           created_at: string
-          creator_id: string | null
-          description: string | null
+          creator_id: string
+          creator_nick: string
+          creator_pw_hash: string
+          hidden: boolean
           id: string
-          is_public: boolean | null
-          name: string | null
+          like_count: number
+          name: string
+          report_count: number
           script: string
-          thumbnail_url: string | null
-          updated_at: string | null
-          words: { word: string; tags: string[] }[]
+          updated_at: string
         }
         Insert: {
-          author_handle?: string | null
-          author_password_hash?: string | null
-          categories?: string[]
           created_at?: string
-          creator_id?: string | null
-          description?: string | null
+          creator_id: string
+          creator_nick: string
+          creator_pw_hash: string
+          hidden?: boolean
           id?: string
-          is_public?: boolean | null
-          name?: string | null
+          like_count?: number
+          name: string
+          report_count?: number
           script?: string
-          thumbnail_url?: string | null
-          updated_at?: string | null
-          words?: { word: string; tags: string[] }[]
+          updated_at?: string
         }
         Update: {
-          author_handle?: string | null
-          author_password_hash?: string | null
-          categories?: string[]
           created_at?: string
-          creator_id?: string | null
-          description?: string | null
+          creator_id?: string
+          creator_nick?: string
+          creator_pw_hash?: string
+          hidden?: boolean
           id?: string
-          is_public?: boolean | null
-          name?: string | null
+          like_count?: number
+          name?: string
+          report_count?: number
           script?: string
-          thumbnail_url?: string | null
-          updated_at?: string | null
-          words?: { word: string; tags: string[] }[]
+          updated_at?: string
         }
         Relationships: []
       }
-      likes: {
+      words: {
         Row: {
+          active: boolean
           created_at: string
           deck_id: string
-          user_id: string
+          id: string
+          text: string
         }
         Insert: {
+          active?: boolean
           created_at?: string
           deck_id: string
-          user_id: string
+          id?: string
+          text: string
         }
         Update: {
+          active?: boolean
           created_at?: string
           deck_id?: string
-          user_id?: string
+          id?: string
+          text?: string
         }
         Relationships: [
           {
-            foreignKeyName: "likes_deck_id_fkey"
+            foreignKeyName: "words_deck_id_fkey"
             columns: ["deck_id"]
             isOneToOne: false
             referencedRelation: "decks"


### PR DESCRIPTION
Fixes #68

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> decks/words 스키마가 ADR 0001(creator 자격증명)·0010(word 영구 ID + soft-delete)·0014(NFC canonical text) 결정을 올바르게 반영하는가?

## Scope

### 포함
- `supabase/migrations/20260612000002_t1_decks_words.sql` (신규)
  - **decks**: `creator_id`(anon_id, **auth.users FK 없음** — 익명 유저 GC 후에도 nick/pw로 덱 접근 보장) + `creator_nick`(`#` 불허 CHECK) + `creator_pw_hash`(bcrypt 형식 CHECK) 모두 필수, `script` CHECK(latin/hangul/kana), `like_count`/`hidden`/`report_count`
  - **words**: 영구 ID + `active` soft-delete + `UNIQUE(deck_id, text)` (재추가 = active toggle, ADR 0010), 활성 단어 partial index
  - RLS: SELECT 전체 공개만 (hidden 필터는 app 레벨, 이슈 명세). 쓰기 정책 없음 — mutation은 server action의 service_role
- `types/database.ts` — 신규 스키마로 갱신. **live DB가 일시정지 상태라 `supabase gen types` 불가 → 수기 작성**. DB 복구 후 재생성으로 검증 권장

### 제외
- 이슈 본문의 `ALTER TABLE` 스케치는 구 테이블 전제 — T0(#98)에서 drop됐으므로 `CREATE TABLE`로 구현
- `count(active) >= 1` invariant — ADR 0010대로 DB CHECK 없이 server action 레벨 enforce (T1c #70)
- like_count 갱신 트리거 — likes 테이블과 함께 T5(#48)
- 피드 정렬 인덱스 — T6a(#75)
- **배포**: Supabase 프로젝트 일시정지(무료 티어 한도)로 `db push` 보류 중. 멱등 작성이라 복구 후 일괄 적용 가능

## Scope Check

```
verdict: APPROVE
primary layer: infra (DB schema migration)
secondary layers: mechanical (types/database.ts — 스키마 파생 타입 수기 갱신)
ADR count: 0 (기존 ADR 0001/0010/0014 참조만)
file count: 2
decision interlock: interlocked (types는 migration의 파생물)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- `pnpm typecheck` / `pnpm lint` / `pnpm build` 통과 (이슈 AC: schema 변경에 의한 타입 오류 없음)
- 마이그레이션 적용 AC는 DB 복구 후 확인 예정

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_