### PR TITLE
feat(comments): [T4] (deck, date) thread 댓글 + 가시성 게이트

### DIFF
--- a/app/actions/comment.ts
+++ b/app/actions/comment.ts
@@ -1,0 +1,229 @@
+"use server";
+
+import { createAdminClient } from "@/lib/supabase-admin";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import { getOrCreateAnonUserId } from "@/lib/anon-session";
+import { checkThreadVisibility } from "@/lib/comment-gate";
+import {
+  hashPassword,
+  verifyPassword,
+  validateNick,
+  validatePasswordLength,
+  formatDisplayNick,
+} from "@/lib/identity";
+
+// 댓글의 모든 read/write/delete/report는 server action only (ADR 0007, #47).
+// comments 테이블은 RLS 정책이 없어 client direct 접근이 전면 차단된다.
+
+export interface CommentView {
+  id: string;
+  threadDate: string;
+  displayNick: string;
+  text: string;
+  createdAt: string;
+  isMine: boolean;
+}
+
+export interface CommentThreadsView {
+  /** threadDate DESC 정렬, 각 thread 내부는 최신순 */
+  threads: { date: string; comments: CommentView[] }[];
+  /** 오늘 thread 잠금 여부 — 데일리 미완료 (ADR 0007 룰 2) */
+  todayLocked: boolean;
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const COMMENT_MAX_LENGTH = 500;
+
+async function dailyStatusFor(
+  deckId: string,
+  date: string,
+  anonId: string,
+): Promise<string | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("daily_rounds")
+    .select("status")
+    .eq("anon_id", anonId)
+    .eq("deck_id", deckId)
+    .eq("date", date)
+    .maybeSingle();
+  return data?.status ?? null;
+}
+
+export async function getComments(
+  deckId: string,
+  readerToday: string,
+): Promise<ActionResponse<CommentThreadsView>> {
+  return safeAction(async () => {
+    if (!DATE_PATTERN.test(readerToday)) {
+      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+    }
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+
+    const todayStatus = await dailyStatusFor(deckId, readerToday, anonId);
+    const todayGate = checkThreadVisibility(readerToday, readerToday, todayStatus);
+
+    const admin = createAdminClient();
+    // 게이트 룰: 과거 thread 전체 + (게이트 통과 시) 오늘 thread.
+    // 미래 thread(T > readerToday)는 쿼리에서부터 제외 — 무조건 차단 (룰 3)
+    const maxDate = todayGate.visible ? readerToday : readerToday; // lte 기준
+    let query = admin
+      .from("comments")
+      .select("id, thread_date, anon_id, nick, text, created_at")
+      .eq("deck_id", deckId)
+      .eq("deleted", false)
+      .eq("hidden", false)
+      .order("thread_date", { ascending: false })
+      .order("created_at", { ascending: false })
+      .limit(200);
+    query = todayGate.visible ? query.lte("thread_date", maxDate) : query.lt("thread_date", maxDate);
+
+    const { data: rows, error } = await query;
+    if (error) {
+      return { success: false, message: `댓글을 가져오는데 실패했습니다: ${error.message}` };
+    }
+
+    const threads: CommentThreadsView["threads"] = [];
+    for (const row of rows ?? []) {
+      const view: CommentView = {
+        id: row.id,
+        threadDate: row.thread_date,
+        displayNick: formatDisplayNick(row.nick, row.anon_id),
+        text: row.text,
+        createdAt: row.created_at,
+        isMine: row.anon_id === anonId,
+      };
+      const last = threads[threads.length - 1];
+      if (last && last.date === row.thread_date) last.comments.push(view);
+      else threads.push({ date: row.thread_date, comments: [view] });
+    }
+
+    return {
+      success: true,
+      data: { threads, todayLocked: !todayGate.visible },
+      message: "댓글을 가져왔습니다.",
+    };
+  });
+}
+
+export async function createComment(input: {
+  deckId: string;
+  text: string;
+  nick: string;
+  password: string;
+  /** 작성자 client local date — thread_date로 캡처 (ADR 0007) */
+  writerToday: string;
+}): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const { deckId, text, nick, password, writerToday } = input;
+
+    if (!DATE_PATTERN.test(writerToday)) {
+      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+    }
+    const trimmed = text.trim();
+    const fieldErrors: { [key: string]: string[] } = {};
+    if (!trimmed || trimmed.length > COMMENT_MAX_LENGTH) {
+      fieldErrors.text = [`댓글은 1~${COMMENT_MAX_LENGTH}자여야 합니다.`];
+    }
+    if (!validateNick(nick.trim())) fieldErrors.nick = ["닉네임은 1~20자, '#' 없이 입력해야 합니다."];
+    if (!validatePasswordLength(password)) fieldErrors.password = ["비밀번호는 4~64자여야 합니다."];
+    if (Object.keys(fieldErrors).length > 0) {
+      return { success: false, message: "입력값을 확인해주세요.", fieldErrors };
+    }
+
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+
+    // 작성도 가시성 게이트를 통과해야 한다 (잠긴 thread에 작성 불가)
+    const todayStatus = await dailyStatusFor(deckId, writerToday, anonId);
+    const gate = checkThreadVisibility(writerToday, writerToday, todayStatus);
+    if (!gate.visible) {
+      return { success: false, message: "오늘의 데일리를 완료하면 댓글을 쓸 수 있습니다." };
+    }
+
+    const admin = createAdminClient();
+    const { data: deck } = await admin.from("decks").select("id").eq("id", deckId).single();
+    if (!deck) return { success: false, message: "덱을 찾을 수 없습니다." };
+
+    const pwHash = await hashPassword(password);
+    const { error } = await admin.from("comments").insert({
+      deck_id: deckId,
+      thread_date: writerToday,
+      anon_id: anonId,
+      nick: nick.trim(),
+      pw_hash: pwHash,
+      text: trimmed,
+    });
+    if (error) {
+      return { success: false, message: `댓글 작성에 실패했습니다: ${error.message}` };
+    }
+
+    return { success: true, message: "댓글을 남겼습니다." };
+  });
+}
+
+// nick+pw 일치 시 삭제 — 디바이스 무관 (ADR 0007). soft delete.
+export async function deleteComment(input: {
+  commentId: string;
+  nick: string;
+  password: string;
+}): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const { commentId, nick, password } = input;
+    const admin = createAdminClient();
+
+    const { data: comment } = await admin
+      .from("comments")
+      .select("id, nick, pw_hash, deleted")
+      .eq("id", commentId)
+      .single();
+    if (!comment || comment.deleted) {
+      return { success: false, message: "댓글을 찾을 수 없습니다." };
+    }
+
+    // enumeration 방어: 무엇이 틀렸는지 구분하지 않는다 (ADR 0001)
+    const nickMatches = comment.nick === nick.trim();
+    const pwMatches = await verifyPassword(password, comment.pw_hash);
+    if (!nickMatches || !pwMatches) {
+      return { success: false, message: "닉네임 또는 비밀번호가 올바르지 않습니다." };
+    }
+
+    const { error } = await admin
+      .from("comments")
+      .update({ deleted: true })
+      .eq("id", commentId);
+    if (error) {
+      return { success: false, message: `댓글 삭제에 실패했습니다: ${error.message}` };
+    }
+    return { success: true, message: "댓글을 삭제했습니다." };
+  });
+}
+
+// 신고 — report_count 증가만 수행. 자동 가림 임계치 처리는 T7(#50) 모더레이션 트랙.
+export async function reportComment(commentId: string): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+
+    const admin = createAdminClient();
+    const { data: comment } = await admin
+      .from("comments")
+      .select("id, report_count, deleted")
+      .eq("id", commentId)
+      .single();
+    if (!comment || comment.deleted) {
+      return { success: false, message: "댓글을 찾을 수 없습니다." };
+    }
+
+    const { error } = await admin
+      .from("comments")
+      .update({ report_count: comment.report_count + 1 })
+      .eq("id", commentId);
+    if (error) {
+      return { success: false, message: `신고에 실패했습니다: ${error.message}` };
+    }
+    return { success: true, message: "신고가 접수되었습니다." };
+  });
+}

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getDeckById } from "@/app/actions/deck";
 import { DeckMetaCard } from "@/components/DeckMetaCard";
