### PR TITLE
feat(schema): [T3a] challenge_runs 테이블 마이그레이션

### DIFF
--- a/supabase/migrations/20260612000004_t3_challenge_mode.sql
+++ b/supabase/migrations/20260612000004_t3_challenge_mode.sql
@@ -1,0 +1,31 @@
+-- [T3a] Challenge mode 스키마: challenge_runs (#73)
+-- ADR 0006: (anon_id, deck_id, date) 1일 1회 — PK가 두 번째 시작을 차단
+-- ADR 0015: shuffle_order는 결정적 셔플 결과를 영구 저장 (재계산 X)
+-- ADR 0009: 상태성 레코드는 version 낙관적 락 보유 — 이슈 스케치에 없지만 ADR이 요구
+-- 이슈 스케치의 bigint id는 T1a(uuid PK) 스키마에 맞춰 uuid로 적응
+
+CREATE TABLE IF NOT EXISTS public.challenge_runs (
+  anon_id uuid NOT NULL,
+  deck_id uuid NOT NULL REFERENCES public.decks(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  -- deterministic_shuffle(daily_words.active_word_ids, hash(deck+date+"endurance")) 결과.
+  -- 배열 원소 FK는 불가 — 생성은 server action 전용 (ADR 0015)
+  shuffle_order uuid[] NOT NULL CHECK (cardinality(shuffle_order) >= 1),
+  current_round integer NOT NULL DEFAULT 0 CHECK (current_round >= 0),
+  score integer NOT NULL DEFAULT 0 CHECK (score >= 0),
+  -- NULL(진행 중) | completed(전체 클리어) | failed(시도 소진/포기)
+  ended_reason text CHECK (ended_reason IN ('completed', 'failed')),
+  -- 현재 라운드의 추측 기록 [{ units, states, at }] — 라운드 전환 시 비움
+  attempts jsonb NOT NULL DEFAULT '[]',
+  version integer NOT NULL DEFAULT 0 CHECK (version >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (anon_id, deck_id, date)
+);
+
+-- RLS — 쓰기는 server action의 service_role만. 본인 run만 조회 가능.
+ALTER TABLE public.challenge_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "challenge_runs_select_own" ON public.challenge_runs;
+CREATE POLICY "challenge_runs_select_own" ON public.challenge_runs
+  FOR SELECT USING (anon_id = auth.uid());

--- a/types/database.ts
+++ b/types/database.ts
@@ -14,6 +14,56 @@ export type Database = {
   }
   public: {
     Tables: {
+      challenge_runs: {
+        Row: {
+          anon_id: string
+          attempts: Json
+          created_at: string
+          current_round: number
+          date: string
+          deck_id: string
+          ended_reason: string | null
+          score: number
+          shuffle_order: string[]
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          anon_id: string
+          attempts?: Json
+          created_at?: string
+          current_round?: number
+          date: string
+          deck_id: string
+          ended_reason?: string | null
+          score?: number
+          shuffle_order: string[]
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          anon_id?: string
+          attempts?: Json
+          created_at?: string
+          current_round?: number
+          date?: string
+          deck_id?: string
+          ended_reason?: string | null
+          score?: number
+          shuffle_order?: string[]
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "challenge_runs_deck_id_fkey"
+            columns: ["deck_id"]
+            isOneToOne: false
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       daily_rounds: {
         Row: {
           anon_id: string


### PR DESCRIPTION
Fixes #73

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> challenge_runs 스키마(PK·shuffle_order·version·RLS)가 ADR 0006/0009/0015를 올바르게 구현하는가?

## Scope

### 포함 (2 files, 순수 additive)
- `supabase/migrations/20260612000004_t3_challenge_mode.sql`
  - `(anon_id, deck_id, date)` PK — **같은 날 두 번째 시작 차단** (이슈 AC, ADR 0006의 1일 1회)
  - `shuffle_order uuid[]` (`cardinality >= 1` CHECK) — 결정적 셔플 결과 **영구 저장** (ADR 0015: 재계산 X)
  - `current_round`/`score`/`ended_reason`(NULL/completed/failed) CHECK
  - RLS: 본인 run만 SELECT (`anon_id = auth.uid()`), 쓰기는 service_role
- `types/database.ts` — 수기 갱신 (#99/#102와 동일 승인 패턴)

### 이슈 스케치 대비 편차 (SQL 주석에 근거 명시)
- `version integer` 추가 — **ADR 0009가 ChallengeRun 같은 상태성 레코드에 낙관적 락을 명시 요구** (스케치 누락분 보정)
- `attempts jsonb` 추가 — 현재 라운드 추측 기록 (T3b 진행 상태 복원에 필요, daily_rounds와 동일 패턴)
- `created_at`/`updated_at` 추가
- `bigint` → `uuid` 적응 (T1a 스키마 정합)

### 제외
- 셔플/게이트 로직, UI — T3b(#74)

## Scope Check

```
verdict: APPROVE
primary layer: infra (DB schema migration)
secondary layers: mechanical (types/database.ts)
ADR count: 0 (ADR 0006/0009/0015 참조만)
file count: 2
decision interlock: interlocked
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- [x] `pnpm typecheck` / lint 통과 (이슈 AC: pnpm build — types 정합 확인)
- [ ] 마이그레이션 적용 — Supabase 프로젝트 복구 후 일괄 적용 (멱등 작성)

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_