### PR TITLE
feat(deck): [T1c] Deck CRUD vertical — 생성/조회/편집 + server actions

### DIFF
--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -1,0 +1,258 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase-admin";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import {
+  hashPassword,
+  verifyPassword,
+  validateNick,
+  validatePasswordLength,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_MAX_LENGTH,
+  NICK_MAX_LENGTH,
+} from "@/lib/identity";
+import { parseWordLines, planWordUpdate, type DeckWordRow } from "@/lib/deckWords";
+import { isSupportedScript } from "@/lib/scripts";
+import type { Tables } from "@/types/database";
+
+// creator_pw_hash 노출 방지용 화이트리스트
+const DECK_PUBLIC_COLUMNS =
+  "id, name, script, creator_id, creator_nick, like_count, hidden, report_count, created_at, updated_at";
+
+export type PublicDeck = Omit<Tables<"decks">, "creator_pw_hash">;
+export type DeckWord = Tables<"words">;
+
+export interface DeckWithWords {
+  deck: PublicDeck;
+  words: DeckWord[];
+}
+
+// 익명 세션이 없으면 lazy 발급한다.
+// ADR 0001은 미들웨어 자동 발급을 제시하지만, 모든 방문(봇 포함)마다
+// 익명 유저가 쌓이는 것을 피해 "첫 쓰기 시점" 발급으로 운영한다.
+async function getOrCreateAnonUserId(): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (user) return user.id;
+
+  const { data, error } = await supabase.auth.signInAnonymously();
+  if (error || !data.user) return null;
+  return data.user.id;
+}
+
+type CredentialCheck =
+  | { ok: true }
+  | { ok: false; message: string };
+
+async function verifyCredentials(
+  deckId: string,
+  nick: string,
+  password: string,
+): Promise<CredentialCheck> {
+  const admin = createAdminClient();
+  const { data: deck, error } = await admin
+    .from("decks")
+    .select("creator_nick, creator_pw_hash")
+    .eq("id", deckId)
+    .single();
+
+  if (error || !deck) {
+    return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+
+  // enumeration 방어: 닉/비밀번호 중 무엇이 틀렸는지 구분해 알려주지 않는다 (ADR 0001)
+  const nickMatches = deck.creator_nick === nick;
+  const pwMatches = await verifyPassword(password, deck.creator_pw_hash);
+  if (!nickMatches || !pwMatches) {
+    return { ok: false, message: "닉네임 또는 비밀번호가 올바르지 않습니다." };
+  }
+  return { ok: true };
+}
+
+export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
+  return safeAction(async () => {
+    const name = String(formData.get("name") ?? "").trim();
+    const script = String(formData.get("script") ?? "latin");
+    const nick = String(formData.get("nick") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+    const wordsText = String(formData.get("words_text") ?? "");
+
+    const fieldErrors: { [key: string]: string[] } = {};
+    if (!name || name.length > 100) fieldErrors.name = ["덱 이름은 1~100자여야 합니다."];
+    if (!isSupportedScript(script)) fieldErrors.script = ["지원하지 않는 쓰기체계입니다."];
+    if (!validateNick(nick)) {
+      fieldErrors.nick = [`닉네임은 1~${NICK_MAX_LENGTH}자, '#' 없이 입력해야 합니다.`];
+    }
+    if (!validatePasswordLength(password)) {
+      fieldErrors.password = [`비밀번호는 ${PASSWORD_MIN_LENGTH}~${PASSWORD_MAX_LENGTH}자여야 합니다.`];
+    }
+
+    const wordsValidation = isSupportedScript(script)
+      ? parseWordLines(wordsText, script)
+      : null;
+    if (wordsValidation && !wordsValidation.ok) {
+      fieldErrors.words = [wordsValidation.message];
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      return { success: false, message: "입력값을 확인해주세요.", fieldErrors };
+    }
+
+    const creatorId = await getOrCreateAnonUserId();
+    if (!creatorId) {
+      return { success: false, message: "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요." };
+    }
+
+    const pwHash = await hashPassword(password);
+    const admin = createAdminClient();
+
+    const { data: deck, error: deckError } = await admin
+      .from("decks")
+      .insert({
+        name,
+        script,
+        creator_id: creatorId,
+        creator_nick: nick,
+        creator_pw_hash: pwHash,
+      })
+      .select("id")
+      .single();
+
+    if (deckError || !deck) {
+      return { success: false, message: `덱 생성에 실패했습니다: ${deckError?.message}` };
+    }
+
+    const words = (wordsValidation as { ok: true; words: string[] }).words;
+    const { error: wordsError } = await admin
+      .from("words")
+      .insert(words.map((text) => ({ deck_id: deck.id, text })));
+
+    if (wordsError) {
+      // 단어 없는 덱은 invariant 위반 — 덱을 남기지 않는다
+      await admin.from("decks").delete().eq("id", deck.id);
+      return { success: false, message: `단어 저장에 실패했습니다: ${wordsError.message}` };
+    }
+
+    revalidatePath(`/d/${deck.id}`);
+    return { success: true, data: { id: deck.id }, message: "덱을 만들었습니다." };
+  });
+}
+
+export async function getDeckById(deckId: string): Promise<ActionResponse<DeckWithWords>> {
+  return safeAction(async () => {
+    const supabase = await createClient();
+
+    const { data: deck, error: deckError } = await supabase
+      .from("decks")
+      .select(DECK_PUBLIC_COLUMNS)
+      .eq("id", deckId)
+      .single();
+
+    if (deckError || !deck) {
+      return { success: false, message: "덱을 찾을 수 없습니다." };
+    }
+
+    const { data: words, error: wordsError } = await supabase
+      .from("words")
+      .select("*")
+      .eq("deck_id", deckId)
+      .order("created_at", { ascending: true });
+
+    if (wordsError) {
+      return { success: false, message: `단어 목록을 가져오는데 실패했습니다: ${wordsError.message}` };
+    }
+
+    return {
+      success: true,
+      data: { deck, words: words ?? [] },
+      message: "덱을 가져왔습니다.",
+    };
+  });
+}
+
+export async function verifyDeckCredentials(
+  deckId: string,
+  nick: string,
+  password: string,
+): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const check = await verifyCredentials(deckId, nick, password);
+    if (!check.ok) return { success: false, message: check.message };
+    return { success: true, message: "확인되었습니다." };
+  });
+}
+
+export async function updateDeckWords(input: {
+  deckId: string;
+  nick: string;
+  password: string;
+  addWordsText: string;
+  deactivateIds: string[];
+}): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const { deckId, nick, password, addWordsText, deactivateIds } = input;
+
+    const check = await verifyCredentials(deckId, nick, password);
+    if (!check.ok) return { success: false, message: check.message };
+
+    const admin = createAdminClient();
+    const { data: deckRow, error: deckError } = await admin
+      .from("decks")
+      .select("script")
+      .eq("id", deckId)
+      .single();
+    if (deckError || !deckRow || !isSupportedScript(deckRow.script)) {
+      return { success: false, message: "덱을 찾을 수 없습니다." };
+    }
+
+    const parsed = parseWordLines(addWordsText, deckRow.script, { requireMin: false });
+    if (!parsed.ok) {
+      return { success: false, message: parsed.message, fieldErrors: { words: [parsed.message] } };
+    }
+
+    const { data: existing, error: wordsError } = await admin
+      .from("words")
+      .select("id, text, active")
+      .eq("deck_id", deckId);
+    if (wordsError || !existing) {
+      return { success: false, message: "단어 목록을 가져오는데 실패했습니다." };
+    }
+
+    const planResult = planWordUpdate(existing as DeckWordRow[], parsed.words, deactivateIds);
+    if (!planResult.ok) return { success: false, message: planResult.message };
+
+    const { toInsert, toReactivateIds, toDeactivateIds } = planResult.plan;
+
+    if (toInsert.length > 0) {
+      const { error } = await admin
+        .from("words")
+        .insert(toInsert.map((text) => ({ deck_id: deckId, text })));
+      if (error) return { success: false, message: `단어 추가에 실패했습니다: ${error.message}` };
+    }
+    if (toReactivateIds.length > 0) {
+      const { error } = await admin
+        .from("words")
+        .update({ active: true })
+        .in("id", toReactivateIds);
+      if (error) return { success: false, message: `단어 재활성화에 실패했습니다: ${error.message}` };
+    }
+    if (toDeactivateIds.length > 0) {
+      const { error } = await admin
+        .from("words")
+        .update({ active: false })
+        .in("id", toDeactivateIds);
+      if (error) return { success: false, message: `단어 비활성화에 실패했습니다: ${error.message}` };
+    }
+
+    await admin
+      .from("decks")
+      .update({ updated_at: new Date().toISOString() })
+      .eq("id", deckId);
+
+    revalidatePath(`/d/${deckId}`);
+    return { success: true, message: "덱을 수정했습니다." };
+  });
+}