+import { CommentThread } from "@/components/CommentThread";
 import { Button } from "@/components/ui/button";
 
 interface DeckPageProps {
@@ -27,6 +28,8 @@ export default async function DeckPage({ params }: DeckPageProps) {
           <Link href={`/d/${deck.id}/edit`}>편집</Link>
         </Button>
       </div>
+
+      <CommentThread deckId={deck.id} />
     </main>
   );
 }

--- a/components/CommentDeleteButton.tsx
+++ b/components/CommentDeleteButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { actionWithToast } from "@/lib/action-with-toast";
+import { deleteComment } from "@/app/actions/comment";
+import { loadCachedCredentials } from "@/lib/credentialCache";
+
+interface CommentDeleteButtonProps {
+  commentId: string;
+  onDeleted: () => void;
+}
+
+// nick+pw 일치 시 삭제 — 디바이스 무관 (ADR 0007). 검증은 서버에서만.
+export function CommentDeleteButton({ commentId, onDeleted }: CommentDeleteButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [nick, setNick] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const cached = loadCachedCredentials();
+    if (cached) {
+      setNick(cached.nick);
+      setPassword(cached.password);
+    }
+  }, [open]);
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const result = await actionWithToast(() =>
+        deleteComment({ commentId, nick, password }),
+      );
+      if (result.success) {
+        setOpen(false);
+        onDeleted();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+        >
+          삭제
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64">
+        <form onSubmit={handleDelete} className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            작성할 때 쓴 닉네임과 비밀번호를 입력하세요.
+          </p>
+          <Input
+            value={nick}
+            onChange={(e) => setNick(e.target.value)}
+            placeholder="닉네임"
+            required
+          />
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호"
+            required
+          />
+          <Button type="submit" size="sm" disabled={submitting} className="w-full">
+            {submitting ? "삭제 중..." : "삭제"}
+          </Button>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/CommentForm.tsx
+++ b/components/CommentForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { actionWithToast } from "@/lib/action-with-toast";
+import { createComment } from "@/app/actions/comment";
+import { loadCachedCredentials, saveCachedCredentials } from "@/lib/credentialCache";
+
+interface CommentFormProps {
+  deckId: string;
+  writerToday: string;
+  onCreated: () => void;
+}
+
+export function CommentForm({ deckId, writerToday, onCreated }: CommentFormProps) {
+  const [text, setText] = useState("");
+  const [nick, setNick] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // ADR 0001: 단일 (nick, pw) convention — localStorage 캐시로 자동 채움
+  useEffect(() => {
+    const cached = loadCachedCredentials();
+    if (cached) {
+      setNick(cached.nick);
+      setPassword(cached.password);
+    }
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const result = await actionWithToast(() =>
+        createComment({ deckId, text, nick, password, writerToday }),
+      );
+      if (result.success) {
+        saveCachedCredentials({ nick: nick.trim(), password });
+        setText("");
+        onCreated();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="오늘의 단어에 대해 한마디 (결과를 붙여넣어도 좋아요)"
+        maxLength={500}
+        rows={3}
+        required
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          value={nick}
+          onChange={(e) => setNick(e.target.value)}
+          placeholder="닉네임"
+          maxLength={20}
+          className="w-32"
+          required
+        />
+        <Input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="비밀번호"
+          minLength={4}
+          maxLength={64}
+          className="w-32"
+          required
+        />
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "작성 중..." : "댓글 남기기"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { CommentForm } from "@/components/CommentForm";
+import { CommentDeleteButton } from "@/components/CommentDeleteButton";
+import { getComments, reportComment, type CommentThreadsView } from "@/app/actions/comment";
+import { actionWithToast } from "@/lib/action-with-toast";
+
+function localDate(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+interface CommentThreadProps {
+  deckId: string;
+}
+
+// (deck, date) 단위 thread를 날짜 헤더로 그룹해 최신순 표시 (#47).
+// 가시성 게이트는 server action(getComments)이 계산한다 — 클라이언트는 결과만 렌더.
+export function CommentThread({ deckId }: CommentThreadProps) {
+  const [view, setView] = useState<CommentThreadsView | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [today] = useState(localDate);
+
+  const reload = useCallback(async () => {
+    const result = await getComments(deckId, today);
+    if (result.success && result.data) {
+      setView(result.data);
+      setLoadError(null);
+    } else {
+      setLoadError(result.message);
+    }
+  }, [deckId, today]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleReport = async (commentId: string) => {
+    await actionWithToast(() => reportComment(commentId));
+  };
+
+  if (loadError) return <p className="text-sm text-destructive">{loadError}</p>;
+  if (!view) return <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>;
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-lg font-bold">댓글</h2>
+
+      {view.todayLocked ? (
+        <div className="rounded-lg border p-4 text-center text-sm text-muted-foreground">
+          🔒 오늘의 데일리를 완료하면 오늘 댓글을 보고 쓸 수 있습니다.
+        </div>
+      ) : (
+        <CommentForm deckId={deckId} writerToday={today} onCreated={reload} />
+      )}
+
+      {view.threads.length === 0 && !view.todayLocked && (
+        <p className="text-sm text-muted-foreground">아직 댓글이 없습니다. 첫 댓글을 남겨보세요!</p>
+      )}
+
+      {view.threads.map((thread) => (
+        <div key={thread.date} className="space-y-2">
+          <h3 className="text-sm font-semibold text-muted-foreground">{thread.date}</h3>
+          <ul className="space-y-3">
+            {thread.comments.map((comment) => (
+              <li key={comment.id} className="rounded-lg border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium">{comment.displayNick}</span>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs text-muted-foreground"
+                      onClick={() => handleReport(comment.id)}
+                    >
+                      신고
+                    </Button>
+                    <CommentDeleteButton commentId={comment.id} onDeleted={reload} />
+                  </div>
+                </div>
+                <p className="mt-1 whitespace-pre-wrap text-sm">{comment.text}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/lib/comment-gate.test.ts
+++ b/lib/comment-gate.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { checkThreadVisibility } from './comment-gate';
+
+const TODAY = '2026-06-12';
+const YESTERDAY = '2026-06-11';
+const TOMORROW = '2026-06-13';
+
+describe('checkThreadVisibility — 게이트 룰 매트릭스 (ADR 0007, AC)', () => {
+  it('과거 thread는 풀이 이력 무관 항상 공개', () => {
+    for (const status of [null, 'in_progress', 'completed', 'failed']) {
+      expect(checkThreadVisibility(YESTERDAY, TODAY, status)).toEqual({ visible: true });
+    }
+  });
+
+  it('오늘 thread는 데일리 종료(솔브) 후 공개', () => {
+    expect(checkThreadVisibility(TODAY, TODAY, 'completed')).toEqual({ visible: true });
+  });
+
+  it('오늘 thread는 시도 소진/포기(failed)도 공개 — 더 플레이할 수 없어 스포 무관', () => {
+    expect(checkThreadVisibility(TODAY, TODAY, 'failed')).toEqual({ visible: true });
+  });
+
+  it('오늘 thread는 미풀이/진행 중이면 잠금', () => {
+    expect(checkThreadVisibility(TODAY, TODAY, null)).toEqual({
+      visible: false,
+      reason: 'today_locked',
+    });
+    expect(checkThreadVisibility(TODAY, TODAY, 'in_progress')).toEqual({
+      visible: false,
+      reason: 'today_locked',
+    });
+  });
+
+  it('미래 thread는 무조건 차단 — 풀이 상태를 위조해도 룰 3이 우선 (AC future block)', () => {
+    // Sydney 사용자가 2026-06-13 thread를 먼저 작성해도 KST 2026-06-12 reader에겐 비공개
+    for (const status of [null, 'in_progress', 'completed', 'failed']) {
+      expect(checkThreadVisibility(TOMORROW, TODAY, status)).toEqual({
+        visible: false,
+        reason: 'future',
+      });
+    }
+  });
+});

--- a/lib/comment-gate.ts
+++ b/lib/comment-gate.ts
@@ -1,0 +1,32 @@
+// 댓글 가시성 게이트 — 스포일러 방지 단일 룰 (ADR 0007)
+//
+// thread (deck, T)가 reader R에게 보이는 조건:
+//   1. T <  R.local_today                          → 과거 thread, 항상 공개
+//   2. T == R.local_today AND 그날 데일리 라운드 종료 → 공개
+//   3. T >  R.local_today                          → 미래 thread, 무조건 차단
+//      (시차로 먼저 작성된 댓글이라도 reader가 그 날짜에 도달 전엔 비공개.
+//       클라이언트 date 조작으로 미래 라운드를 위조해도 룰 3이 우선)
+//
+// "데일리 종료" 해석: ADR 0007의 'completed'는 ADR 0006("솔브 OR 시도 소진 =
+// 완료")과 동일 기준을 가리킨다. 현행 status 모델은 그 '완료'를
+// completed(솔브)/failed(소진·포기)로 분리했으므로 둘 다 게이트를 통과시킨다 —
+// failed reader는 더 이상 플레이할 수 없어 스포일러 위협이 없고,
+// 챌린지 게이트(lib/challenge.ts)와 기준이 일치한다.
+
+import { isChallengeUnlocked } from "./challenge";
+
+export type ThreadVisibility =
+  | { visible: true }
+  | { visible: false; reason: "today_locked" | "future" };
+
+export function checkThreadVisibility(
+  threadDate: string,
+  readerToday: string,
+  dailyRoundStatus: string | null,
+): ThreadVisibility {
+  if (threadDate < readerToday) return { visible: true };
+  if (threadDate > readerToday) return { visible: false, reason: "future" };
+  // T == today
+  if (isChallengeUnlocked(dailyRoundStatus)) return { visible: true };
+  return { visible: false, reason: "today_locked" };
+}

--- a/supabase/migrations/20260612000005_t4_comments.sql
+++ b/supabase/migrations/20260612000005_t4_comments.sql
@@ -1,0 +1,29 @@
+-- [T4] Comments: (deck_id, thread_date) 단위 댓글 thread (#47)
+-- ADR 0007: 가시성 게이트(스포일러 방지)는 server action 책임.
+-- comments 테이블은 client direct 접근 전면 금지 — RLS를 켜고 정책을 만들지
+-- 않아 anon/authenticated의 모든 직접 접근을 차단한다 (service_role만 통과).
+
+CREATE TABLE IF NOT EXISTS public.comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  deck_id uuid NOT NULL REFERENCES public.decks(id) ON DELETE CASCADE,
+  -- 작성자 client local date 캡처 — 게이트 판정의 기준 날짜 (ADR 0007)
+  thread_date date NOT NULL,
+  anon_id uuid NOT NULL,
+  -- 표시 disambiguation {nick}#{anon_id 앞 4hex}, '#' 불허 (ADR 0001)
+  nick text NOT NULL
+    CHECK (char_length(nick) BETWEEN 1 AND 20 AND nick NOT LIKE '%#%'),
+  pw_hash text NOT NULL CHECK (pw_hash ~ '^\$2[aby]\$\d{2}\$.{53}$'),
+  text text NOT NULL CHECK (char_length(text) BETWEEN 1 AND 500),
+  deleted boolean NOT NULL DEFAULT false,
+  hidden boolean NOT NULL DEFAULT false,
+  report_count integer NOT NULL DEFAULT 0 CHECK (report_count >= 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- thread 조회 패턴: (deck, date) 그룹 최신순 (#47)
+CREATE INDEX IF NOT EXISTS comments_deck_thread_created_idx
+  ON public.comments (deck_id, thread_date, created_at DESC);
+
+-- RLS: 정책 없음 = 전면 차단. 게이트 룰을 RLS에 넣지 않는다 (이슈 #47 명세 —
+-- RLS는 방어적 fallback이며 게이트는 reader local date 의존이라 server action 전용)
+ALTER TABLE public.comments ENABLE ROW LEVEL SECURITY;

--- a/types/database.ts
+++ b/types/database.ts
@@ -14,6 +14,56 @@ export type Database = {
   }
   public: {
     Tables: {
+      comments: {
+        Row: {
+          anon_id: string
+          created_at: string
+          deck_id: string
+          deleted: boolean
+          hidden: boolean
+          id: string
+          nick: string
+          pw_hash: string
+          report_count: number
+          text: string
+          thread_date: string
+        }
+        Insert: {
+          anon_id: string
+          created_at?: string
+          deck_id: string
+          deleted?: boolean
+          hidden?: boolean
+          id?: string
+          nick: string
+          pw_hash: string
+          report_count?: number
+          text: string
+          thread_date: string
+        }
+        Update: {
+          anon_id?: string
+          created_at?: string
+          deck_id?: string
+          deleted?: boolean
+          hidden?: boolean
+          id?: string
+          nick?: string
+          pw_hash?: string
+          report_count?: number
+          text?: string
+          thread_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "comments_deck_id_fkey"
+            columns: ["deck_id"]
+            isOneToOne: false
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       challenge_runs: {
         Row: {
           anon_id: string


### PR DESCRIPTION
Fixes #47

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> ADR 0007 가시성 게이트 룰(과거 공개 / 오늘은 데일리 종료 후 / 미래 무조건 차단)의 server-action 구현이 올바른가?

## Scope

### 포함 (9 files)
- **마이그레이션** `20260612000005_t4_comments.sql`
  - `comments`: `thread_date`(작성자 local date 캡처), nick(`#` 불허)/`pw_hash`(bcrypt CHECK), `deleted`/`hidden`/`report_count`, `(deck_id, thread_date, created_at DESC)` 인덱스
  - **RLS 정책 없음 = client direct 접근 전면 차단** — 이슈의 "client direct 접근 전면 금지" 강제 룰을 "hidden 차단 최소 정책"보다 더 강하게 충족 (SELECT 정책을 열면 게이트 우회로 직접 읽기가 가능해져 모순)
- **`lib/comment-gate.ts`** (+게이트 매트릭스 테스트 5개) — 단일 가시성 룰:
  - `T < today` 항상 공개 / `T == today` 데일리 종료 후 / **`T > today` 무조건 차단** (풀이 상태 위조해도 룰 3 우선 — AC의 Sydney/KST 케이스)
- **`app/actions/comment.ts`** — 모든 read/write/delete/report의 유일한 경로
  - `getComments`: 게이트 계산 후 허용 thread만 (미래 thread는 쿼리에서부터 제외)
  - `createComment`: `thread_date` = writer client local date 캡처 + **작성에도 게이트 적용**
  - `deleteComment`: nick+pw 검증, 디바이스 무관, soft delete, enumeration 방어 통합 메시지
  - `reportComment`: report_count 증가만 — 자동 가림 임계치는 T7(#50)
- **UI**: `CommentThread`(날짜 헤더 그룹·최신순·🔒 잠금 화면), `CommentForm`(자격증명 자동 채움), `CommentDeleteButton`(Popover) + `/d/[id]` 통합. **편집 버튼 없음** (AC)

### 스펙 해석 (리뷰 포인트)
- **"데일리 완료" = completed OR failed**: ADR 0007은 'completed'라 쓰면서 "ADR 0006(솔브 OR 시도 소진 = 완료)과 정확히 같은 기준"이라 명시. 현행 status 모델은 그 '완료'를 completed/failed로 분리했으므로 둘 다 통과시킴 — failed reader는 더 플레이할 수 없어 스포 위협이 없고, 챌린지 게이트(`isChallengeUnlocked` 공유)와 기준 일치. 솔브만 인정해야 한다면 한 줄 수정으로 조정 가능

### 제외
- 자동 가림(report 임계치) — T7 #50
- 제작자 게이트 우회 + 배지 — ADR 0007이 별도 결정으로 보류한 항목

## Scope Check

```
verdict: APPROVE
primary layer: comments (단일 기능 vertical)
secondary layers: test, mechanical (types/database.ts)
ADR count: 0
file count: 9
decision interlock: interlocked (schema→lib→actions→components→page 단일 의존 체인)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #47 AC)

- [x] comments 마이그레이션 + 인덱스
- [x] getComments 게이트 룰 적용 / 작성에도 게이트 적용
- [x] 미래 thread 무조건 차단 (테스트로 고정)
- [x] thread_date = writer client local date 자동 캡처
- [x] 디바이스 무관 nick+pw 삭제 / 작성자 표시 `{nick}#{4hex}` / 편집 없음
- [x] **클라이언트 `from('comments')` 직접 호출 0건** — `grep -rn "from(['\"]comments" components/ hooks/ app/ | grep -v app/actions` → 0
- [x] Vitest 게이트 매트릭스 (신규 5개, 총 151개 통과) / typecheck / lint / build 통과
- [ ] 라이브 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 기능 추가: 닉네임과 비밀번호를 사용하여 댓글 작성 가능
  * 댓글 관리: 작성한 댓글 삭제 및 신고 기능 제공
  * 스포일러 방지: 퍼즐 풀이 상태에 따라 댓글 표시 제어
  * 스레드 정렬: 댓글을 날짜별로 그룹화하여 표시

* **테스트**
  * 댓글 게이트 규칙 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->