### PR TITLE
feat(schema): [T2a] daily_words / daily_rounds 테이블 마이그레이션

### DIFF
--- a/supabase/migrations/20260612000003_t2_daily_mode.sql
+++ b/supabase/migrations/20260612000003_t2_daily_mode.sql
@@ -1,0 +1,47 @@
+-- [T2a] Daily mode 스키마: daily_words / daily_rounds (#71)
+-- ADR 0015: DailyWord에 active_word_ids 스냅샷 (Word.id ASC 정렬), 라운드는 date만 캡처
+-- ADR 0009: daily_rounds.version — 모든 액션에 expected_version 동봉하는 낙관적 락
+-- 이슈 스케치의 bigint id는 T1a(uuid PK) 스키마에 맞춰 uuid로 적응
+
+-- 1. daily_words — (deck, date)별 단어 lock. 첫 풀이자가 생성 (ON CONFLICT DO NOTHING)
+CREATE TABLE IF NOT EXISTS public.daily_words (
+  deck_id uuid NOT NULL REFERENCES public.decks(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  -- 시드(hash(deck+date) % cardinality)로 active_word_ids에서 선택된 단어.
+  -- 배열 원소는 Postgres FK가 검증하지 못하므로 word_id도 FK 없이 둔다 —
+  -- 생성은 server action만 가능하고 words는 soft-delete라 dangling이 없다 (ADR 0015)
+  word_id uuid NOT NULL,
+  -- lock 생성 시점의 active word ID 스냅샷. Word.id ASC 정렬 강제 (셔플/시드 결정성)
+  active_word_ids uuid[] NOT NULL CHECK (cardinality(active_word_ids) >= 1),
+  locked_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (deck_id, date)
+);
+
+-- 2. daily_rounds — (anon_id, deck, date)별 진행 상태
+CREATE TABLE IF NOT EXISTS public.daily_rounds (
+  anon_id uuid NOT NULL,
+  deck_id uuid NOT NULL REFERENCES public.decks(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  -- in_progress | completed(솔브) | failed(시도 소진/포기)
+  status text NOT NULL DEFAULT 'in_progress'
+    CHECK (status IN ('in_progress', 'completed', 'failed')),
+  -- [{ guess, result[], at }] — 본인 추측 기록
+  attempts jsonb NOT NULL DEFAULT '[]',
+  version integer NOT NULL DEFAULT 0 CHECK (version >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (anon_id, deck_id, date)
+);
+
+-- 3. RLS — 쓰기는 server action의 service_role만.
+ALTER TABLE public.daily_words ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.daily_rounds ENABLE ROW LEVEL SECURITY;
+
+-- daily_words는 id만 담고 있어 공개해도 단어 텍스트가 새지 않는다
+DROP POLICY IF EXISTS "daily_words_select_all" ON public.daily_words;
+CREATE POLICY "daily_words_select_all" ON public.daily_words FOR SELECT USING (true);
+
+-- 라운드는 본인 것만 조회 가능 (attempts에 본인 추측이 담긴다)
+DROP POLICY IF EXISTS "daily_rounds_select_own" ON public.daily_rounds;
+CREATE POLICY "daily_rounds_select_own" ON public.daily_rounds
+  FOR SELECT USING (anon_id = auth.uid());

--- a/types/database.ts
+++ b/types/database.ts
@@ -14,6 +14,79 @@ export type Database = {
   }
   public: {
     Tables: {
+      daily_rounds: {
+        Row: {
+          anon_id: string
+          attempts: Json
+          created_at: string
+          date: string
+          deck_id: string
+          status: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          anon_id: string
+          attempts?: Json
+          created_at?: string
+          date: string
+          deck_id: string
+          status?: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          anon_id?: string
+          attempts?: Json
+          created_at?: string
+          date?: string
+          deck_id?: string
+          status?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "daily_rounds_deck_id_fkey"
+            columns: ["deck_id"]
+            isOneToOne: false
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      daily_words: {
+        Row: {
+          active_word_ids: string[]
+          date: string
+          deck_id: string
+          locked_at: string
+          word_id: string
+        }
+        Insert: {
+          active_word_ids: string[]
+          date: string
+          deck_id: string
+          locked_at?: string
+          word_id: string
+        }
+        Update: {
+          active_word_ids?: string[]
+          date?: string
+          deck_id?: string
+          locked_at?: string
+          word_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "daily_words_deck_id_fkey"
+            columns: ["deck_id"]
+            isOneToOne: false
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       decks: {
         Row: {
           created_at: string


### PR DESCRIPTION
Fixes #71

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> daily mode 스키마(snapshot 배열 + 낙관적 락 + RLS)가 ADR 0009/0015에 부합하는가?

## Scope

### 포함 (2 files, 순수 additive)
- `supabase/migrations/20260612000003_t2_daily_mode.sql`
  - **daily_words**: `(deck_id, date)` PK, `word_id`, `active_word_ids uuid[]` 스냅샷 (`cardinality >= 1` CHECK — ADR 0015의 row-local invariant), `locked_at`. 첫 풀이자 lock 모델
  - **daily_rounds**: `(anon_id, deck_id, date)` PK, `status` CHECK(in_progress/completed/failed), `attempts jsonb`, `version`(낙관적 락, ADR 0009)
  - RLS: `daily_words` SELECT 공개(uuid만 담겨 단어 텍스트 누설 없음 — ADR 0008 정합), `daily_rounds`는 `anon_id = auth.uid()` 본인만. 쓰기 정책 없음(service_role)
  - `word_id`/`active_word_ids` 원소에 FK 미지정 — ADR 0015가 명시한 결정(배열 FK 불가, server action 생성 전용 + soft-delete로 dangling 없음)
- `types/database.ts` — 수기 갱신 (#99와 동일 패턴: live DB 일시정지로 `gen types` 불가)

### 제외
- 이슈 스케치의 `bigint` id → T1a가 uuid PK로 구현됐으므로 **uuid로 적응**
- lock 생성/시드 로직 — T2b(#72) server action
- challenge_runs — T3a(#73)

## Scope Check

```
verdict: APPROVE
primary layer: infra (DB schema migration)
secondary layers: mechanical (types/database.ts — 마이그레이션 파생)
ADR count: 0 (ADR 0009/0015 참조만)
file count: 2
decision interlock: interlocked
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- [x] `pnpm build` / typecheck / lint 통과 (이슈 AC)
- [ ] 마이그레이션 적용 — Supabase 프로젝트 복구 후 일괄 적용 (멱등 작성)

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_