--- a/app/d/[id]/edit/page.tsx
+++ b/app/d/[id]/edit/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import { getDeckById } from "@/app/actions/deck";
+import { DeckEditForm } from "@/components/DeckEditForm";
+
+interface DeckEditPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function DeckEditPage({ params }: DeckEditPageProps) {
+  const { id } = await params;
+  const result = await getDeckById(id);
+  if (!result.success || !result.data) notFound();
+
+  const { deck, words } = result.data;
+
+  return (
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">{deck.name} 편집</h1>
+      <DeckEditForm deckId={deck.id} words={words} />
+    </main>
+  );
+}

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getDeckById } from "@/app/actions/deck";
+import { DeckMetaCard } from "@/components/DeckMetaCard";
+import { Button } from "@/components/ui/button";
+
+interface DeckPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function DeckPage({ params }: DeckPageProps) {
+  const { id } = await params;
+  const result = await getDeckById(id);
+  if (!result.success || !result.data) notFound();
+
+  const { deck, words } = result.data;
+  const activeWordCount = words.filter((w) => w.active).length;
+
+  return (
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <DeckMetaCard deck={deck} activeWordCount={activeWordCount} />
+      <div className="flex gap-2">
+        <Button asChild variant="outline">
+          <Link href={`/d/${deck.id}/edit`}>편집</Link>
+        </Button>
+        {/* 플레이(데일리 모드)는 T2b에서 추가된다 */}
+      </div>
+    </main>
+  );
+}

