### PR TITLE
feat(game): [T3b] Challenge mode — 결정적 셔플, 데일리 게이트, 다라운드 진행

### DIFF
--- a/app/actions/challenge.ts
+++ b/app/actions/challenge.ts
@@ -1,0 +1,381 @@
+"use server";
+
+import { createAdminClient } from "@/lib/supabase-admin";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import { getOrCreateAnonUserId } from "@/lib/anon-session";
+import { challengeSeed, deterministicShuffle, isChallengeUnlocked } from "@/lib/challenge";
+import { maxAttemptsForLength } from "@/lib/game-seed";
+import { checkRoundAction } from "@/lib/game-lock";
+import { deriveSpecialChars } from "@/lib/game-keyboard";
+import { normalizeWord } from "@/lib/word-validation";
+import { evaluateGuess, type LetterState } from "@/lib/wordleGame";
+import { getScriptAdapter, isSupportedScript } from "@/lib/scripts";
+import type { ScriptAdapter } from "@/lib/scripts/types";
+import type { Json, Tables } from "@/types/database";
+import type { DailyAttemptView } from "@/app/actions/daily";
+
+// 클라이언트로 내려가는 런 뷰 — 단어 텍스트는 미노출 (ADR 0008).
+// answer는 런이 failed로 끝났을 때 마지막 라운드 단어만 공개.
+export interface ChallengeRunView {
+  date: string;
+  currentRound: number;
+  totalRounds: number;
+  score: number;
+  endedReason: "completed" | "failed" | null;
+  attempts: DailyAttemptView[];
+  maxAttempts: number;
+  targetLength: number;
+  specialChars: string[];
+  version: number;
+  answer?: string;
+}
+
+/** gateLocked: 데일리 미완료로 잠김 (ADR 0006). conflict: 낙관적 락 충돌 (ADR 0009) */
+export type ChallengeActionResponse = ActionResponse<ChallengeRunView> & {
+  conflict?: boolean;
+  gateLocked?: boolean;
+};
+
+type ChallengeRunRow = Tables<"challenge_runs">;
+
+interface StoredAttempt {
+  units: string[];
+  states: LetterState[];
+  at: string;
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+interface RunContext {
+  adapter: ScriptAdapter;
+  run: ChallengeRunRow;
+  /** word_id → canonical text (스냅샷 전체, 서버 전용) */
+  textById: Map<string, string>;
+}
+
+function parseAttempts(raw: unknown): StoredAttempt[] {
+  return Array.isArray(raw) ? (raw as StoredAttempt[]) : [];
+}
+
+function currentTarget(ctx: RunContext): string {
+  const { run, textById } = ctx;
+  // 종료된 런은 마지막으로 플레이하던 라운드를 가리킨다
+  const roundIndex = Math.min(run.current_round, run.shuffle_order.length - 1);
+  return textById.get(run.shuffle_order[roundIndex]) ?? "";
+}
+
+function buildView(ctx: RunContext): ChallengeRunView {
+  const { adapter, run, textById } = ctx;
+  const target = currentTarget(ctx);
+  const targetUnits = adapter.splitUnits(target);
+  const endedReason = (run.ended_reason ?? null) as ChallengeRunView["endedReason"];
+  const attempts = parseAttempts(run.attempts);
+
+  return {
+    date: run.date,
+    currentRound: run.current_round,
+    totalRounds: run.shuffle_order.length,
+    score: run.score,
+    endedReason,
+    attempts: attempts.map(({ units, states }) => ({ units, states })),
+    maxAttempts: maxAttemptsForLength(targetUnits.length),
+    targetLength: targetUnits.length,
+    specialChars: deriveSpecialChars([...textById.values()]),
+    version: run.version,
+    ...(endedReason === "failed" ? { answer: target } : {}),
+  };
+}
+
+// 게이트(ADR 0006) 통과 여부 확인 후 본인 런을 로드/생성한다.
+async function loadRunContext(
+  deckId: string,
+  date: string,
+  anonId: string,
+  { createIfMissing }: { createIfMissing: boolean },
+): Promise<
+  | { ok: true; ctx: RunContext }
+  | { ok: false; message: string; gateLocked?: boolean }
+> {
+  const admin = createAdminClient();
+
+  const { data: deck } = await admin
+    .from("decks")
+    .select("id, script")
+    .eq("id", deckId)
+    .single();
+  if (!deck || !isSupportedScript(deck.script)) {
+    return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+  const adapter = getScriptAdapter(deck.script);
+
+  // 1. 데일리 완료 게이트 (솔브 OR 시도 소진 — ADR 0006)
+  const { data: dailyRound } = await admin
+    .from("daily_rounds")
+    .select("status")
+    .eq("anon_id", anonId)
+    .eq("deck_id", deckId)
+    .eq("date", date)
+    .maybeSingle();
+  if (!isChallengeUnlocked(dailyRound?.status ?? null)) {
+    return {
+      ok: false,
+      gateLocked: true,
+      message: "오늘의 데일리를 먼저 완료하면 챌린지가 열립니다.",
+    };
+  }
+
+  // 2. 런 확보 — shuffle_order는 시작 시 1회 계산해 영구 저장 (ADR 0015)
+  let { data: run } = await admin
+    .from("challenge_runs")
+    .select("*")
+    .eq("anon_id", anonId)
+    .eq("deck_id", deckId)
+    .eq("date", date)
+    .maybeSingle();
+
+  if (!run) {
+    if (!createIfMissing) return { ok: false, message: "챌린지를 먼저 시작해주세요." };
+
+    // 게이트 통과 = 데일리 라운드 존재 = lock 존재
+    const { data: lock } = await admin
+      .from("daily_words")
+      .select("active_word_ids")
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .single();
+    if (!lock) return { ok: false, message: "데일리 단어 잠금을 찾을 수 없습니다." };
+
+    const shuffle = deterministicShuffle(lock.active_word_ids, challengeSeed(deckId, date));
+
+    // PK 충돌(같은 날 재시작)은 무시하고 기존 런을 재읽기 — 암시적 이어하기 (ADR 0006)
+    await admin
+      .from("challenge_runs")
+      .upsert(
+        { anon_id: anonId, deck_id: deckId, date, shuffle_order: shuffle },
+        { onConflict: "anon_id,deck_id,date", ignoreDuplicates: true },
+      );
+
+    const { data: recreated } = await admin
+      .from("challenge_runs")
+      .select("*")
+      .eq("anon_id", anonId)
+      .eq("deck_id", deckId)
+      .eq("date", date)
+      .single();
+    if (!recreated) return { ok: false, message: "챌린지 시작에 실패했습니다." };
+    run = recreated;
+  }
+
+  // 3. 스냅샷 단어 텍스트 (서버 전용)
+  const { data: words } = await admin
+    .from("words")
+    .select("id, text")
+    .in("id", run.shuffle_order);
+  if (!words || words.length === 0) {
+    return { ok: false, message: "단어 스냅샷을 가져오는데 실패했습니다." };
+  }
+
+  return {
+    ok: true,
+    ctx: { adapter, run, textById: new Map(words.map((w) => [w.id, w.text])) },
+  };
+}
+
+function runStatus(run: ChallengeRunRow): { status: string; version: number } {
+  return { status: run.ended_reason ? run.ended_reason : "in_progress", version: run.version };
+}
+
+async function updateRunGuarded(
+  ctx: RunContext,
+  anonId: string,
+  deckId: string,
+  patch: Partial<Tables<"challenge_runs">>,
+): Promise<ChallengeRunRow | null> {
+  const admin = createAdminClient();
+  const { data: updated } = await admin
+    .from("challenge_runs")
+    .update({ ...patch, version: ctx.run.version + 1, updated_at: new Date().toISOString() })
+    .eq("anon_id", anonId)
+    .eq("deck_id", deckId)
+    .eq("date", ctx.run.date)
+    .eq("version", ctx.run.version) // DB 레벨 이중 가드 (ADR 0009)
+    .select("*");
+  return updated && updated.length > 0 ? updated[0] : null;
+}
+
+export async function startChallengeRun(
+  deckId: string,
+  clientDate: string,
+): Promise<ChallengeActionResponse> {
+  return safeAction(async () => {
+    if (!DATE_PATTERN.test(clientDate)) {
+      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+    }
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+
+    const loaded = await loadRunContext(deckId, clientDate, anonId, { createIfMissing: true });
+    if (!loaded.ok) {
+      return { success: false, message: loaded.message, gateLocked: loaded.gateLocked };
+    }
+    return { success: true, data: buildView(loaded.ctx), message: "챌린지를 시작했습니다." };
+  });
+}
+
+export async function submitChallengeGuess(input: {
+  deckId: string;
+  date: string;
+  guess: string;
+  expectedVersion: number;
+}): Promise<ChallengeActionResponse> {
+  return safeAction(async () => {
+    const { deckId, date, guess, expectedVersion } = input;
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션이 없습니다." };
+
+    const loaded = await loadRunContext(deckId, date, anonId, { createIfMissing: false });
+    if (!loaded.ok) {
+      return { success: false, message: loaded.message, gateLocked: loaded.gateLocked };
+    }
+    const ctx = loaded.ctx;
+    const { adapter, run, textById } = ctx;
+
+    const lockCheck = checkRoundAction(runStatus(run), expectedVersion);
+    if (!lockCheck.ok) {
+      return { success: false, conflict: true, message: lockCheck.message, data: buildView(ctx) };
+    }
+
+    const target = currentTarget(ctx);
+    const targetUnits = adapter.splitUnits(target);
+    const guessUnits = adapter.splitUnits(normalizeWord(guess.trim()));
+
+    if (guessUnits.length !== targetUnits.length) {
+      return {
+        success: false,
+        message: `글자 수가 맞지 않습니다 (${guessUnits.length}/${targetUnits.length}).`,
+      };
+    }
+
+    const guessJoined = guessUnits.join(" ");
+    const inSnapshot = [...textById.values()].some(
+      (text) => adapter.splitUnits(text).join(" ") === guessJoined,
+    );
+    if (!inSnapshot) {
+      return { success: false, message: "이 덱에 없는 단어입니다." };
+    }
+
+    const evaluated = evaluateGuess(guessUnits, targetUnits);
+    const states = evaluated.letters.map((l) => l.state);
+    const won = states.every((s) => s === "correct");
+    const attempts = parseAttempts(run.attempts);
+    const maxAttempts = maxAttemptsForLength(targetUnits.length);
+    const totalRounds = run.shuffle_order.length;
+
+    let patch: Partial<Tables<"challenge_runs">>;
+    let message: string;
+    if (won) {
+      const nextRound = run.current_round + 1;
+      const perfectClear = nextRound >= totalRounds;
+      patch = {
+        score: run.score + 1,
+        current_round: nextRound,
+        attempts: [] as unknown as Json, // 다음 라운드는 빈 기록으로 시작
+        ...(perfectClear ? { ended_reason: "completed" } : {}),
+      };
+      message = perfectClear ? "PERFECT CLEAR!" : `라운드 클리어! (${nextRound}/${totalRounds})`;
+    } else {
+      const newAttempts = [
+        ...attempts,
+        { units: guessUnits, states, at: new Date().toISOString() },
+      ];
+      const exhausted = newAttempts.length >= maxAttempts;
+      patch = {
+        attempts: newAttempts as unknown as Json,
+        // 한 라운드 소진 → 런 종료, score = 풀어낸 라운드 수 (ADR 0006)
+        ...(exhausted ? { ended_reason: "failed" } : {}),
+      };
+      message = exhausted ? "시도를 모두 소진했습니다." : "추측을 제출했습니다.";
+    }
+
+    const updated = await updateRunGuarded(ctx, anonId, deckId, patch);
+    if (!updated) {
+      const fresh = await loadRunContext(deckId, date, anonId, { createIfMissing: false });
+      return {
+        success: false,
+        conflict: true,
+        message: "다른 탭에서 진행됐습니다. 최신 상태로 갱신합니다.",
+        ...(fresh.ok ? { data: buildView(fresh.ctx) } : {}),
+      };
+    }
+
+    return { success: true, data: buildView({ ...ctx, run: updated }), message };
+  });
+}
+
+// 포기 — 런을 failed로 종료한다 (score는 현재까지 풀어낸 라운드 수 유지)
+export async function failChallengeRun(input: {
+  deckId: string;
+  date: string;
+  expectedVersion: number;
+}): Promise<ChallengeActionResponse> {
+  return safeAction(async () => {
+    const { deckId, date, expectedVersion } = input;
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션이 없습니다." };
+
+    const loaded = await loadRunContext(deckId, date, anonId, { createIfMissing: false });
+    if (!loaded.ok) {
+      return { success: false, message: loaded.message, gateLocked: loaded.gateLocked };
+    }
+    const ctx = loaded.ctx;
+
+    const lockCheck = checkRoundAction(runStatus(ctx.run), expectedVersion);
+    if (!lockCheck.ok) {
+      return { success: false, conflict: true, message: lockCheck.message, data: buildView(ctx) };
+    }
+
+    const updated = await updateRunGuarded(ctx, anonId, deckId, { ended_reason: "failed" });
+    if (!updated) {
+      return { success: false, conflict: true, message: "다른 탭에서 진행됐습니다." };
+    }
+    return { success: true, data: buildView({ ...ctx, run: updated }), message: "챌린지를 포기했습니다." };
+  });
+}
+
+// 명시적 완료 처리 — 모든 라운드를 클리어했는데 종료 마킹이 누락된 경우의 멱등 마무리.
+// (정상 경로에서는 submitChallengeGuess가 마지막 라운드에서 자동으로 completed 처리한다)
+export async function completeChallengeRun(input: {
+  deckId: string;
+  date: string;
+  expectedVersion: number;
+}): Promise<ChallengeActionResponse> {
+  return safeAction(async () => {
+    const { deckId, date, expectedVersion } = input;
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션이 없습니다." };
+
+    const loaded = await loadRunContext(deckId, date, anonId, { createIfMissing: false });
+    if (!loaded.ok) {
+      return { success: false, message: loaded.message, gateLocked: loaded.gateLocked };
+    }
+    const ctx = loaded.ctx;
+
+    if (ctx.run.ended_reason === "completed") {
+      return { success: true, data: buildView(ctx), message: "이미 완료된 챌린지입니다." };
+    }
+    const lockCheck = checkRoundAction(runStatus(ctx.run), expectedVersion);
+    if (!lockCheck.ok) {
+      return { success: false, conflict: true, message: lockCheck.message, data: buildView(ctx) };
+    }
+    if (ctx.run.current_round < ctx.run.shuffle_order.length) {
+      return { success: false, message: "아직 남은 라운드가 있습니다." };
+    }
+
+    const updated = await updateRunGuarded(ctx, anonId, deckId, { ended_reason: "completed" });
+    if (!updated) {
+      return { success: false, conflict: true, message: "다른 탭에서 진행됐습니다." };
+    }
+    return { success: true, data: buildView({ ...ctx, run: updated }), message: "PERFECT CLEAR!" };
+  });
+}

--- a/app/d/[id]/play/page.tsx
+++ b/app/d/[id]/play/page.tsx
@@ -2,13 +2,14 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase-server";
 import { isSupportedScript } from "@/lib/scripts";
 import { DailyGame } from "@/components/DailyGame";
+import { ChallengeGame } from "@/components/ChallengeGame";
 
 interface PlayPageProps {
   params: Promise<{ id: string }>;
   searchParams: Promise<{ mode?: string }>;
 }
 
-// /d/{deck_id}/play?mode=daily — 단어 리스트는 HTML/props에 절대 포함하지 않는다 (ADR 0008)
+// /d/{deck_id}/play?mode=daily|challenge — 단어 리스트는 HTML/props에 절대 포함하지 않는다 (ADR 0008)
 export default async function PlayPage({ params, searchParams }: PlayPageProps) {
   const { id } = await params;
   const { mode = "daily" } = await searchParams;
@@ -21,18 +22,19 @@ export default async function PlayPage({ params, searchParams }: PlayPageProps) 
     .single();
   if (!deck || !isSupportedScript(deck.script)) notFound();
 
-  if (mode !== "daily") {
-    return (
-      <main className="mx-auto max-w-xl px-4 py-8 text-center text-sm text-muted-foreground">
-        챌린지 모드는 준비 중입니다.
-      </main>
-    );
-  }
+  if (mode !== "daily" && mode !== "challenge") notFound();
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
-      <h1 className="text-center text-2xl font-bold">{deck.name}</h1>
-      <DailyGame deckId={deck.id} deckName={deck.name} script={deck.script} />
+      <h1 className="text-center text-2xl font-bold">
+        {deck.name}
+        {mode === "challenge" && <span className="ml-2 text-base font-normal">🔥 챌린지</span>}
+      </h1>
+      {mode === "challenge" ? (
+        <ChallengeGame deckId={deck.id} deckName={deck.name} script={deck.script} />
+      ) : (
+        <DailyGame deckId={deck.id} deckName={deck.name} script={deck.script} />
+      )}
     </main>
   );
 }

--- a/components/ChallengeGame.tsx
+++ b/components/ChallengeGame.tsx
@@ -5,19 +5,19 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { GameBoard } from "@/components/GameBoard";
 import { SmartKeyboard } from "@/components/SmartKeyboard";
-import { ResultScreen } from "@/components/ResultScreen";
+import { GateLockedView } from "@/components/GateLockedView";
+import { PerfectClearScreen } from "@/components/PerfectClearScreen";
 import {
-  startDailyRound,
-  submitDailyGuess,
-  endDailyRound,
-  type DailyActionResponse,
-  type DailyRoundView,
-} from "@/app/actions/daily";
+  startChallengeRun,
+  submitChallengeGuess,
+  failChallengeRun,
+  type ChallengeActionResponse,
+  type ChallengeRunView,
+} from "@/app/actions/challenge";
 import { deriveKeyStates } from "@/lib/game-keyboard";
 import { getScriptAdapter } from "@/lib/scripts";
 import type { ScriptId } from "@/lib/scripts/types";
 
