### PR TITLE
feat(identity): [T1b] nick/pw identity lib + word canonical form 검증

### DIFF
--- a/lib/identity.test.ts
+++ b/lib/identity.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashPassword,
+  verifyPassword,
+  validateNick,
+  validatePasswordLength,
+  formatDisplayNick,
+  NICK_MAX_LENGTH,
+} from './identity';
+
+describe('hashPassword / verifyPassword', () => {
+  it('bcrypt 형식 해시를 생성한다 (DB CHECK 제약과 일치)', async () => {
+    const hash = await hashPassword('test-pw-1234');
+    expect(hash).toMatch(/^\$2[aby]\$\d{2}\$.{53}$/);
+  });
+
+  it('올바른 비밀번호는 검증을 통과한다', async () => {
+    const hash = await hashPassword('correct-pw');
+    await expect(verifyPassword('correct-pw', hash)).resolves.toBe(true);
+  });
+
+  it('틀린 비밀번호는 검증에 실패한다', async () => {
+    const hash = await hashPassword('correct-pw');
+    await expect(verifyPassword('wrong-pw', hash)).resolves.toBe(false);
+  });
+
+  it('같은 비밀번호도 매번 다른 해시가 나온다 (salt)', async () => {
+    const [a, b] = await Promise.all([hashPassword('same-pw'), hashPassword('same-pw')]);
+    expect(a).not.toBe(b);
+    await expect(verifyPassword('same-pw', a)).resolves.toBe(true);
+    await expect(verifyPassword('same-pw', b)).resolves.toBe(true);
+  });
+
+  it('유니코드 비밀번호 round-trip', async () => {
+    const hash = await hashPassword('한글비밀번호123');
+    await expect(verifyPassword('한글비밀번호123', hash)).resolves.toBe(true);
+  });
+});
+
+describe('validateNick', () => {
+  it('한글/로마자 닉을 허용한다', () => {
+    expect(validateNick('철수')).toBe(true);
+    expect(validateNick('pikachu-fan')).toBe(true);
+  });
+
+  it("'#'이 포함된 닉을 거부한다 (표시 형식과 충돌)", () => {
+    expect(validateNick('철수#a3f9')).toBe(false);
+    expect(validateNick('#')).toBe(false);
+  });
+
+  it('빈 닉과 길이 초과 닉을 거부한다', () => {
+    expect(validateNick('')).toBe(false);
+    expect(validateNick('a'.repeat(NICK_MAX_LENGTH + 1))).toBe(false);
+    expect(validateNick('a'.repeat(NICK_MAX_LENGTH))).toBe(true);
+  });
+});
+
+describe('validatePasswordLength', () => {
+  it('4~64자 범위를 강제한다', () => {
+    expect(validatePasswordLength('123')).toBe(false);
+    expect(validatePasswordLength('1234')).toBe(true);
+    expect(validatePasswordLength('a'.repeat(64))).toBe(true);
+    expect(validatePasswordLength('a'.repeat(65))).toBe(false);
+  });
+});
+
+describe('formatDisplayNick', () => {
+  it('{nick}#{anon_id 앞 4 hex} 형식으로 만든다', () => {
+    expect(formatDisplayNick('철수', 'a3f9c2d1-0000-4000-8000-000000000000')).toBe('철수#a3f9');
+  });
+
+  it('uuid 대시를 무시하고 hex만 사용하며 소문자로 통일한다', () => {
+    expect(formatDisplayNick('kim', 'AB-CDEF1234')).toBe('kim#abcd');
+  });
+});

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -1,0 +1,38 @@
+import bcrypt from "bcryptjs";
+
+// ADR 0001: 중앙 identity table 없이 자원(deck/comment) row마다 bcrypt 해시를 저장하는
+// 단일 (nick, pw) convention. 해시/검증은 반드시 서버에서만 수행한다.
+
+const BCRYPT_ROUNDS = 10;
+
+export const NICK_MIN_LENGTH = 1;
+export const NICK_MAX_LENGTH = 20;
+export const PASSWORD_MIN_LENGTH = 4;
+export const PASSWORD_MAX_LENGTH = 64;
+
+export async function hashPassword(pw: string): Promise<string> {
+  return bcrypt.hash(pw, BCRYPT_ROUNDS);
+}
+
+export async function verifyPassword(pw: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(pw, hash);
+}
+
+// nick에 '#' 불허 — 표시 형식 {nick}#{suffix}와 충돌 방지 (ADR 0001)
+export function validateNick(nick: string): boolean {
+  return (
+    nick.length >= NICK_MIN_LENGTH &&
+    nick.length <= NICK_MAX_LENGTH &&
+    !nick.includes("#")
+  );
+}
+
+export function validatePasswordLength(pw: string): boolean {
+  return pw.length >= PASSWORD_MIN_LENGTH && pw.length <= PASSWORD_MAX_LENGTH;
+}
+
+// 표시용 disambiguation: {nick}#{anon_id 앞 4 hex} (예: 철수#a3f9)
+// nick은 전역 유일이 아니므로 UI에서만 구분자로 쓴다 (ADR 0001)
+export function formatDisplayNick(nick: string, anonId: string): string {
+  return `${nick}#${anonId.replaceAll("-", "").slice(0, 4).toLowerCase()}`;
+}