--- a/app/d/new/page.tsx
+++ b/app/d/new/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { DeckForm } from "@/components/DeckForm";
+
+export const metadata: Metadata = {
+  title: "새 덱 만들기 | wordledecks",
+};
+
+export default function NewDeckPage() {
+  return (
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">새 덱 만들기</h1>
+      <DeckForm />
+    </main>
+  );
+}

--- a/components/DeckEditForm.tsx
+++ b/components/DeckEditForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { actionWithToast } from "@/lib/action-with-toast";
+import { verifyDeckCredentials, updateDeckWords, type DeckWord } from "@/app/actions/deck";
+import { loadCachedCredentials, saveCachedCredentials } from "@/lib/credentialCache";
+import { cn } from "@/lib/utils";
+
+interface DeckEditFormProps {
+  deckId: string;
+  words: DeckWord[];
+}
+
+export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
+  const router = useRouter();
+  const [nick, setNick] = useState("");
+  const [password, setPassword] = useState("");
+  const [unlocked, setUnlocked] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // 저장 전까지 보류되는 비활성화/재활성화 토글 (id 집합)
+  const [toggledIds, setToggledIds] = useState<Set<string>>(new Set());
+  const [addWordsText, setAddWordsText] = useState("");
+
+  useEffect(() => {
+    const cached = loadCachedCredentials();
+    if (cached) {
+      setNick(cached.nick);
+      setPassword(cached.password);
+    }
+  }, []);
+
+  const willBeActive = (word: DeckWord) =>
+    toggledIds.has(word.id) ? !word.active : word.active;
+
+  const activeAfterToggle = words.filter(willBeActive).length;
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setVerifying(true);
+    try {
+      const result = await actionWithToast(
+        () => verifyDeckCredentials(deckId, nick.trim(), password),
+        { showOnlyError: true },
+      );
+      if (result.success) {
+        saveCachedCredentials({ nick: nick.trim(), password });
+        setUnlocked(true);
+      }
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // 재활성화 토글은 add(text 재추가)로, 비활성화 토글은 deactivateIds로 전달
+      const reactivateTexts = words
+        .filter((w) => toggledIds.has(w.id) && !w.active)
+        .map((w) => w.text);
+      const deactivateIds = words
+        .filter((w) => toggledIds.has(w.id) && w.active)
+        .map((w) => w.id);
+
+      const result = await actionWithToast(() =>
+        updateDeckWords({
+          deckId,
+          nick: nick.trim(),
+          password,
+          addWordsText: [addWordsText, ...reactivateTexts].join("\n"),
+          deactivateIds,
+        }),
+      );
+      if (result.success) {
+        setToggledIds(new Set());
+        setAddWordsText("");
+        router.refresh();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!unlocked) {
+    return (
+      <form onSubmit={handleVerify} className="max-w-sm space-y-4">
+        <p className="text-sm text-muted-foreground">
+          덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요.
+        </p>
+        <div className="space-y-2">
+          <Label htmlFor="edit-nick">닉네임</Label>
+          <Input id="edit-nick" value={nick} onChange={(e) => setNick(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="edit-password">비밀번호</Label>
+          <Input
+            id="edit-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" disabled={verifying}>
+          {verifying ? "확인 중..." : "확인"}
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <h2 className="text-sm font-medium">단어 ({words.length}개)</h2>
+        <ul className="space-y-1">
+          {words.map((word) => {
+            const active = willBeActive(word);
+            return (
+              <li key={word.id} className="flex items-center gap-2">
+                <span className={cn("flex-1 text-sm", !active && "text-muted-foreground line-through")}>
+                  {word.text}
+                </span>
+                {toggledIds.has(word.id) && <Badge variant="outline">변경됨</Badge>}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setToggledIds((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(word.id)) next.delete(word.id);
+                      else next.add(word.id);
+                      return next;
+                    })
+                  }
+                >
+                  {active ? "비활성화" : "재활성화"}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+        {activeAfterToggle < 1 && (
+          <p className="text-sm text-destructive">활성 단어가 최소 1개 필요합니다.</p>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <Label htmlFor="edit-add-words">단어 추가 (줄당 1개)</Label>
+        <Textarea
+          id="edit-add-words"
+          value={addWordsText}
+          onChange={(e) => setAddWordsText(e.target.value)}
+          rows={4}
+        />
+      </section>
+
+      <Button onClick={handleSave} disabled={saving || activeAfterToggle < 1}>
+        {saving ? "저장 중..." : "저장"}
+      </Button>
+    </div>
+  );
+}

--- a/components/DeckForm.tsx
+++ b/components/DeckForm.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { actionWithToast } from "@/lib/action-with-toast";
+import { createDeck } from "@/app/actions/deck";
+import { parseWordLines } from "@/lib/deckWords";
+import { SUPPORTED_SCRIPTS } from "@/lib/scripts";
+import type { ScriptId } from "@/lib/scripts/types";
+import { DeckSimulator } from "@/components/DeckSimulator";
+import {
+  loadCachedCredentials,
+  saveCachedCredentials,
+  appendMyDeck,
+} from "@/lib/credentialCache";
+
+const SCRIPT_LABELS: Record<string, string> = {
+  latin: "로마자 (a-z)",
+  hangul: "한글",
+  kana: "가나 (히라가나)",
+};
+
+export function DeckForm() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [script, setScript] = useState<ScriptId>("latin");
+  const [nick, setNick] = useState("");
+  const [password, setPassword] = useState("");
+  const [wordsText, setWordsText] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSimulator, setShowSimulator] = useState(false);
+
+  // ADR 0001: localStorage의 (nick, pw) 캐시로 폼 자동 채움
+  useEffect(() => {
+    const cached = loadCachedCredentials();
+    if (cached) {
+      setNick(cached.nick);
+      setPassword(cached.password);
+    }
+  }, []);
+
+  const wordsValidation = useMemo(
+    () => parseWordLines(wordsText, script, { requireMin: false }),
+    [wordsText, script],
+  );
+  const validWords = wordsValidation.ok ? wordsValidation.words : [];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.set("name", name);
+      formData.set("script", script);
+      formData.set("nick", nick);
+      formData.set("password", password);
+      formData.set("words_text", wordsText);
+
+      const result = await actionWithToast(() => createDeck(formData));
+      if (result.success && result.data) {
+        saveCachedCredentials({ nick, password });
+        appendMyDeck({ id: result.data.id, name });
+        router.push(`/d/${result.data.id}`);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="deck-name">덱 이름</Label>
+        <Input
+          id="deck-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={100}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>쓰기체계</Label>
+        <Select value={script} onValueChange={(v) => setScript(v as ScriptId)}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SUPPORTED_SCRIPTS.map((id) => (
+              <SelectItem key={id} value={id}>
+                {SCRIPT_LABELS[id] ?? id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="deck-nick">닉네임</Label>
+          <Input
+            id="deck-nick"
+            value={nick}
+            onChange={(e) => setNick(e.target.value)}
+            maxLength={20}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="deck-password">비밀번호 (덱 전용 PIN)</Label>
+          <Input
+            id="deck-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={4}
+            maxLength={64}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="deck-words">단어 목록 (줄당 1개)</Label>
+        <Textarea
+          id="deck-words"
+          value={wordsText}
+          onChange={(e) => setWordsText(e.target.value)}
+          rows={10}
+          placeholder={"pikachu\ncharmander\n..."}
+          required
+        />
+        {!wordsValidation.ok && (
+          <p className="text-sm text-destructive">{wordsValidation.message}</p>
+        )}
+        {wordsValidation.ok && (
+          <p className="text-sm text-muted-foreground">유효 단어 {validWords.length}개</p>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={isSubmitting || validWords.length === 0}>
+          {isSubmitting ? "만드는 중..." : "덱 만들기"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={validWords.length === 0}
+          onClick={() => setShowSimulator((v) => !v)}
+        >
+          시뮬레이션
+        </Button>
+      </div>
+
+      {showSimulator && validWords.length > 0 && (
+        <DeckSimulator words={validWords} script={script} />
+      )}
+    </form>
+  );
+}

--- a/components/DeckMetaCard.tsx
+++ b/components/DeckMetaCard.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatDisplayNick } from "@/lib/identity";
+import type { PublicDeck } from "@/app/actions/deck";
+
+const SCRIPT_LABELS: Record<string, string> = {
+  latin: "로마자",
+  hangul: "한글",
+  kana: "가나",
+};
+
+interface DeckMetaCardProps {
+  deck: PublicDeck;
+  activeWordCount: number;
+}
+
+export function DeckMetaCard({ deck, activeWordCount }: DeckMetaCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {deck.name}
+          <Badge variant="secondary">{SCRIPT_LABELS[deck.script] ?? deck.script}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 text-sm text-muted-foreground">
+        <p>단어 {activeWordCount}개</p>
+        <p>제작자 {formatDisplayNick(deck.creator_nick, deck.creator_id)}</p>
+        <p>만든 날 {new Date(deck.created_at).toLocaleDateString("ko-KR")}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/DeckSimulator.tsx
+++ b/components/DeckSimulator.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  initializeGame,
+  submitGuess,
+  selectRandomWord,
+  isGameComplete,
+  type GameState,
+  type LetterState,
+} from "@/lib/wordleGame";
+import { getScriptAdapter } from "@/lib/scripts";
+import type { ScriptId } from "@/lib/scripts/types";
+import { normalizeWord } from "@/lib/word-validation";
+import { cn } from "@/lib/utils";
+
+// 덱 제작자가 저장 전에 1라운드를 미리 플레이해보는 간이 시뮬레이터.
+// 정식 게임 보드/키보드는 T2b에서 별도 구현된다.
+
+const TILE_STYLES: Record<LetterState, string> = {
+  correct: "bg-green-500 text-white border-green-500",
+  present: "bg-yellow-500 text-white border-yellow-500",
+  absent: "bg-gray-400 text-white border-gray-400",
+  empty: "bg-transparent",
+};
+
+interface DeckSimulatorProps {
+  words: string[];
+  script: ScriptId;
+}
+
+export function DeckSimulator({ words, script }: DeckSimulatorProps) {
+  const adapter = useMemo(() => getScriptAdapter(script), [script]);
+  const [game, setGame] = useState<GameState>(() =>
+    initializeGame(selectRandomWord(words), 6, undefined, adapter),
+  );
+  const [guess, setGuess] = useState("");
+  const [lengthError, setLengthError] = useState<string | null>(null);
+
+  const targetLength = adapter.splitUnits(game.targetWord).length;
+
+  const restart = () => {
+    setGame(initializeGame(selectRandomWord(words), 6, undefined, adapter));
+    setGuess("");
+    setLengthError(null);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const normalized = normalizeWord(guess.trim());
+    const guessLength = adapter.splitUnits(normalized).length;
+    if (guessLength !== targetLength) {
+      setLengthError(`글자 수가 맞지 않습니다 (${guessLength}/${targetLength}).`);
+      return;
+    }
+    setLengthError(null);
+    setGame((prev) => submitGuess({ ...prev, currentGuess: normalized }));
+    setGuess("");
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <p className="text-sm text-muted-foreground">
+        시뮬레이션 — {targetLength}글자 단어, {game.maxGuesses}번의 기회
+      </p>
+
+      <div className="space-y-1">
+        {game.guesses.map((row, i) => (
+          <div key={i} className="flex gap-1">
+            {row.letters.map((letter, j) => (
+              <span
+                key={j}
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded border text-sm font-bold",
+                  TILE_STYLES[letter.state],
+                )}
+              >
+                {letter.char}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {game.gameStatus === "playing" ? (
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <Input
+            value={guess}
+            onChange={(e) => setGuess(e.target.value)}
+            placeholder="추측 단어 입력"
+            aria-label="추측 단어"
+          />
+          <Button type="submit" variant="secondary">
+            제출
+          </Button>
+        </form>
+      ) : (
+        <p className="text-sm font-medium">
+          {game.gameStatus === "won" ? "정답!" : `실패 — 정답은 "${game.targetWord}"`}
+        </p>
+      )}
+
+      {lengthError && <p className="text-sm text-destructive">{lengthError}</p>}
+
+      {isGameComplete(game) && (
+        <Button type="button" variant="outline" size="sm" onClick={restart}>
+          다른 단어로 다시
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/lib/credentialCache.ts
+++ b/lib/credentialCache.ts
@@ -1,0 +1,61 @@
+// ADR 0001: raw (nick, pw) + my_decks를 localStorage에 캐시해 폼 자동 채움.
+// 마찰 최소화 우선 — XSS 방어는 T11(#56) 보안 베이스라인 트랙에서 다룬다.
+
+const CREDENTIALS_KEY = "wordledecks.credentials";
+const MY_DECKS_KEY = "wordledecks.my_decks";
+
+export interface CachedCredentials {
+  nick: string;
+  password: string;
+}
+
+export interface MyDeckEntry {
+  id: string;
+  name: string;
+}
+
+export function loadCachedCredentials(): CachedCredentials | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CREDENTIALS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.nick === "string" && typeof parsed?.password === "string") {
+      return { nick: parsed.nick, password: parsed.password };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedCredentials(credentials: CachedCredentials): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(credentials));
+  } catch {
+    // 저장 실패는 무시 (private mode 등)
+  }
+}
+
+export function loadMyDecks(): MyDeckEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(MY_DECKS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function appendMyDeck(entry: MyDeckEntry): void {
+  if (typeof window === "undefined") return;
+  try {
+    const decks = loadMyDecks().filter((d) => d.id !== entry.id);
+    decks.unshift(entry);
+    window.localStorage.setItem(MY_DECKS_KEY, JSON.stringify(decks));
+  } catch {
+    // 저장 실패는 무시
+  }
+}

--- a/lib/deckWords.test.ts
+++ b/lib/deckWords.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { parseWordLines, planWordUpdate, type DeckWordRow } from './deckWords';
+
+function row(id: string, text: string, active: boolean): DeckWordRow {
+  return { id, text, active };
+}
+
+describe('parseWordLines', () => {
+  it('정규화(NFC+lowercase) 후 dedupe한다', () => {
+    const result = parseWordLines('LoL\nlol\npikachu', 'latin');
+    expect(result).toEqual({ ok: true, words: ['lol', 'pikachu'] });
+  });
+
+  it('빈 줄과 공백 줄은 무시한다', () => {
+    const result = parseWordLines('\n  \npikachu\n', 'latin');
+    expect(result).toEqual({ ok: true, words: ['pikachu'] });
+  });
+
+  it('허용 문자 외 단어는 원본 줄을 들어 거부한다', () => {
+    const result = parseWordLines('pikachu\nstar wars', 'latin');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.invalidLines).toEqual(['star wars']);
+  });
+
+  it('유효 단어 0개면 "최소 1개 단어 필요" 에러 (AC)', () => {
+    const result = parseWordLines('', 'latin');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('최소 1개');
+  });
+
+  it('requireMin: false면 0개를 허용한다 (편집 시 추가 없음 케이스)', () => {
+    expect(parseWordLines('', 'latin', { requireMin: false })).toEqual({ ok: true, words: [] });
+  });
+});
+
+describe('planWordUpdate — reactivate via toggle (ADR 0010)', () => {
+  it('비활성 row와 같은 text 추가는 insert가 아니라 reactivate다', () => {
+    const existing = [row('w1', '피카츄', false), row('w2', '이상해씨', true)];
+    const result = planWordUpdate(existing, ['피카츄'], []);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: ['w1'], toDeactivateIds: [] },
+    });
+  });
+
+  it('이미 active인 text 추가는 no-op이다', () => {
+    const existing = [row('w1', '피카츄', true)];
+    const result = planWordUpdate(existing, ['피카츄'], []);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: [], toDeactivateIds: [] },
+    });
+  });
+
+  it('새 text는 insert된다', () => {
+    const existing = [row('w1', '피카츄', true)];
+    const result = planWordUpdate(existing, ['파이리'], []);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: ['파이리'], toReactivateIds: [], toDeactivateIds: [] },
+    });
+  });
+
+  it('같은 row가 추가·비활성화에 동시에 걸리면 추가가 이긴다', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', true)];
+    const result = planWordUpdate(existing, ['피카츄'], ['w1']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: ['w1'], toDeactivateIds: [] },
+    });
+  });
+});
+
+describe('planWordUpdate — min 1 active invariant (ADR 0010)', () => {
+  it('마지막 active 단어 비활성화는 reject된다 (AC)', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', false)];
+    const result = planWordUpdate(existing, [], ['w1']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('마지막 활성 단어');
+  });
+
+  it('비활성화와 동시에 새 단어를 추가하면 통과한다', () => {
+    const existing = [row('w1', '피카츄', true)];
+    const result = planWordUpdate(existing, ['파이리'], ['w1']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: ['파이리'], toReactivateIds: [], toDeactivateIds: ['w1'] },
+    });
+  });
+
+  it('active가 2개 이상 남으면 비활성화 가능하다', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', true)];
+    const result = planWordUpdate(existing, [], ['w2']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: [], toDeactivateIds: ['w2'] },
+    });
+  });
+
+  it('존재하지 않거나 이미 비활성인 id의 비활성화 요청은 무시한다', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', false)];
+    const result = planWordUpdate(existing, [], ['w2', 'unknown']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: [], toDeactivateIds: [] },
+    });
+  });
+});

