### PR TITLE
feat(game): [T2b] Daily mode — 시드, 낙관적 락, 게임 보드, smart 키보드

### DIFF
--- a/app/actions/daily.ts
+++ b/app/actions/daily.ts
@@ -1,0 +1,357 @@
+"use server";
+
+import { createAdminClient } from "@/lib/supabase-admin";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import { getOrCreateAnonUserId } from "@/lib/anon-session";
+import { dailySeed, pickDailyWordId, maxAttemptsForLength } from "@/lib/game-seed";
+import { checkRoundAction } from "@/lib/game-lock";
+import { deriveSpecialChars } from "@/lib/game-keyboard";
+import { normalizeWord } from "@/lib/word-validation";
+import { evaluateGuess, type LetterState } from "@/lib/wordleGame";
+import { getScriptAdapter, isSupportedScript } from "@/lib/scripts";
+import type { ScriptAdapter } from "@/lib/scripts/types";
+import type { Json, Tables } from "@/types/database";
+
+// 클라이언트로 내려가는 라운드 뷰. 단어 텍스트(스냅샷/정답)는
+// 라운드가 끝나기 전까지 절대 포함하지 않는다 (ADR 0008).
+export interface DailyAttemptView {
+  units: string[];
+  states: LetterState[];
+}
+
+export interface DailyRoundView {
+  date: string;
+  status: "in_progress" | "completed" | "failed";
+  attempts: DailyAttemptView[];
+  maxAttempts: number;
+  targetLength: number;
+  specialChars: string[];
+  version: number;
+  /** 라운드 종료 후에만 공개되는 정답 */
+  answer?: string;
+}
+
+/** version 불일치/종료 라운드 액션 시 conflict: true + 최신 뷰를 담아 반환한다 (ADR 0009의 409 대응) */
+export type DailyActionResponse = ActionResponse<DailyRoundView> & { conflict?: boolean };
+
+type DailyWordRow = Tables<"daily_words">;
+type DailyRoundRow = Tables<"daily_rounds">;
+
+interface StoredAttempt {
+  units: string[];
+  states: LetterState[];
+  at: string;
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+interface RoundContext {
+  adapter: ScriptAdapter;
+  lock: DailyWordRow;
+  round: DailyRoundRow;
+  targetText: string;
+  snapshotTexts: string[];
+}
+
+function parseAttempts(raw: unknown): StoredAttempt[] {
+  return Array.isArray(raw) ? (raw as StoredAttempt[]) : [];
+}
+
+function buildView(ctx: RoundContext): DailyRoundView {
+  const { adapter, round, targetText, snapshotTexts } = ctx;
+  const attempts = parseAttempts(round.attempts);
+  const targetUnits = adapter.splitUnits(targetText);
+  const status = round.status as DailyRoundView["status"];
+
+  return {
+    date: round.date,
+    status,
+    attempts: attempts.map(({ units, states }) => ({ units, states })),
+    maxAttempts: maxAttemptsForLength(targetUnits.length),
+    targetLength: targetUnits.length,
+    specialChars: deriveSpecialChars(snapshotTexts),
+    version: round.version,
+    ...(status !== "in_progress" ? { answer: targetText } : {}),
+  };
+}
+
+// (deck, date)의 lock과 본인 라운드를 로드하거나 생성한다.
+async function loadRoundContext(
+  deckId: string,
+  date: string,
+  anonId: string,
+  { createIfMissing }: { createIfMissing: boolean },
+): Promise<{ ok: true; ctx: RoundContext } | { ok: false; message: string }> {
+  const admin = createAdminClient();
+
+  const { data: deck } = await admin
+    .from("decks")
+    .select("id, script")
+    .eq("id", deckId)
+    .single();
+  if (!deck || !isSupportedScript(deck.script)) {
+    return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+  const adapter = getScriptAdapter(deck.script);
+
+  // 1. lock 확보 — 첫 풀이자가 생성, race는 ON CONFLICT DO NOTHING (ADR 0015)
+  let { data: lock } = await admin
+    .from("daily_words")
+    .select("*")
+    .eq("deck_id", deckId)
+    .eq("date", date)
+    .maybeSingle();
+
+  if (!lock) {
+    if (!createIfMissing) return { ok: false, message: "라운드를 먼저 시작해주세요." };
+
+    const { data: activeWords, error: wordsError } = await admin
+      .from("words")
+      .select("id")
+      .eq("deck_id", deckId)
+      .eq("active", true)
+      .order("id", { ascending: true }); // 결정적 정렬 필수 (ADR 0015)
+    if (wordsError || !activeWords || activeWords.length === 0) {
+      return { ok: false, message: "덱에 활성 단어가 없습니다." };
+    }
+
+    const sortedIds = activeWords.map((w) => w.id);
+    const wordId = pickDailyWordId(sortedIds, dailySeed(deckId, date));
+
+    await admin
+      .from("daily_words")
+      .upsert(
+        { deck_id: deckId, date, word_id: wordId, active_word_ids: sortedIds },
+        { onConflict: "deck_id,date", ignoreDuplicates: true },
+      );
+
+    const { data: relocked } = await admin
+      .from("daily_words")
+      .select("*")
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .single();
+    if (!relocked) return { ok: false, message: "데일리 단어 잠금에 실패했습니다." };
+    lock = relocked;
+  }
+
+  // 2. 본인 라운드 확보
+  let { data: round } = await admin
+    .from("daily_rounds")
+    .select("*")
+    .eq("anon_id", anonId)
+    .eq("deck_id", deckId)
+    .eq("date", date)
+    .maybeSingle();
+
+  if (!round) {
+    if (!createIfMissing) return { ok: false, message: "라운드를 먼저 시작해주세요." };
+    await admin
+      .from("daily_rounds")
+      .upsert(
+        { anon_id: anonId, deck_id: deckId, date },
+        { onConflict: "anon_id,deck_id,date", ignoreDuplicates: true },
+      );
+    const { data: recreated } = await admin
+      .from("daily_rounds")
+      .select("*")
+      .eq("anon_id", anonId)
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .single();
+    if (!recreated) return { ok: false, message: "라운드 생성에 실패했습니다." };
+    round = recreated;
+  }
+
+  // 3. 스냅샷 단어 텍스트 (서버 전용 — 클라이언트로 내려가지 않는다)
+  const { data: snapshotWords, error: snapshotError } = await admin
+    .from("words")
+    .select("id, text")
+    .in("id", lock.active_word_ids);
+  if (snapshotError || !snapshotWords) {
+    return { ok: false, message: "단어 스냅샷을 가져오는데 실패했습니다." };
+  }
+
+  const targetText = snapshotWords.find((w) => w.id === lock.word_id)?.text;
+  if (!targetText) return { ok: false, message: "데일리 단어를 찾을 수 없습니다." };
+
+  return {
+    ok: true,
+    ctx: {
+      adapter,
+      lock,
+      round,
+      targetText,
+      snapshotTexts: snapshotWords.map((w) => w.text),
+    },
+  };
+}
+
+export async function startDailyRound(
+  deckId: string,
+  clientDate: string,
+): Promise<DailyActionResponse> {
+  return safeAction(async () => {
+    if (!DATE_PATTERN.test(clientDate)) {
+      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+    }
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) {
+      return { success: false, message: "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요." };
+    }
+
+    const loaded = await loadRoundContext(deckId, clientDate, anonId, { createIfMissing: true });
+    if (!loaded.ok) return { success: false, message: loaded.message };
+
+    return { success: true, data: buildView(loaded.ctx), message: "라운드를 시작했습니다." };
+  });
+}
+
+export async function submitDailyGuess(input: {
+  deckId: string;
+  date: string;
+  guess: string;
+  expectedVersion: number;
+}): Promise<DailyActionResponse> {
+  return safeAction(async () => {
+    const { deckId, date, guess, expectedVersion } = input;
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션이 없습니다." };
+
+    const loaded = await loadRoundContext(deckId, date, anonId, { createIfMissing: false });
+    if (!loaded.ok) return { success: false, message: loaded.message };
+    const ctx = loaded.ctx;
+    const { adapter, round, targetText, snapshotTexts } = ctx;
+
+    const lockCheck = checkRoundAction(round, expectedVersion);
+    if (!lockCheck.ok) {
+      return {
+        success: false,
+        conflict: true,
+        message: lockCheck.message,
+        data: buildView(ctx),
+      };
+    }
+
+    const targetUnits = adapter.splitUnits(targetText);
+    const guessUnits = adapter.splitUnits(normalizeWord(guess.trim()));
+
+    if (guessUnits.length !== targetUnits.length) {
+      return {
+        success: false,
+        message: `글자 수가 맞지 않습니다 (${guessUnits.length}/${targetUnits.length}).`,
+      };
+    }
+
+    // 스냅샷 활성 단어 집합에 있어야 추측으로 인정 (ADR 0008 — 자동완성/리스트 노출 없음)
+    const guessJoined = guessUnits.join(" ");
+    const inSnapshot = snapshotTexts.some(
+      (text) => adapter.splitUnits(text).join(" ") === guessJoined,
+    );
+    if (!inSnapshot) {
+      return { success: false, message: "이 덱에 없는 단어입니다." };
+    }
+
+    const evaluated = evaluateGuess(guessUnits, targetUnits);
+    const states = evaluated.letters.map((l) => l.state);
+    const attempts = parseAttempts(round.attempts);
+    const newAttempts: StoredAttempt[] = [
+      ...attempts,
+      { units: guessUnits, states, at: new Date().toISOString() },
+    ];
+
+    const won = states.every((s) => s === "correct");
+    const maxAttempts = maxAttemptsForLength(targetUnits.length);
+    const newStatus = won
+      ? "completed"
+      : newAttempts.length >= maxAttempts
+        ? "failed"
+        : "in_progress";
+
+    // DB 레벨 이중 가드: version 조건이 빗나가면(직전 검증 후 race) 갱신 0건
+    const admin = createAdminClient();
+    const { data: updated } = await admin
+      .from("daily_rounds")
+      .update({
+        // StoredAttempt는 인덱스 시그니처가 없어 Json에 직접 대입 불가 — 구조는 Json 호환
+        attempts: newAttempts as unknown as Json,
+        status: newStatus,
+        version: round.version + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("anon_id", anonId)
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .eq("version", round.version)
+      .select("*");
+
+    if (!updated || updated.length === 0) {
+      const fresh = await loadRoundContext(deckId, date, anonId, { createIfMissing: false });
+      return {
+        success: false,
+        conflict: true,
+        message: "다른 탭에서 진행됐습니다. 최신 상태로 갱신합니다.",
+        ...(fresh.ok ? { data: buildView(fresh.ctx) } : {}),
+      };
+    }
+
+    return {
+      success: true,
+      data: buildView({ ...ctx, round: updated[0] }),
+      message: won ? "정답입니다!" : "추측을 제출했습니다.",
+    };
+  });
+}
+
+// 포기 — 라운드를 failed로 종료한다
+export async function endDailyRound(input: {
+  deckId: string;
+  date: string;
+  expectedVersion: number;
+}): Promise<DailyActionResponse> {
+  return safeAction(async () => {
+    const { deckId, date, expectedVersion } = input;
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션이 없습니다." };
+
+    const loaded = await loadRoundContext(deckId, date, anonId, { createIfMissing: false });
+    if (!loaded.ok) return { success: false, message: loaded.message };
+    const ctx = loaded.ctx;
+
+    const lockCheck = checkRoundAction(ctx.round, expectedVersion);
+    if (!lockCheck.ok) {
+      return { success: false, conflict: true, message: lockCheck.message, data: buildView(ctx) };
+    }
+
+    const admin = createAdminClient();
+    const { data: updated } = await admin
+      .from("daily_rounds")
+      .update({
+        status: "failed",
+        version: ctx.round.version + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("anon_id", anonId)
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .eq("version", ctx.round.version)
+      .select("*");
+
+    if (!updated || updated.length === 0) {
+      const fresh = await loadRoundContext(deckId, date, anonId, { createIfMissing: false });
+      return {
+        success: false,
+        conflict: true,
+        message: "다른 탭에서 진행됐습니다. 최신 상태로 갱신합니다.",
+        ...(fresh.ok ? { data: buildView(fresh.ctx) } : {}),
+      };
+    }
+
+    return {
+      success: true,
+      data: buildView({ ...ctx, round: updated[0] }),
+      message: "라운드를 포기했습니다.",
+    };
+  });
+}

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/identity";
 import { parseWordLines, planWordUpdate, type DeckWordRow } from "@/lib/deckWords";
 import { isSupportedScript } from "@/lib/scripts";
+import { getOrCreateAnonUserId } from "@/lib/anon-session";
 import type { Tables } from "@/types/database";
 
 // creator_pw_hash 노출 방지용 화이트리스트
@@ -28,19 +29,6 @@ export type DeckWord = Tables<"words">;
 export interface DeckWithWords {
   deck: PublicDeck;
   words: DeckWord[];
-}
-
-// 익명 세션이 없으면 lazy 발급한다.
-// ADR 0001은 미들웨어 자동 발급을 제시하지만, 모든 방문(봇 포함)마다
-// 익명 유저가 쌓이는 것을 피해 "첫 쓰기 시점" 발급으로 운영한다.
-async function getOrCreateAnonUserId(): Promise<string | null> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (user) return user.id;
-
-  const { data, error } = await supabase.auth.signInAnonymously();
-  if (error || !data.user) return null;
-  return data.user.id;
 }
 
 type CredentialCheck =

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -20,10 +20,12 @@ export default async function DeckPage({ params }: DeckPageProps) {
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
       <DeckMetaCard deck={deck} activeWordCount={activeWordCount} />
       <div className="flex gap-2">
+        <Button asChild>
+          <Link href={`/d/${deck.id}/play?mode=daily`}>오늘의 데일리 플레이</Link>
+        </Button>
         <Button asChild variant="outline">
           <Link href={`/d/${deck.id}/edit`}>편집</Link>
         </Button>
-        {/* 플레이(데일리 모드)는 T2b에서 추가된다 */}
       </div>
     </main>
   );

--- a/app/d/[id]/play/page.tsx
+++ b/app/d/[id]/play/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase-server";
+import { isSupportedScript } from "@/lib/scripts";
+import { DailyGame } from "@/components/DailyGame";
+
+interface PlayPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ mode?: string }>;
+}
+
+// /d/{deck_id}/play?mode=daily — 단어 리스트는 HTML/props에 절대 포함하지 않는다 (ADR 0008)
+export default async function PlayPage({ params, searchParams }: PlayPageProps) {
+  const { id } = await params;
+  const { mode = "daily" } = await searchParams;
+
+  const supabase = await createClient();
+  const { data: deck } = await supabase
+    .from("decks")
+    .select("id, name, script")
+    .eq("id", id)
+    .single();
+  if (!deck || !isSupportedScript(deck.script)) notFound();
+
+  if (mode !== "daily") {
+    return (
+      <main className="mx-auto max-w-xl px-4 py-8 text-center text-sm text-muted-foreground">
+        챌린지 모드는 준비 중입니다.
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <h1 className="text-center text-2xl font-bold">{deck.name}</h1>
+      <DailyGame deckId={deck.id} deckName={deck.name} script={deck.script} />
+    </main>
+  );
+}

--- a/components/AttemptHistory.tsx
+++ b/components/AttemptHistory.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { DailyAttemptView } from "@/app/actions/daily";
+import type { LetterState } from "@/lib/wordleGame";
+import { cn } from "@/lib/utils";
+
+export const TILE_STYLES: Record<LetterState, string> = {
+  correct: "bg-green-500 text-white border-green-500",
+  present: "bg-yellow-500 text-white border-yellow-500",
+  absent: "bg-gray-400 text-white border-gray-400",
+  empty: "bg-transparent",
+};
+
+interface AttemptHistoryProps {
+  attempts: DailyAttemptView[];
+}
+
+export function AttemptHistory({ attempts }: AttemptHistoryProps) {
+  return (
+    <>
+      {attempts.map((attempt, i) => (
+        <div key={i} className="flex justify-center gap-1">
+          {attempt.units.map((unit, j) => (
+            <span
+              key={j}
+              className={cn(
+                "flex h-12 w-12 items-center justify-center rounded border-2 text-lg font-bold",
+                TILE_STYLES[attempt.states[j] ?? "empty"],
+              )}
+            >
+              {unit}
+            </span>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/components/DailyGame.tsx
+++ b/components/DailyGame.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { GameBoard } from "@/components/GameBoard";
+import { SmartKeyboard } from "@/components/SmartKeyboard";
+import { ResultScreen } from "@/components/ResultScreen";
+import {
+  startDailyRound,
+  submitDailyGuess,
+  endDailyRound,
+  type DailyActionResponse,
+  type DailyRoundView,
+} from "@/app/actions/daily";
+import { deriveKeyStates } from "@/lib/game-keyboard";
+import { getScriptAdapter } from "@/lib/scripts";
+import type { ScriptId } from "@/lib/scripts/types";
+
+// 데일리는 client-local date 기준 (ADR 0015 — date는 보안 경계가 아님)
+function localDate(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+interface DailyGameProps {
+  deckId: string;
+  deckName: string;
+  script: ScriptId;
+}
+
+export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
+  const adapter = useMemo(() => getScriptAdapter(script), [script]);
+  const [view, setView] = useState<DailyRoundView | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [currentUnits, setCurrentUnits] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [date] = useState(localDate);
+
+  useEffect(() => {
+    let cancelled = false;
+    startDailyRound(deckId, date).then((result) => {
+      if (cancelled) return;
+      if (result.success && result.data) setView(result.data);
+      else setLoadError(result.message);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [deckId, date]);
+
+  // conflict(다른 탭 진행) 응답은 최신 뷰로 강제 갱신한다 (ADR 0009)
+  const applyResult = useCallback((result: DailyActionResponse) => {
+    if (result.data) setView(result.data);
+    if (!result.success) toast.error(result.message);
+    else if (result.data?.status === "completed") toast.success(result.message);
+  }, []);
+
+  const finished = view !== null && view.status !== "in_progress";
+  const keyStates = useMemo(
+    () => (view ? deriveKeyStates(view.attempts, adapter) : {}),
+    [view, adapter],
+  );
+
+  const handleKey = useCallback(
+    (char: string) => {
+      if (!view || finished) return;
+      setCurrentUnits((prev) =>
+        prev.length >= view.targetLength ? prev : [...prev, adapter.normalizeChar(char)],
+      );
+    },
+    [view, finished, adapter],
+  );
+
+  const handleBackspace = useCallback(() => {
+    setCurrentUnits((prev) => prev.slice(0, -1));
+  }, []);
+
+  const handleEnter = useCallback(async () => {
+    if (!view || finished || submitting) return;
+    if (currentUnits.length !== view.targetLength) {
+      toast.error(`${view.targetLength}글자를 입력해주세요.`);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const result = await submitDailyGuess({
+        deckId,
+        date,
+        guess: currentUnits.join(""),
+        expectedVersion: view.version,
+      });
+      applyResult(result);
+      if (result.success || result.conflict) setCurrentUnits([]);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [view, finished, submitting, currentUnits, deckId, date, applyResult]);
+
+  const handleGiveUp = useCallback(async () => {
+    if (!view || finished || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await endDailyRound({ deckId, date, expectedVersion: view.version });
+      applyResult(result);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [view, finished, submitting, deckId, date, applyResult]);
+
+  if (loadError) {
+    return <p className="text-center text-sm text-destructive">{loadError}</p>;
+  }
+  if (!view) {
+    return <p className="text-center text-sm text-muted-foreground">불러오는 중...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <GameBoard
+        attempts={view.attempts}
+        currentUnits={currentUnits}
+        targetLength={view.targetLength}
+        maxAttempts={view.maxAttempts}
+        finished={finished}
+      />
+
+      {finished ? (
+        <ResultScreen deckName={deckName} view={view} />
+      ) : (
+        <>
+          <SmartKeyboard
+            script={script}
+            specialChars={view.specialChars}
+            keyStates={keyStates}
+            disabled={submitting}
+            onKey={handleKey}
+            onEnter={handleEnter}
+            onBackspace={handleBackspace}
+          />
+          <div className="text-center">
+            <Button type="button" variant="ghost" size="sm" onClick={handleGiveUp} disabled={submitting}>
+              포기하기
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/GameBoard.tsx
+++ b/components/GameBoard.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { DailyAttemptView } from "@/app/actions/daily";
+import { AttemptHistory } from "@/components/AttemptHistory";
+import { cn } from "@/lib/utils";
+
+interface GameBoardProps {
+  attempts: DailyAttemptView[];
+  currentUnits: string[];
+  targetLength: number;
+  maxAttempts: number;
+  finished: boolean;
+}
+
+// 가변 격자: 열 수 = 단어 글자(unit) 수, 행 수 = maxAttempts
+export function GameBoard({
+  attempts,
+  currentUnits,
+  targetLength,
+  maxAttempts,
+  finished,
+}: GameBoardProps) {
+  const emptyRows = Math.max(
+    0,
+    maxAttempts - attempts.length - (finished ? 0 : 1),
+  );
+
+  return (
+    <div className="space-y-1">
+      <AttemptHistory attempts={attempts} />
+
+      {!finished && (
+        <div className="flex justify-center gap-1">
+          {Array.from({ length: targetLength }, (_, i) => (
+            <span
+              key={i}
+              className={cn(
+                "flex h-12 w-12 items-center justify-center rounded border-2 text-lg font-bold",
+                currentUnits[i] ? "border-foreground" : "border-muted",
+              )}
+            >
+              {currentUnits[i] ?? ""}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {Array.from({ length: emptyRows }, (_, row) => (
+        <div key={row} className="flex justify-center gap-1">
+          {Array.from({ length: targetLength }, (_, i) => (
+            <span key={i} className="h-12 w-12 rounded border-2 border-muted" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/ResultScreen.tsx
+++ b/components/ResultScreen.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import type { DailyRoundView } from "@/app/actions/daily";
+
+const STATE_EMOJI: Record<string, string> = {
+  correct: "🟩",
+  present: "🟨",
+  absent: "⬛",
+};
+
+export function buildShareText(deckName: string, view: DailyRoundView): string {
+  const score =
+    view.status === "completed" ? `${view.attempts.length}/${view.maxAttempts}` : `X/${view.maxAttempts}`;
+  const grid = view.attempts
+    .map((attempt) => attempt.states.map((s) => STATE_EMOJI[s] ?? "⬛").join(""))
+    .join("\n");
+  return `${deckName} 데일리 ${view.date} ${score}\n\n${grid}`;
+}
+
+interface ResultScreenProps {
+  deckName: string;
+  view: DailyRoundView;
+}
+
+export function ResultScreen({ deckName, view }: ResultScreenProps) {
+  const won = view.status === "completed";
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildShareText(deckName, view));
+      toast.success("결과를 복사했습니다.");
+    } catch {
+      toast.error("클립보드 복사에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4 text-center">
+      <p className="text-lg font-bold">{won ? "🎉 정답!" : "아쉽네요"}</p>
+      {view.answer && (
+        <p className="text-sm text-muted-foreground">
+          정답: <span className="font-semibold text-foreground">{view.answer}</span>
+        </p>
+      )}
+      <p className="text-sm text-muted-foreground">
+        {won ? `${view.attempts.length}/${view.maxAttempts} 시도` : `X/${view.maxAttempts}`}
+      </p>
+      <Button type="button" onClick={handleCopy}>
+        결과 복사
+      </Button>
+      <p className="text-xs text-muted-foreground">내일 새로운 단어가 잠금 해제됩니다.</p>
+    </div>
+  );
+}

--- a/components/SmartKeyboard.tsx
+++ b/components/SmartKeyboard.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ScriptId } from "@/lib/scripts/types";
+import type { LetterState } from "@/lib/wordleGame";
+import { getScriptAdapter } from "@/lib/scripts";
+import { cn } from "@/lib/utils";
+
+// ADR 0014 hybrid rendering:
+// 기본 script 알파벳은 고정 레이아웃 전체 표시(누설 0),
+// 특수문자 행은 snapshot에서 derive된 키만 표시한다.
+
+const KEY_STATE_STYLES: Record<string, string> = {
+  correct: "bg-green-500 text-white",
+  present: "bg-yellow-500 text-white",
+  absent: "bg-gray-400 text-white",
+};
+
+interface SmartKeyboardProps {
+  script: ScriptId;
+  specialChars: string[];
+  keyStates: Record<string, LetterState>;
+  disabled?: boolean;
+  onKey: (char: string) => void;
+  onEnter: () => void;
+  onBackspace: () => void;
+}
+
+export function SmartKeyboard({
+  script,
+  specialChars,
+  keyStates,
+  disabled = false,
+  onKey,
+  onEnter,
+  onBackspace,
+}: SmartKeyboardProps) {
+  const adapter = useMemo(() => getScriptAdapter(script), [script]);
+
+  const renderKey = (char: string) => {
+    const state = keyStates[adapter.keyId(char)];
+    return (
+      <button
+        key={char}
+        type="button"
+        disabled={disabled}
+        onClick={() => onKey(char)}
+        className={cn(
+          "min-w-7 rounded px-1.5 py-3 text-sm font-semibold",
+          state ? KEY_STATE_STYLES[state] : "bg-muted",
+          disabled && "opacity-50",
+        )}
+      >
+        {char}
+      </button>
+    );
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {specialChars.length > 0 && (
+        <div className="flex justify-center gap-1">{specialChars.map(renderKey)}</div>
+      )}
+
+      {adapter.keyboard.rows.map((row, i) => (
+        <div key={i} className="flex justify-center gap-1">
+          {row.map(renderKey)}
+        </div>
+      ))}
+
+      <div className="flex justify-center gap-1">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onEnter}
+          className={cn("rounded bg-muted px-4 py-3 text-sm font-semibold", disabled && "opacity-50")}
+        >
+          {adapter.keyboard.enterLabel}
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onBackspace}
+          className={cn("rounded bg-muted px-4 py-3 text-sm font-semibold", disabled && "opacity-50")}
+        >
+          ⌫
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/anon-session.ts
+++ b/lib/anon-session.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@/lib/supabase-server";
+
+// 익명 세션이 없으면 lazy 발급한다.
+// ADR 0001은 미들웨어 자동 발급을 제시하지만, 모든 방문(봇 포함)마다
+// 익명 유저가 쌓이는 것을 피해 "첫 쓰기/플레이 시점" 발급으로 운영한다.
+export async function getOrCreateAnonUserId(): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (user) return user.id;
+
+  const { data, error } = await supabase.auth.signInAnonymously();
+  if (error || !data.user) return null;
+  return data.user.id;
+}

--- a/lib/game-keyboard.test.ts
+++ b/lib/game-keyboard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSpecialChars, deriveKeyStates } from './game-keyboard';
+import { getScriptAdapter } from './scripts';
+
+describe('deriveSpecialChars — snapshot 단어에서 특수키 derive (ADR 0014, AC)', () => {
+  it('사용된 특수문자만, 정의된 순서로 반환한다', () => {
+    expect(deriveSpecialChars(['x-men', 'mr.', 'ff14'])).toEqual(['1', '4', '-', '.']);
+  });
+
+  it('특수문자가 없으면 빈 배열 (UI 노이즈 0)', () => {
+    expect(deriveSpecialChars(['pikachu', '피카츄'])).toEqual([]);
+  });
+
+  it('알파벳/한글은 특수키로 derive되지 않는다', () => {
+    expect(deriveSpecialChars(["l'arc"])).toEqual(["'"]);
+  });
+
+  it('입력이 같으면 결과도 같다 (결정성)', () => {
+    const words = ['x-men', "l'arc", '1세대'];
+    expect(deriveSpecialChars(words)).toEqual(deriveSpecialChars(words));
+  });
+});
+
+describe('deriveKeyStates — 시도 기록 → 키 상태', () => {
+  const latin = getScriptAdapter('latin');
+
+  it('correct > present > absent 우선순위로 승급하고 강등하지 않는다', () => {
+    const states = deriveKeyStates(
+      [
+        { units: ['a', 'b'], states: ['present', 'absent'] },
+        { units: ['a', 'c'], states: ['correct', 'present'] },
+        { units: ['a', 'c'], states: ['absent', 'absent'] }, // 강등 시도
+      ],
+      latin,
+    );
+    expect(states[latin.keyId('a')]).toBe('correct');
+    expect(states[latin.keyId('b')]).toBe('absent');
+    expect(states[latin.keyId('c')]).toBe('present');
+  });
+
+  it('한글은 자모 keyId 단위로 상태를 합친다', () => {
+    const hangul = getScriptAdapter('hangul');
+    const states = deriveKeyStates(
+      [{ units: ['ㅍ', 'ㅣ'], states: ['correct', 'absent'] }],
+      hangul,
+    );
+    expect(states[hangul.keyId('ㅍ')]).toBe('correct');
+    expect(states[hangul.keyId('ㅣ')]).toBe('absent');
+  });
+
+  it('시도가 없으면 빈 객체', () => {
+    expect(deriveKeyStates([], latin)).toEqual({});
+  });
+});

--- a/lib/game-keyboard.ts
+++ b/lib/game-keyboard.ts
@@ -1,0 +1,46 @@
+import type { ScriptAdapter } from "./scripts/types";
+import type { LetterState } from "./wordleGame";
+
+// Smart keyboard 구성 (ADR 0014 hybrid rendering):
+// - 기본 script 알파벳: adapter.keyboard의 고정 레이아웃 전체 표시 (누설 0)
+// - 특수문자(0-9, -, ', .): DailyWord snapshot의 단어들에서 derive —
+//   사용된 것만 표시한다. "이 덱/날짜에 하이픈 단어 있음" 수준의 약한 누설 감수.
+
+const SPECIAL_CHARS = [..."0123456789-'."] as const;
+
+export function deriveSpecialChars(snapshotWordTexts: readonly string[]): string[] {
+  const present = new Set<string>();
+  for (const text of snapshotWordTexts) {
+    for (const ch of text) {
+      if ((SPECIAL_CHARS as readonly string[]).includes(ch)) present.add(ch);
+    }
+  }
+  return SPECIAL_CHARS.filter((ch) => present.has(ch));
+}
+
+// 시도 기록에서 키보드 키 상태를 derive한다 (correct > present > absent 우선순위)
+export interface AttemptUnits {
+  units: string[];
+  states: LetterState[];
+}
+
+const STATE_PRIORITY: Record<string, number> = { absent: 1, present: 2, correct: 3 };
+
+export function deriveKeyStates(
+  attempts: readonly AttemptUnits[],
+  adapter: ScriptAdapter,
+): Record<string, LetterState> {
+  const keyStates: Record<string, LetterState> = {};
+  for (const attempt of attempts) {
+    attempt.units.forEach((unit, i) => {
+      const state = attempt.states[i];
+      if (!unit || !state || state === "empty") return;
+      const keyId = adapter.keyId(unit);
+      const current = keyStates[keyId];
+      if (!current || STATE_PRIORITY[state] > STATE_PRIORITY[current]) {
+        keyStates[keyId] = state;
+      }
+    });
+  }
+  return keyStates;
+}

--- a/lib/game-lock.test.ts
+++ b/lib/game-lock.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { checkRoundAction } from './game-lock';
+
+describe('checkRoundAction — 낙관적 락 (ADR 0009)', () => {
+  it('in_progress + version 일치 → 통과', () => {
+    expect(checkRoundAction({ status: 'in_progress', version: 3 }, 3)).toEqual({ ok: true });
+  });
+
+  it('version 불일치 → version_conflict (멀티 탭 race)', () => {
+    const result = checkRoundAction({ status: 'in_progress', version: 4 }, 3);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('version_conflict');
+  });
+
+  it('끝난 라운드는 version과 무관하게 finished', () => {
+    for (const status of ['completed', 'failed']) {
+      const result = checkRoundAction({ status, version: 3 }, 3);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('finished');
+    }
+  });
+
+  it('status 검증이 version 검증보다 먼저다 (ADR 0009 검증 순서)', () => {
+    const result = checkRoundAction({ status: 'completed', version: 5 }, 3);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('finished');
+  });
+});

--- a/lib/game-lock.ts
+++ b/lib/game-lock.ts
@@ -1,0 +1,29 @@
+// 낙관적 락 헬퍼 (ADR 0009)
+// 상태성 레코드(DailyRound 등)는 version을 보유하고, 모든 액션 요청에
+// 클라이언트가 expected_version을 동봉한다. 검증 순서: status → version.
+
+export interface LockableRecord {
+  status: string;
+  version: number;
+}
+
+export type LockCheck =
+  | { ok: true }
+  | { ok: false; reason: "finished" | "version_conflict"; message: string };
+
+export function checkRoundAction(
+  record: LockableRecord,
+  expectedVersion: number,
+): LockCheck {
+  if (record.status !== "in_progress") {
+    return { ok: false, reason: "finished", message: "이미 끝난 라운드입니다." };
+  }
+  if (record.version !== expectedVersion) {
+    return {
+      ok: false,
+      reason: "version_conflict",
+      message: "다른 탭에서 진행됐습니다. 최신 상태로 갱신합니다.",
+    };
+  }
+  return { ok: true };
+}

--- a/lib/game-seed.test.ts
+++ b/lib/game-seed.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashSeed,
+  dailySeed,
+  pickDailyWordId,
+  maxAttemptsForLength,
+} from './game-seed';
+
+describe('hashSeed / dailySeed — 결정성 (AC)', () => {
+  it('같은 입력은 항상 같은 시드를 낸다', () => {
+    expect(hashSeed('deck-1:2026-06-12')).toBe(hashSeed('deck-1:2026-06-12'));
+    expect(dailySeed('deck-1', '2026-06-12')).toBe(dailySeed('deck-1', '2026-06-12'));
+  });
+
+  it('deck/date/salt가 다르면 다른 시드를 낸다', () => {
+    const base = dailySeed('deck-1', '2026-06-12');
+    expect(dailySeed('deck-2', '2026-06-12')).not.toBe(base);
+    expect(dailySeed('deck-1', '2026-06-13')).not.toBe(base);
+    // 챌린지 시드는 데일리와 별개 (ADR 0006: salt "endurance")
+    expect(dailySeed('deck-1', '2026-06-12', 'endurance')).not.toBe(base);
+  });
+
+  it('unsigned 32-bit 범위를 보장한다 (음수 modulo 방지)', () => {
+    for (const input of ['a', 'deck:2026-01-01', '한글덱:2026-12-31:endurance']) {
+      const seed = hashSeed(input);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThanOrEqual(0xffffffff);
+    }
+  });
+});
+
+describe('pickDailyWordId', () => {
+  it('시드가 같으면 같은 단어를 고른다', () => {
+    const ids = ['w1', 'w2', 'w3', 'w4', 'w5'];
+    const seed = dailySeed('deck-1', '2026-06-12');
+    expect(pickDailyWordId(ids, seed)).toBe(pickDailyWordId(ids, seed));
+  });
+
+  it('배열 범위 안의 원소를 반환한다', () => {
+    const ids = ['w1', 'w2', 'w3'];
+    for (let day = 1; day <= 28; day++) {
+      const seed = dailySeed('deck-1', `2026-06-${String(day).padStart(2, '0')}`);
+      expect(ids).toContain(pickDailyWordId(ids, seed));
+    }
+  });
+
+  it('빈 배열이면 throw한다 (min-1-active invariant 위반)', () => {
+    expect(() => pickDailyWordId([], 1)).toThrow();
+  });
+});
+
+describe('maxAttemptsForLength — 글자수+1, 5~8 클램프 (AC)', () => {
+  it.each([
+    [1, 5], // 1+1=2 → 5로 클램프
+    [4, 5],
+    [5, 6],
+    [6, 7],
+    [7, 8],
+    [8, 8], // 8+1=9 → 8로 클램프
+    [20, 8],
+  ])('글자수 %i → 시도 %i회', (length, expected) => {
+    expect(maxAttemptsForLength(length)).toBe(expected);
+  });
+});

--- a/lib/game-seed.ts
+++ b/lib/game-seed.ts
@@ -1,0 +1,33 @@
+// 데일리/챌린지 결정적 시드 (ADR 0005, 0015)
+// 같은 (deck, date) 입력이면 어느 서버 인스턴스에서 계산해도 같은 결과여야 한다.
+// crypto 불필요 — 분포 균일성과 결정성만 요구된다.
+
+// FNV-1a 32-bit
+export function hashSeed(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0; // unsigned 32-bit
+}
+
+export function dailySeed(deckId: string, date: string, salt = ""): number {
+  return hashSeed(`${deckId}:${date}${salt ? `:${salt}` : ""}`);
+}
+
+// active_word_ids(Word.id ASC 정렬)에서 오늘의 단어를 고른다 (ADR 0015)
+export function pickDailyWordId(sortedWordIds: readonly string[], seed: number): string {
+  if (sortedWordIds.length === 0) {
+    throw new Error("active_word_ids가 비어있습니다. (min-1-active invariant 위반)");
+  }
+  return sortedWordIds[seed % sortedWordIds.length];
+}
+
+// 시도 횟수 = 글자수 + 1, 5~8 클램프 (#72 AC)
+export const MIN_ATTEMPTS = 5;
+export const MAX_ATTEMPTS = 8;
+
+export function maxAttemptsForLength(targetUnitLength: number): number {
+  return Math.min(MAX_ATTEMPTS, Math.max(MIN_ATTEMPTS, targetUnitLength + 1));
+}

--- a/lib/wordleGame.ts
+++ b/lib/wordleGame.ts
@@ -131,7 +131,8 @@ export function submitGuess(gameState: GameState): GameState {
   };
 }
 
-function evaluateGuess(guessUnits: string[], targetUnits: string[]): Guess {
+// 서버측 데일리 판정(app/actions/daily.ts)에서도 사용하므로 export한다
+export function evaluateGuess(guessUnits: string[], targetUnits: string[]): Guess {
   const result: Letter[] = [];
 
   // 첫 번째 패스: 정확한 위치의 글자 확인


### PR DESCRIPTION
Fixes #72

> [!NOTE]
> **Stacked PR** — base가 #102([T2a] daily 스키마)입니다. #102 머지 시 base가 main으로 자동 전환됩니다. 머지 순서: #102 → 본 PR.

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> daily mode 게임 로직(seed/lock/keyboard/서버 판정)과 UI가 ADR 0005/0008/0009/0014/0015를 올바르게 구현하는가?

## Scope

### 포함 (17 files: semantic 14 + test 3)
- **lib (순수 함수 + 테스트 24개)**
  - `game-seed.ts`: FNV-1a 결정적 시드, `pickDailyWordId`, `maxAttemptsForLength`(**글자수+1, 5~8 클램프** — AC)
  - `game-lock.ts`: `checkRoundAction` — status → version 순 검증 (ADR 0009)
  - `game-keyboard.ts`: `deriveSpecialChars`(snapshot에서 사용된 특수키만 — ADR 0014 hybrid), `deriveKeyStates`
- **`app/actions/daily.ts`**
  - `startDailyRound`: 첫 풀이자 lock 생성 — **`Word.id ASC` 정렬 스냅샷**(AC) + `ON CONFLICT DO NOTHING` race-safe + 재읽기 (ADR 0015). 두 번째 사용자는 같은 word+snapshot (AC)
  - `submitDailyGuess`: **스냅샷 멤버십 검증**("이 덱에 없는 단어" — ADR 0008), 서버측 판정(`evaluateGuess`), **version 불일치 시 `conflict: true` + 최신 뷰 반환**(AC의 409 대응) — 어플리케이션 검증 + DB `eq(version)` 이중 가드
  - `endDailyRound`: 포기 처리
  - **단어 텍스트(스냅샷/정답)는 라운드 종료 전까지 클라이언트 미노출** (ADR 0008) — view 타입에서 구조적으로 차단
- **UI**: `DailyGame`(컨테이너, conflict 시 토스트+강제 갱신), `GameBoard`(가변 격자), `AttemptHistory`, `SmartKeyboard`(고정 script 알파벳 + derive된 특수키), `ResultScreen`(이모지 그리드 클립보드 복사 — AC)
- **Routes**: `/d/[id]/play?mode=daily` (challenge는 "준비 중" — T3b), 덱 상세에 플레이 버튼(T2a 주석 예약 자리)
- **Mechanical**: `lib/anon-session.ts` 추출(deck.ts와 공유, 행동 변경 없음), `wordleGame.ts` `evaluateGuess` export 1줄(서버 재사용)

### 제외
- 챌린지 모드 — T3a/T3b (#73/#74)
- 물리 키보드/IME 입력 — 온스크린 키보드만 (스크립트 간 일관 UX, IME 대응은 후속)
- 데일리 완료 게이트 활용 — T3b

## Scope Check

```
verdict: APPROVE
primary layer: game-state
secondary layers: test, mechanical (anon-session 추출, evaluateGuess export)
ADR count: 0
file count: 17 (semantic 14, test 3)
decision interlock: interlocked (전부 "daily mode 플레이 루프" 단일 결정에 종속)
split suggestion: 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #72 AC)

- [x] Vitest: 시드 결정성 / 낙관적 락 / 키보드 derive / snapshot 정렬은 `ORDER BY id ASC` 쿼리 + pick 결정성 테스트 (신규 24개, 총 136개 통과)
- [x] 시도 횟수 = 글자수+1, 5~8 클램프 (파라미터라이즈드 테스트)
- [x] `expected_version` 불일치 → `conflict: true` + 토스트 + 뷰 강제 갱신
- [x] 결과 클립보드 복사 (`navigator.clipboard` + 이모지 그리드)
- [x] `pnpm test` / `pnpm build`(`/d/[id]/play` 라우트 생성 확인) / typecheck / lint 통과
- [ ] lock 생성·동시 접속 AC의 라이브 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 데일리 게임 모드 추가: 매일 같은 단어로 플레이하는 새로운 게임 모드
  * 향상된 게임 인터페이스: 게임 보드, 동적 키보드, 결과 공유 화면 추가

* **Bug Fixes**
  * 게임 상태 동기화 개선: 버전 기반 동시성 제어로 플레이 중 발생할 수 있는 상태 충돌 해결

* **Tests**
  * 게임 로직 및 상태 관리에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->