--- a/lib/word-validation.test.ts
+++ b/lib/word-validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeWord, validateAllowedChars } from './word-validation';
+
+describe('normalizeWord', () => {
+  it('NFC로 정규화한다 (NFD 입력 → 동일 canonical form)', () => {
+    const nfd = '가'.normalize('NFD'); // ᄀ + ᅡ (분해형)
+    expect(nfd).not.toBe('가');
+    expect(normalizeWord(nfd)).toBe('가');
+
+    const eAcuteNfd = 'pokémon'.normalize('NFD');
+    expect(normalizeWord(eAcuteNfd)).toBe('pokémon'.normalize('NFC'));
+  });
+
+  it('roman은 lowercase로 정규화한다 (LoL → lol)', () => {
+    expect(normalizeWord('LoL')).toBe('lol');
+    expect(normalizeWord('X-Men')).toBe('x-men');
+  });
+
+  it('결정적이다 (idempotent)', () => {
+    for (const input of ['가'.normalize('NFD'), 'LoL', 'ぽけもん', "L'Arc"]) {
+      const once = normalizeWord(input);
+      expect(normalizeWord(once)).toBe(once);
+    }
+  });
+});
+
+describe('validateAllowedChars — latin', () => {
+  it('a-z + 공통 추가 문자(0-9, -, \', .)를 허용한다', () => {
+    expect(validateAllowedChars('x-men', 'latin')).toBe(true);
+    expect(validateAllowedChars("l'arc", 'latin')).toBe(true);
+    expect(validateAllowedChars('mr.', 'latin')).toBe(true);
+    expect(validateAllowedChars('ff14', 'latin')).toBe(true);
+  });
+
+  it('공백·기호·다른 script를 거부한다', () => {
+    expect(validateAllowedChars('at&t', 'latin')).toBe(false);
+    expect(validateAllowedChars('star wars', 'latin')).toBe(false);
+    expect(validateAllowedChars('피카츄', 'latin')).toBe(false);
+  });
+
+  it('canonical form이 아닌 대문자를 거부한다 (normalizeWord 선행 전제)', () => {
+    expect(validateAllowedChars('LoL', 'latin')).toBe(false);
+    expect(validateAllowedChars(normalizeWord('LoL'), 'latin')).toBe(true);
+  });
+
+  it('빈 문자열을 거부한다', () => {
+    expect(validateAllowedChars('', 'latin')).toBe(false);
+  });
+});
+
+describe('validateAllowedChars — hangul', () => {
+  it('완성형 한글 + 공통 추가 문자를 허용한다', () => {
+    expect(validateAllowedChars('피카츄', 'hangul')).toBe(true);
+    expect(validateAllowedChars('1세대', 'hangul')).toBe(true);
+  });
+
+  it('자모 단독·공백·latin을 거부한다', () => {
+    expect(validateAllowedChars('ㅍㅋㅊ', 'hangul')).toBe(false); // 완성형만 허용
+    expect(validateAllowedChars('고무고무 열매', 'hangul')).toBe(false);
+    expect(validateAllowedChars('lol', 'hangul')).toBe(false);
+  });
+});
+
+describe('validateAllowedChars — kana', () => {
+  it('히라가나 + 공통 추가 문자를 허용한다', () => {
+    expect(validateAllowedChars('ぽけもん', 'kana')).toBe(true);
+    expect(validateAllowedChars('ff14'.replace(/[a-z]/g, ''), 'kana')).toBe(true); // '14'
+  });
+
+  it('가타카나를 거부한다 (canonical은 히라가나)', () => {
+    expect(validateAllowedChars('ポケモン', 'kana')).toBe(false);
+  });
+
+  it('장음 기호(ー)는 ADR 0014 allowlist에 없어 거부한다', () => {
+    // らーめん 같은 단어는 현재 불가 — 필요해지면 allowlist 한 줄 확장으로 해결
+    expect(validateAllowedChars('らーめん', 'kana')).toBe(false);
+  });
+});
+
+describe('validateAllowedChars — 미지원 script', () => {
+  it('adapter가 없는 script는 항상 거부한다', () => {
+    expect(validateAllowedChars('абв', 'cyrillic')).toBe(false);
+  });
+});