--- a/lib/deckWords.ts
+++ b/lib/deckWords.ts
@@ -1,0 +1,114 @@
+import type { ScriptId } from "./scripts/types";
+import { normalizeWord, validateAllowedChars } from "./word-validation";
+
+// 덱 단어 도메인 규칙 (ADR 0010):
+// - word row는 영구 ID. 같은 text 재추가는 기존 row의 active toggle
+// - count(active) >= 1 invariant는 DB CHECK 없이 이 레벨에서 enforce
+// 순수 함수로 분리해 DB 없이 단위 테스트한다.
+
+export interface DeckWordRow {
+  id: string;
+  text: string;
+  active: boolean;
+}
+
+export interface WordUpdatePlan {
+  toInsert: string[];
+  toReactivateIds: string[];
+  toDeactivateIds: string[];
+}
+
+export type WordsValidation =
+  | { ok: true; words: string[] }
+  | { ok: false; message: string; invalidLines: string[] };
+
+export type PlanResult =
+  | { ok: true; plan: WordUpdatePlan }
+  | { ok: false; message: string };
+
+export const MIN_ACTIVE_WORDS = 1;
+
+// 줄 단위 입력을 canonical form으로 정규화·검증·dedupe한다.
+// requireMin이 true면 유효 단어 0개를 에러로 처리한다 (덱 생성 경로).
+export function parseWordLines(
+  raw: string,
+  scriptId: ScriptId,
+  { requireMin = true }: { requireMin?: boolean } = {},
+): WordsValidation {
+  const invalidLines: string[] = [];
+  const seen = new Set<string>();
+  const words: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const normalized = normalizeWord(trimmed);
+    if (!validateAllowedChars(normalized, scriptId)) {
+      invalidLines.push(trimmed);
+      continue;
+    }
+    if (seen.has(normalized)) continue; // 정규화 후 중복은 조용히 dedupe
+    seen.add(normalized);
+    words.push(normalized);
+  }
+
+  if (invalidLines.length > 0) {
+    return {
+      ok: false,
+      message: `허용되지 않는 문자가 포함된 단어가 있습니다: ${invalidLines.join(", ")}`,
+      invalidLines,
+    };
+  }
+  if (requireMin && words.length < MIN_ACTIVE_WORDS) {
+    return { ok: false, message: "최소 1개 단어 필요", invalidLines: [] };
+  }
+  return { ok: true, words };
+}
+
+// 단어 추가/비활성화 요청을 insert/reactivate/deactivate 계획으로 변환한다.
+// addTexts는 canonical form 전제. 같은 row가 추가·비활성화에 동시에 걸리면 추가가 이긴다.
+export function planWordUpdate(
+  existing: DeckWordRow[],
+  addTexts: string[],
+  deactivateIds: string[],
+): PlanResult {
+  const byText = new Map(existing.map((w) => [w.text, w]));
+  const byId = new Map(existing.map((w) => [w.id, w]));
+
+  const toInsert: string[] = [];
+  const reactivate = new Set<string>();
+
+  for (const text of new Set(addTexts)) {
+    const row = byText.get(text);
+    if (!row) {
+      toInsert.push(text);
+    } else if (!row.active || deactivateIds.includes(row.id)) {
+      reactivate.add(row.id); // 재추가 = active toggle (영구 ID 유지)
+    }
+    // 이미 active이고 비활성화 대상도 아니면 no-op
+  }
+
+  const toDeactivateIds = deactivateIds.filter((id) => {
+    const row = byId.get(id);
+    return row !== undefined && row.active && !reactivate.has(id);
+  });
+
+  const activeAfter =
+    existing.filter((w) => w.active).length -
+    toDeactivateIds.length +
+    reactivate.size -
+    [...reactivate].filter((id) => byId.get(id)?.active).length +
+    toInsert.length;
+
+  if (activeAfter < MIN_ACTIVE_WORDS) {
+    return {
+      ok: false,
+      message: "마지막 활성 단어는 비활성화할 수 없습니다. 활성 단어가 최소 1개 필요합니다.",
+    };
+  }
+
+  return {
+    ok: true,
+    plan: { toInsert, toReactivateIds: [...reactivate], toDeactivateIds },
+  };
+}