-// 데일리는 client-local date 기준 (ADR 0015 — date는 보안 경계가 아님)
 function localDate(): string {
   const now = new Date();
   const y = now.getFullYear();
@@ -26,15 +26,16 @@ function localDate(): string {
   return `${y}-${m}-${d}`;
 }
 
-interface DailyGameProps {
+interface ChallengeGameProps {
   deckId: string;
   deckName: string;
   script: ScriptId;
 }
 
-export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
+export function ChallengeGame({ deckId, deckName, script }: ChallengeGameProps) {
   const adapter = useMemo(() => getScriptAdapter(script), [script]);
-  const [view, setView] = useState<DailyRoundView | null>(null);
+  const [view, setView] = useState<ChallengeRunView | null>(null);
+  const [gateLocked, setGateLocked] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [currentUnits, setCurrentUnits] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -42,9 +43,10 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
 
   useEffect(() => {
     let cancelled = false;
-    startDailyRound(deckId, date).then((result) => {
+    startChallengeRun(deckId, date).then((result) => {
       if (cancelled) return;
       if (result.success && result.data) setView(result.data);
+      else if (result.gateLocked) setGateLocked(true);
       else setLoadError(result.message);
     });
     return () => {
@@ -52,14 +54,13 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
     };
   }, [deckId, date]);
 
-  // conflict(다른 탭 진행) 응답은 최신 뷰로 강제 갱신한다 (ADR 0009)
-  const applyResult = useCallback((result: DailyActionResponse) => {
+  const applyResult = useCallback((result: ChallengeActionResponse) => {
     if (result.data) setView(result.data);
     if (!result.success) toast.error(result.message);
-    else if (result.data?.status === "completed") toast.success(result.message);
+    else toast.success(result.message);
   }, []);
 
-  const finished = view !== null && view.status !== "in_progress";
+  const ended = view !== null && view.endedReason !== null;
   const keyStates = useMemo(
     () => (view ? deriveKeyStates(view.attempts, adapter) : {}),
     [view, adapter],
@@ -67,12 +68,12 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
 
   const handleKey = useCallback(
     (char: string) => {
-      if (!view || finished) return;
+      if (!view || ended) return;
       setCurrentUnits((prev) =>
         prev.length >= view.targetLength ? prev : [...prev, adapter.normalizeChar(char)],
       );
     },
-    [view, finished, adapter],
+    [view, ended, adapter],
   );
 
   const handleBackspace = useCallback(() => {
@@ -80,14 +81,14 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
   }, []);
 
   const handleEnter = useCallback(async () => {
-    if (!view || finished || submitting) return;
+    if (!view || ended || submitting) return;
     if (currentUnits.length !== view.targetLength) {
       toast.error(`${view.targetLength}글자를 입력해주세요.`);
       return;
     }
     setSubmitting(true);
     try {
-      const result = await submitDailyGuess({
+      const result = await submitChallengeGuess({
         deckId,
         date,
         guess: currentUnits.join(""),
@@ -98,38 +99,69 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
     } finally {
       setSubmitting(false);
     }
-  }, [view, finished, submitting, currentUnits, deckId, date, applyResult]);
+  }, [view, ended, submitting, currentUnits, deckId, date, applyResult]);
 
   const handleGiveUp = useCallback(async () => {
-    if (!view || finished || submitting) return;
+    if (!view || ended || submitting) return;
     setSubmitting(true);
     try {
-      const result = await endDailyRound({ deckId, date, expectedVersion: view.version });
+      const result = await failChallengeRun({ deckId, date, expectedVersion: view.version });
       applyResult(result);
     } finally {
       setSubmitting(false);
     }
-  }, [view, finished, submitting, deckId, date, applyResult]);
+  }, [view, ended, submitting, deckId, date, applyResult]);
 
-  if (loadError) {
-    return <p className="text-center text-sm text-destructive">{loadError}</p>;
-  }
-  if (!view) {
-    return <p className="text-center text-sm text-muted-foreground">불러오는 중...</p>;
+  const handleCopyFailed = useCallback(async () => {
+    if (!view) return;
+    try {
+      await navigator.clipboard.writeText(
+        `${deckName} 챌린지 ${view.date} ${view.score}/${view.totalRounds} 🔥`,
+      );
+      toast.success("결과를 복사했습니다.");
+    } catch {
+      toast.error("클립보드 복사에 실패했습니다.");
+    }
+  }, [view, deckName]);
+
+  if (gateLocked) return <GateLockedView deckId={deckId} />;
+  if (loadError) return <p className="text-center text-sm text-destructive">{loadError}</p>;
+  if (!view) return <p className="text-center text-sm text-muted-foreground">불러오는 중...</p>;
+
+  if (view.endedReason === "completed") {
+    return <PerfectClearScreen deckName={deckName} date={view.date} totalRounds={view.totalRounds} />;
   }
 
   return (
     <div className="space-y-6">
+      <p className="text-center text-sm text-muted-foreground">
+        라운드 {Math.min(view.currentRound + 1, view.totalRounds)} / {view.totalRounds} · 점수{" "}
+        {view.score}
+      </p>
+
       <GameBoard
         attempts={view.attempts}
         currentUnits={currentUnits}
         targetLength={view.targetLength}
         maxAttempts={view.maxAttempts}
-        finished={finished}
+        finished={ended}
       />
 
-      {finished ? (
-        <ResultScreen deckName={deckName} view={view} deckId={deckId} />
+      {view.endedReason === "failed" ? (
+        <div className="space-y-3 rounded-lg border p-4 text-center">
+          <p className="text-lg font-bold">
+            {view.score}/{view.totalRounds} 🔥
+          </p>
+          {view.answer && (
+            <p className="text-sm text-muted-foreground">
+              막힌 단어: <span className="font-semibold text-foreground">{view.answer}</span>
+            </p>
+          )}
+          <Button type="button" onClick={handleCopyFailed}>
+            결과 복사
+          </Button>
+          <p className="text-xs text-muted-foreground">내일 다시 도전할 수 있습니다.</p>
+        </div>
       ) : (
         <>
           <SmartKeyboard

--- a/components/GateLockedView.tsx
+++ b/components/GateLockedView.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface GateLockedViewProps {
+  deckId: string;
+}
+
+// ADR 0006: 챌린지는 그날 데일리 완료(솔브 OR 시도 소진) 후 잠금 해제
+export function GateLockedView({ deckId }: GateLockedViewProps) {
+  return (
+    <div className="space-y-4 rounded-lg border p-8 text-center">
+      <p className="text-4xl">🔒</p>
+      <p className="font-medium">오늘의 데일리를 먼저 풀어야 챌린지가 열립니다.</p>
+      <p className="text-sm text-muted-foreground">
+        데일리를 완료하면(정답이 아니어도) 챌린지가 잠금 해제됩니다.
+      </p>
+      <Button asChild>
+        <Link href={`/d/${deckId}/play?mode=daily`}>오늘의 데일리 풀러 가기</Link>
+      </Button>
+    </div>
+  );
+}

--- a/components/PerfectClearScreen.tsx
+++ b/components/PerfectClearScreen.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+interface PerfectClearScreenProps {
+  deckName: string;
+  date: string;
+  totalRounds: number;
+}
+
+export function PerfectClearScreen({ deckName, date, totalRounds }: PerfectClearScreenProps) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        `🎉 PERFECT CLEAR — ${deckName} 챌린지 ${date} ${totalRounds}/${totalRounds}`,
+      );
+      toast.success("결과를 복사했습니다.");
+    } catch {
+      toast.error("클립보드 복사에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border-2 border-green-500 p-8 text-center">
+      <p className="text-4xl">🎉</p>
+      <p className="text-2xl font-bold tracking-wide">PERFECT CLEAR</p>
+      <p className="text-sm text-muted-foreground">
+        덱의 모든 단어({totalRounds}개)를 풀어냈습니다!
+      </p>
+      <Button type="button" onClick={handleCopy}>
+        결과 복사
+      </Button>
+    </div>
+  );
+}

--- a/components/ResultScreen.tsx
+++ b/components/ResultScreen.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import type { DailyRoundView } from "@/app/actions/daily";
@@ -22,9 +23,11 @@ export function buildShareText(deckName: string, view: DailyRoundView): string {
 interface ResultScreenProps {
   deckName: string;
   view: DailyRoundView;
+  /** 전달 시 챌린지 진입 CTA 표시 — 데일리 완료가 챌린지를 잠금 해제한다 (ADR 0006) */
+  deckId?: string;
 }
 
-export function ResultScreen({ deckName, view }: ResultScreenProps) {
+export function ResultScreen({ deckName, view, deckId }: ResultScreenProps) {
   const won = view.status === "completed";
 
   const handleCopy = async () => {
@@ -47,9 +50,16 @@ export function ResultScreen({ deckName, view }: ResultScreenProps) {
       <p className="text-sm text-muted-foreground">
         {won ? `${view.attempts.length}/${view.maxAttempts} 시도` : `X/${view.maxAttempts}`}
       </p>
-      <Button type="button" onClick={handleCopy}>
-        결과 복사
-      </Button>
+      <div className="flex justify-center gap-2">
+        <Button type="button" onClick={handleCopy}>
+          결과 복사
+        </Button>
+        {deckId && (
+          <Button asChild variant="outline">
+            <Link href={`/d/${deckId}/play?mode=challenge`}>🔥 챌린지 도전</Link>
+          </Button>
+        )}
+      </div>
       <p className="text-xs text-muted-foreground">내일 새로운 단어가 잠금 해제됩니다.</p>
     </div>
   );

--- a/lib/challenge.test.ts
+++ b/lib/challenge.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  challengeSeed,
+  deterministicShuffle,
+  isChallengeUnlocked,
+} from './challenge';
+import { dailySeed } from './game-seed';
+
+describe('challengeSeed', () => {
+  it('데일리 시드와 다르다 (salt "endurance" — ADR 0006)', () => {
+    expect(challengeSeed('deck-1', '2026-06-12')).not.toBe(dailySeed('deck-1', '2026-06-12'));
+  });
+
+  it('같은 입력이면 항상 같다', () => {
+    expect(challengeSeed('deck-1', '2026-06-12')).toBe(challengeSeed('deck-1', '2026-06-12'));
+  });
+});
+
+describe('deterministicShuffle — 셔플 결정성 (AC)', () => {
+  const ids = Array.from({ length: 50 }, (_, i) => `w${i}`);
+
+  it('같은 시드면 같은 순서다 — 두 사용자 같은 (deck, date) 보장', () => {
+    const seed = challengeSeed('deck-1', '2026-06-12');
+    expect(deterministicShuffle(ids, seed)).toEqual(deterministicShuffle(ids, seed));
+  });
+
+  it('원소를 잃거나 더하지 않는 순열이다', () => {
+    const shuffled = deterministicShuffle(ids, 12345);
+    expect([...shuffled].sort()).toEqual([...ids].sort());
+    expect(shuffled).toHaveLength(ids.length);
+  });
+
+  it('다른 시드면 (높은 확률로) 다른 순서다', () => {
+    expect(deterministicShuffle(ids, 1)).not.toEqual(deterministicShuffle(ids, 2));
+  });
+
+  it('입력 배열을 변경하지 않는다', () => {
+    const original = [...ids];
+    deterministicShuffle(ids, 999);
+    expect(ids).toEqual(original);
+  });
+
+  it('원소 1개도 동작한다', () => {
+    expect(deterministicShuffle(['only'], 7)).toEqual(['only']);
+  });
+});
+
+describe('isChallengeUnlocked — 데일리 게이트 (ADR 0006, AC)', () => {
+  it('데일리 솔브(completed) → 해제', () => {
+    expect(isChallengeUnlocked('completed')).toBe(true);
+  });
+
+  it('시도 소진/포기(failed)도 완료로 인정 → 해제', () => {
+    expect(isChallengeUnlocked('failed')).toBe(true);
+  });
+
+  it('진행 중이거나 라운드 미시작이면 잠금', () => {
+    expect(isChallengeUnlocked('in_progress')).toBe(false);
+    expect(isChallengeUnlocked(null)).toBe(false);
+  });
+});

--- a/lib/challenge.ts
+++ b/lib/challenge.ts
@@ -1,0 +1,40 @@
+import { dailySeed } from "./game-seed";
+
+// 챌린지 모드 순수 로직 (ADR 0005, 0006, 0015)
+// - 셔플은 결정적: 같은 (deck, date)면 모든 사용자가 같은 시퀀스
+// - 시드는 데일리와 별개 salt ("endurance")
+// - 게이트: 그날 데일리 라운드 완료(솔브 OR 시도 소진) 후 잠금 해제
+
+export const CHALLENGE_SALT = "endurance";
+
+export function challengeSeed(deckId: string, date: string): number {
+  return dailySeed(deckId, date, CHALLENGE_SALT);
+}
+
+// mulberry32 — 시드 기반 결정적 PRNG (crypto 불필요)
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// 시드 기반 Fisher-Yates. 입력을 변경하지 않고 새 배열을 반환한다.
+export function deterministicShuffle<T>(items: readonly T[], seed: number): T[] {
+  const arr = [...items];
+  const rand = mulberry32(seed);
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+// ADR 0006: 데일리 "완료"는 솔브(completed)뿐 아니라 시도 소진/포기(failed)도 인정
+export function isChallengeUnlocked(dailyRoundStatus: string | null): boolean {
+  return dailyRoundStatus === "completed" || dailyRoundStatus === "failed";
+}


### PR DESCRIPTION
Fixes #74

> [!NOTE]
> **Stacked PR** — base가 #104([T3a] challenge_runs 스키마)입니다. 머지 순서: #104 → 본 PR. (#104 머지 후 base를 main으로 변경해야 합니다 — 제가 처리합니다)

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> 챌린지 모드(결정적 셔플·데일리 게이트·다라운드 진행)가 ADR 0005/0006/0009/0015대로 구현되었는가?

## Scope

### 포함 (9 files)
- **`lib/challenge.ts`** (+테스트 11개)
  - `deterministicShuffle`: mulberry32 PRNG + Fisher-Yates — **같은 (deck, date)면 모든 사용자 동일 셔플** (AC), 순열 보존·입력 불변 테스트
  - `challengeSeed`: `hash(deck+date+"endurance")` — 데일리 시드와 분리 (ADR 0006)
  - `isChallengeUnlocked`: **솔브(completed) OR 시도 소진/포기(failed) 모두 게이트 통과** (ADR 0006 "데일리 완료 = 시도 다 써도 인정")
- **`app/actions/challenge.ts`**
  - `startChallengeRun`: 게이트 체크 → `shuffle_order` **1회 계산 후 영구 저장, 재로드 시 저장값 사용** (AC, ADR 0015). 같은 날 재시작은 PK 충돌 무시 + 기존 런 재개(암시적 이어하기 — ADR 0006)
  - `submitChallengeGuess`: 라운드 클리어 → score+1·다음 라운드·attempts 리셋, **한 라운드 소진 → `ended_reason='failed'`·score 유지** (AC), 전체 클리어 → `completed`
  - `failChallengeRun`(포기), `completeChallengeRun`(멱등 마무리 — 정상 경로는 submit이 자동 처리)
  - version 낙관적 락: 앱 검증 + DB `eq(version)` 이중 가드, conflict 시 최신 뷰 반환
  - 단어 텍스트 미노출, failed 시 막힌 단어만 공개 (ADR 0008)
- **UI**: `ChallengeGame`(라운드 전환, GameBoard/SmartKeyboard 재사용), `GateLockedView`(🔒 + 데일리 유도 — AC), `PerfectClearScreen`(🎉 + 복사 — AC), failed 결과 **"n/total 🔥" 클립보드 복사** (AC)
- **연결**: play 라우트 `mode=challenge` 분기, 데일리 ResultScreen에 챌린지 CTA (ADR 0006 견인 흐름 — 없으면 챌린지 도달 불가)

### 제외
- 점수 랭킹 — ADR 0003 (공개 랭킹 없음)
- 댓글/신고 — T4/T7

## Scope Check

```
verdict: APPROVE
primary layer: game-state
secondary layers: test
ADR count: 0
file count: 9
decision interlock: interlocked (CTA·mode 분기·게임 로직이 단일 decision에 종속)
split suggestion: 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #74 AC)

- [x] 데일리 미완료 시 잠금 + "데일리 먼저" 안내 (GateLockedView)
- [x] shuffle_order 계산 후 저장, 재로드 시 저장값 사용 (upsert ignoreDuplicates + 재읽기)
- [x] 결정성: 같은 (deck, date) → 같은 shuffle_order (테스트)
- [x] 같은 날 두 번째 시작 차단 — PK 충돌 시 기존 런 재개
- [x] 라운드 소진 → failed, score = 풀어낸 라운드 수
- [x] 전체 클리어 → PERFECT CLEAR 화면
- [x] 클립보드 복사 ("n/total 🔥" / "🎉 PERFECT CLEAR")
- [x] Vitest: 셔플 결정성·게이트 검증 (신규 11개, 총 146개 통과)
- [x] `pnpm test` / `pnpm build` / typecheck / lint 통과
- [ ] 라이브 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_