--- a/lib/word-validation.ts
+++ b/lib/word-validation.ts
@@ -1,0 +1,29 @@
+import type { ScriptId } from "@/lib/scripts/types";
+
+// ADR 0014: Word 허용 문자 집합 + canonical form
+// - 저장 텍스트는 normalizeWord를 거친 canonical form (NFC + lowercase)
+// - script 알파벳: latin a-z / hangul 가-힣(완성형) / kana ぁ-ゖゝゞ(히라가나)
+// - 공통 추가 허용: 0-9, -, ', .
+// - 그 외(공백, 기호, 다른 script, control char)는 reject — 자동 변환하지 않는다
+// 향후 문자 추가는 allowlist 한 줄 확장. 축소는 기존 Word 무효화라 어려움.
+
+const SCRIPT_PATTERNS: Partial<Record<ScriptId, RegExp>> = {
+  latin: /^[a-z0-9\-'.]+$/,
+  hangul: /^[가-힣0-9\-'.]+$/,
+  kana: /^[ぁ-ゖゝゞ0-9\-'.]+$/,
+};
+
+// NFC 정규화 + lowercase. 결정적(idempotent)이어야 dedupe/추측 매칭이 안정된다.
+// lowercase는 latin 외 script에는 no-op이므로 script 무관하게 적용한다.
+export function normalizeWord(text: string): string {
+  return text.normalize("NFC").toLowerCase();
+}
+
+// canonical form(normalizeWord 결과)에 대한 허용 문자 검증.
+// 정규화 전 텍스트(대문자, NFD 등)는 그대로 넣으면 reject될 수 있다 —
+// 호출자는 normalizeWord를 먼저 적용해야 한다.
+export function validateAllowedChars(text: string, scriptId: ScriptId): boolean {
+  const pattern = SCRIPT_PATTERNS[scriptId];
+  if (!pattern) return false;
+  return pattern.test(text);
+}


### PR DESCRIPTION
Fixes #69

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Justification

pr-scope-checker가 SUGGEST_SPLIT(identity vs word-validation 독립 구현)을 제안했으나, **이슈 #69가 #44 [T1]의 scope 분할 결과물로서 두 lib을 한 묶음으로 사전 선언**했고(선언 scope = actual diff 정확히 일치), 4개 파일 226줄 전부 신규 헬퍼 + 테스트라 단일 PR로 진행 — 사용자 확인 완료.

## Main Review Question

> 두 helper lib이 ADR 0001(nick+pw convention)과 ADR 0014(script별 allowlist + NFC canonical form)를 충실히 구현하는가?

## Scope

### 포함 (전부 신규, +226줄)
- `lib/identity.ts` — ADR 0001
  - `hashPassword`/`verifyPassword` (bcrypt rounds 10, T1a의 DB 해시 형식 CHECK와 일치)
  - `validateNick` (`#` 불허 — `{nick}#{suffix}` 표시 형식과 충돌 방지, 1~20자)
  - `validatePasswordLength` (4~64자), `formatDisplayNick` (`{nick}#{anon_id 앞 4hex}`)
- `lib/word-validation.ts` — ADR 0014
  - `normalizeWord`: NFC + lowercase, 결정적(idempotent)
  - `validateAllowedChars`: script 알파벳(a-z / 가-힣 완성형 / ぁ-ゖゝゞ) + 공통 `0-9` `-` `'` `.` allowlist, 그 외 reject
- 테스트 24개: bcrypt round-trip·salt, NFC 결정성, script별 엣지케이스 (가타카나 거부, 자모 거부, 대문자 거부 등)

### 제외
- server action 연결 (nick/pw 인증 플로우) — T1c #70
- 기존 `lib/scripts/` 어댑터와의 통합 — 어댑터는 게임 입력 단계, 본 lib은 저장 canonical form 검증으로 역할이 다름

### 리뷰 참고 (B급 관찰)
- 장음 기호 `ー`(らーめん 등)는 ADR 0014 allowlist에 없어 거부됨 — 테스트로 명시 고정. 필요해지면 allowlist 한 줄 확장 (ADR이 확장은 쉽고 축소는 어렵다고 명시)

## Scope Check

```
verdict: SUGGEST_SPLIT → 사용자 확인 후 단일 PR 진행 (Justification 참조)
primary layer: identity (lib/identity.ts + test)
secondary layers: game-state 인접 (lib/word-validation.ts + test)
ADR count: 0 (ADR 0001/0014 구현)
file count: 4 (전부 신규)
decision interlock: independent (이슈 #69 사전 선언 bundle로 묶음)
split suggestion: PR A(identity) / PR B(word-validation) — 미채택
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #69 AC)

- [x] `hashPassword`/`verifyPassword` 구현 + Vitest 통과
- [x] NFC 정규화 + 결정성(idempotent) 테스트 통과
- [x] 허용 문자 검증 + 스크립트별 테스트
- [x] `pnpm test` 99개 전체 통과 / typecheck / lint 클린

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 비밀번호 보안 처리 기능 추가 (해싱 및 검증)
  * 닉네임 유효성 검증 및 표시 형식 지정 추가
  * 다국어 단어 정규화 및 문자 검증 기능 추가 (라틴, 한글, 일본어 지원)

* **Tests**
  * 비밀번호 및 닉네임 처리 기능 테스트 추가
  * 다국어 단어 검증 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->