--- a/lib/word-validation.ts
+++ b/lib/word-validation.ts
@@ -1,4 +1,4 @@
-import type { ScriptId } from "@/lib/scripts/types";
+import type { ScriptId } from "./scripts/types";
 
 // ADR 0014: Word 허용 문자 집합 + canonical form
 // - 저장 텍스트는 normalizeWord를 거친 canonical form (NFC + lowercase)


### PR DESCRIPTION
Fixes #70

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> Deck CRUD vertical(routes + DeckForm/시뮬레이션 + server actions)이 #70 AC를 충족하는가?

## Scope

### 포함 (12 files)
- **Server actions** `app/actions/deck.ts`
  - `createDeck` — nick+pw+단어 리스트, **단어 ≥ 1 강제** (AC). 쓰기는 service_role(admin client), 단어 insert 실패 시 덱 롤백
  - `getDeckById` — `creator_pw_hash` 제외 화이트리스트 SELECT
  - `verifyDeckCredentials` — nick/pw 중 무엇이 틀렸는지 구분하지 않는 통합 에러 (ADR 0001 enumeration 방어)
  - `updateDeckWords` — 단어 add/deactivate, **마지막 active 제거 reject** (AC)
  - 익명 세션: **첫 쓰기 시점 lazy 발급** — ADR 0001의 "미들웨어 자동 발급"에서 의도적 일탈 (봇 방문마다 익명 유저 적체 방지, T0가 미들웨어를 세션 refresh+locale로 고정한 것과도 정합). 리뷰 포인트
