### PR TITLE
feat(schema): [T6a] feed/search partial index — like_count/created_at/name

### DIFF
--- a/supabase/migrations/20260612000007_t6_feed_indexes.sql
+++ b/supabase/migrations/20260612000007_t6_feed_indexes.sql
@@ -1,0 +1,18 @@
+-- [T6a] Feed/search 정렬 인덱스 (#75)
+-- 피드/검색의 모든 쿼리는 hidden = false 필터를 동반하므로 partial index로 만든다.
+
+-- Hot/좋아요순
+CREATE INDEX IF NOT EXISTS idx_decks_likes_visible
+  ON public.decks (like_count DESC)
+  WHERE hidden = false;
+
+-- 최신순
+CREATE INDEX IF NOT EXISTS idx_decks_created_visible
+  ON public.decks (created_at DESC)
+  WHERE hidden = false;
+
+-- 덱 이름 키워드 검색 (ILIKE '%q%' 부분 일치 지원 — 단어 내용 검색은 의도적으로 없음, ADR 0008)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS idx_decks_name_visible
+  ON public.decks USING gin (name gin_trgm_ops)
+  WHERE hidden = false;


### PR DESCRIPTION
Fixes #75

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> feed/search 정렬·검색용 partial index 설계가 올바른가?

## Scope

### 포함 (1 file)
- `20260612000007_t6_feed_indexes.sql` — `hidden = false` partial index 3종
  - `like_count DESC` (Hot/좋아요순), `created_at DESC` (최신순)
  - `name gin_trgm_ops` + `pg_trgm` 확장 — 이슈가 제시한 두 옵션 중 **trgm 채택** (`ILIKE '%q%'` 부분 일치 지원, btree text_pattern_ops는 prefix만 가능)

### 제외
- 피드/검색 UI·쿼리 — T6b(#76, stacked 예정)

## Scope Check

```
verdict: APPROVE
primary layer: infra (DB migration)
secondary layers: 없음
ADR count: 0
file count: 1
decision interlock: interlocked (세 인덱스 모두 단일 결정에서 파생)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- [x] `pnpm typecheck` 통과 (코드 변경 없음 — 이슈 AC: pnpm build)
- [ ] 인덱스 적용·EXPLAIN — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_