- **도메인 순수 함수** `lib/deckWords.ts` (+test 13개) — 선언 scope 대비 추가된 파일이지만 AC "Vitest: min 1 active invariant, reactivate via toggle"의 충족 수단
  - `parseWordLines`: 정규화(NFC+lowercase)→allowlist 검증→dedupe→최소 1개
  - `planWordUpdate`: 같은 text 재추가 = 기존 row reactivate (ADR 0010), min-1-active invariant
- **`lib/credentialCache.ts`** — ADR 0001의 localStorage (nick,pw)+my_decks 캐시 구현. **raw pw 저장에 대한 보안 논의는 #56 [T11]로 명시 위임된 닫힌 결정** — 관련 리뷰 피드백은 Triage C
- **Components**: `DeckForm`(실시간 단어 검증+시뮬레이션 버튼), `DeckSimulator`(1라운드 미리 플레이 — lib/wordleGame 재사용, 정식 게임 보드는 T2b), `DeckMetaCard`(`{nick}#{4hex}` 표시), `DeckEditForm`(nick/pw 게이트 → 토글·추가 배치 저장)
- **Routes**: `/d/new`, `/d/[id]`, `/d/[id]/edit`
- `lib/word-validation.ts` — import alias→상대경로 1줄 (mechanical; vitest alias 미설정 환경에서 런타임 해석 실패 예방)

### 제외
- 플레이(데일리 모드) 라우트 — T2b #72
- 덱 이름/script 수정 — 이슈 scope 외 (script는 단어와 결합되어 잠금)
- 피드/검색 — T6 #75/#76

## Scope Check

```
verdict: APPROVE
primary layer: game-state
secondary layers: identity (credentialCache), test (deckWords.test), mechanical (word-validation 1줄)
ADR count: 0
file count: 12 (선언 ~8 → 12: deckWords 분리=AC Vitest 수단, Simulator/EditForm 컴포넌트 분리, credentialCache=ADR 0001 구현)
decision interlock: interlocked (새 decision 0, 전부 기존 ADR/이슈 AC의 구현)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #70 AC)

- [x] 단어 0개 생성 시도 → reject "최소 1개 단어 필요" (parseWordLines + 테스트)
- [x] 마지막 active 단어 비활성화 → reject (planWordUpdate + 테스트, 클라이언트도 이중 가드)
- [x] 허용 문자 외 입력 폼 reject (실시간 검증 + 서버 재검증)
- [x] `/d/{id}` 메타 표시: 이름·script·단어 수·제작자 `nick#suffix`
- [x] 시뮬레이션 버튼: 1라운드 미리 플레이
- [x] Vitest: min 1 active invariant ✓, reactivate via toggle ✓ (13개 신규, 총 112개 통과)
- [x] `pnpm build` / `pnpm test` / typecheck / lint 통과
- [ ] 실제 생성/편집 E2E — **Supabase 프로젝트 일시정지로 라이브 검증 불가**, DB 복구 후 확인 필요 (T1a 마이그레이션도 미적용 상태)

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_