### PR TITLE
feat(feed): [T6b] 메인 피드 + 검색 — Hot/좋아요/최신 탭, 무한 스크롤

### DIFF
--- a/app/actions/feed.ts
+++ b/app/actions/feed.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { createClient } from "@/lib/supabase-server";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import { sortByHotScore } from "@/lib/hot-score";
+import { escapeLikePattern, normalizeSearchQuery } from "@/lib/search";
+
+// 피드/검색 조회 (#76). decks SELECT는 공개 RLS라 anon 클라이언트로 충분 —
+// creator_pw_hash는 화이트리스트로 제외한다.
+
+const FEED_COLUMNS =
+  "id, name, script, creator_id, creator_nick, like_count, created_at";
+// Hot은 computed score라 DB 정렬 불가 — 최신 window를 가져와 서버(JS)에서 정렬한다.
+// hot 점수는 recency 가중이라 오래된 덱은 어차피 하위권 → window 근사로 충분 (MVP)
+const HOT_WINDOW = 200;
+const DEFAULT_LIMIT = 24;
+
+export type FeedSort = "hot" | "likes" | "new";
+
+export interface FeedDeck {
+  id: string;
+  name: string;
+  script: string;
+  creator_id: string;
+  creator_nick: string;
+  like_count: number;
+  created_at: string;
+}
+
+export interface FeedPage {
+  decks: FeedDeck[];
+  /** 다음 페이지 cursor — null이면 끝 */
+  nextOffset: number | null;
+}
+
+export async function getFeed(input: {
+  sort: FeedSort;
+  offset?: number;
+  limit?: number;
+}): Promise<ActionResponse<FeedPage>> {
+  return safeAction(async () => {
+    const { sort } = input;
+    const offset = Math.max(0, input.offset ?? 0);
+    const limit = Math.min(48, Math.max(1, input.limit ?? DEFAULT_LIMIT));
+    const supabase = await createClient();
+
+    // hidden 덱은 모든 피드에서 제외 (AC)
+    const base = supabase.from("decks").select(FEED_COLUMNS).eq("hidden", false);
+
+    if (sort === "hot") {
+      const { data, error } = await base
+        .order("created_at", { ascending: false })
+        .limit(HOT_WINDOW);
+      if (error) return { success: false, message: `피드를 가져오는데 실패했습니다: ${error.message}` };
+
+      const sorted = sortByHotScore(data ?? []);
+      const page = sorted.slice(offset, offset + limit);
+      const end = offset + page.length;
+      return {
+        success: true,
+        data: { decks: page, nextOffset: end < sorted.length ? end : null },
+        message: "피드를 가져왔습니다.",
+      };
+    }
+
+    const query =
+      sort === "likes"
+        ? base.order("like_count", { ascending: false }).order("created_at", { ascending: false })
+        : base.order("created_at", { ascending: false }).order("id", { ascending: false });
+
+    const { data, error } = await query.range(offset, offset + limit - 1);
+    if (error) return { success: false, message: `피드를 가져오는데 실패했습니다: ${error.message}` };
+
+    const decks = data ?? [];
+    return {
+      success: true,
+      data: {
+        decks,
+        nextOffset: decks.length === limit ? offset + decks.length : null,
+      },
+      message: "피드를 가져왔습니다.",
+    };
+  });
+}
+
+// 덱 이름 키워드 검색 — 단어 내용 매칭 없음 (ADR 0008)
+export async function searchDecks(input: {
+  q: string;
+  offset?: number;
+  limit?: number;
+}): Promise<ActionResponse<FeedPage>> {
+  return safeAction(async () => {
+    const q = normalizeSearchQuery(input.q);
+    if (!q) return { success: true, data: { decks: [], nextOffset: null }, message: "검색어가 비어있습니다." };
+
+    const offset = Math.max(0, input.offset ?? 0);
+    const limit = Math.min(48, Math.max(1, input.limit ?? DEFAULT_LIMIT));
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("decks")
+      .select(FEED_COLUMNS)
+      .eq("hidden", false)
+      .ilike("name", `%${escapeLikePattern(q)}%`)
+      .order("like_count", { ascending: false })
+      .order("created_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+    if (error) return { success: false, message: `검색에 실패했습니다: ${error.message}` };
+
+    const decks = data ?? [];
+    return {
+      success: true,
+      data: {
+        decks,
+        nextOffset: decks.length === limit ? offset + decks.length : null,
+      },
+      message: "검색했습니다.",
+    };
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,39 @@
-// T0 foundation reset placeholder — 신규 도메인 라우트(/d/[id] 등)는 T1c에서 추가된다
-export default function Home() {
+import Link from "next/link";
+import { getFeed, type FeedSort } from "@/app/actions/feed";
+import { FeedTabs } from "@/components/FeedTabs";
+import { FeedList } from "@/components/FeedList";
+import { SearchBar } from "@/components/SearchBar";
+import { Button } from "@/components/ui/button";
+
+interface HomePageProps {
+  searchParams: Promise<{ sort?: string }>;
+}
+
+function resolveSort(raw: string | undefined): FeedSort {
+  return raw === "likes" || raw === "new" ? raw : "hot"; // Hot 탭 기본 (AC)
+}
+
+export default async function Home({ searchParams }: HomePageProps) {
+  const { sort: rawSort } = await searchParams;
+  const sort = resolveSort(rawSort);
+
+  const result = await getFeed({ sort });
+  const page = result.success && result.data ? result.data : { decks: [], nextOffset: null };
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-bold">wordledecks</h1>
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">wordledecks</h1>
+        <div className="flex-1">
+          <SearchBar />
+        </div>
+        <Button asChild size="sm">
+          <Link href="/d/new">새 덱</Link>
+        </Button>
+      </div>
+
+      <FeedTabs active={sort} />
+      <FeedList initialDecks={page.decks} initialNextOffset={page.nextOffset} sort={sort} />
     </main>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { searchDecks } from "@/app/actions/feed";
+import { SearchBar } from "@/components/SearchBar";
+import { FeedList } from "@/components/FeedList";
+
+export const metadata: Metadata = {
+  title: "덱 검색 | wordledecks",
+};
+
+interface SearchPageProps {
+  searchParams: Promise<{ q?: string }>;
+}
+
+// 덱 이름 키워드 검색 — 단어 내용 매칭 없음 (ADR 0008)
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const { q = "" } = await searchParams;
+  const result = await searchDecks({ q });
+  const page = result.success && result.data ? result.data : { decks: [], nextOffset: null };
+
+  return (
+    <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <SearchBar defaultValue={q} />
+      <FeedList
+        initialDecks={page.decks}
+        initialNextOffset={page.nextOffset}
+        sort="likes"
+        query={q}
+      />
+    </main>
+  );
+}

--- a/components/EmptyResult.tsx
+++ b/components/EmptyResult.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface EmptyResultProps {
+  query?: string;
+}
+
+export function EmptyResult({ query }: EmptyResultProps) {
+  return (
+    <div className="space-y-4 rounded-lg border p-8 text-center">
+      <p className="text-sm text-muted-foreground">
+        {query ? `[${query}] 덱이 아직 없습니다. 직접 만들어보세요!` : "아직 덱이 없습니다. 첫 덱을 만들어보세요!"}
+      </p>
+      <Button asChild>
+        <Link href="/d/new">새 덱 만들기</Link>
+      </Button>
+    </div>
+  );
+}

--- a/components/FeedDeckCard.tsx
+++ b/components/FeedDeckCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { LikeButton } from "@/components/LikeButton";
+import { formatDisplayNick } from "@/lib/identity";
+import type { FeedDeck } from "@/app/actions/feed";
+
+const SCRIPT_LABELS: Record<string, string> = {
+  latin: "로마자",
+  hangul: "한글",
+  kana: "가나",
+};
+
+export function FeedDeckCard({ deck }: { deck: FeedDeck }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border p-4">
+      <Link href={`/d/${deck.id}`} className="min-w-0 flex-1 space-y-1">
+        <p className="truncate font-semibold">{deck.name}</p>
+        <p className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Badge variant="secondary">{SCRIPT_LABELS[deck.script] ?? deck.script}</Badge>
+          {formatDisplayNick(deck.creator_nick, deck.creator_id)}
+        </p>
+      </Link>
+      <LikeButton deckId={deck.id} initialCount={deck.like_count} />
+    </div>
+  );
+}

--- a/components/FeedList.tsx
+++ b/components/FeedList.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { FeedDeckCard } from "@/components/FeedDeckCard";
+import { EmptyResult } from "@/components/EmptyResult";
+import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { getFeed, searchDecks, type FeedDeck, type FeedSort } from "@/app/actions/feed";
+
+interface FeedListProps {
+  /** 서버에서 렌더한 첫 페이지 */
+  initialDecks: FeedDeck[];
+  initialNextOffset: number | null;
+  sort: FeedSort;
+  /** 검색 모드 — 지정 시 searchDecks로 추가 로드 */
+  query?: string;
+}
+
+export function FeedList({ initialDecks, initialNextOffset, sort, query }: FeedListProps) {
+  const [decks, setDecks] = useState(initialDecks);
+  const [nextOffset, setNextOffset] = useState(initialNextOffset);
+  const loadingRef = useRef(false);
+
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current || nextOffset === null) return;
+    loadingRef.current = true;
+    try {
+      const result = query !== undefined
+        ? await searchDecks({ q: query, offset: nextOffset })
+        : await getFeed({ sort, offset: nextOffset });
+      if (result.success && result.data) {
+        const { decks: more, nextOffset: next } = result.data;
+        setDecks((prev) => {
+          const seen = new Set(prev.map((d) => d.id));
+          return [...prev, ...more.filter((d) => !seen.has(d.id))];
+        });
+        setNextOffset(next);
+      }
+    } finally {
+      loadingRef.current = false;
+    }
+  }, [nextOffset, sort, query]);
+
+  const sentinelRef = useIntersectionObserver(loadMore);
+
+  if (decks.length === 0) return <EmptyResult query={query} />;
+
+  return (
+    <div className="space-y-3">
+      {decks.map((deck) => (
+        <FeedDeckCard key={deck.id} deck={deck} />
+      ))}
+      {nextOffset !== null && (
+        <div ref={sentinelRef} className="py-4 text-center text-sm text-muted-foreground">
+          불러오는 중...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/FeedTabs.tsx
+++ b/components/FeedTabs.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { FeedSort } from "@/app/actions/feed";
+
+const TABS: { sort: FeedSort; label: string; href: string }[] = [
+  { sort: "hot", label: "🔥 Hot", href: "/" },
+  { sort: "likes", label: "좋아요순", href: "/?sort=likes" },
+  { sort: "new", label: "최신순", href: "/?sort=new" },
+];
+
+export function FeedTabs({ active }: { active: FeedSort }) {
+  return (
+    <nav className="flex gap-1 border-b">
+      {TABS.map((tab) => (
+        <Link
+          key={tab.sort}
+          href={tab.href}
+          className={cn(
+            "px-3 py-2 text-sm font-medium",
+            active === tab.sort
+              ? "border-b-2 border-foreground text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,17 @@
+import { Input } from "@/components/ui/input";
+
+// GET form — /search?q=... 로 이동 (서버 컴포넌트에서 사용 가능)
+export function SearchBar({ defaultValue = "" }: { defaultValue?: string }) {
+  return (
+    <form action="/search" className="w-full">
+      <Input
+        type="search"
+        name="q"
+        defaultValue={defaultValue}
+        placeholder="덱 이름 검색"
+        maxLength={50}
+        aria-label="덱 이름 검색"
+      />
+    </form>
+  );
+}

--- a/lib/hot-score.test.ts
+++ b/lib/hot-score.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { hotScore, sortByHotScore, HOT_DECAY_SECONDS } from './hot-score';
+
+describe('hotScore — 결정성 (AC)', () => {
+  it('같은 입력이면 항상 같은 점수', () => {
+    expect(hotScore(10, '2026-06-12T00:00:00Z')).toBe(hotScore(10, '2026-06-12T00:00:00Z'));
+  });
+
+  it('좋아요는 로그 스케일로 가산된다 (10배 = +1점)', () => {
+    const at = '2026-06-12T00:00:00Z';
+    expect(hotScore(100, at) - hotScore(10, at)).toBeCloseTo(1, 10);
+    expect(hotScore(1, at)).toBe(hotScore(0, at)); // max(likes, 1)
+  });
+
+  it('decay 초만큼 최신이면 +1점 (좋아요 10배와 등가)', () => {
+    const base = new Date('2026-06-12T00:00:00Z');
+    const later = new Date(base.getTime() + HOT_DECAY_SECONDS * 1000);
+    expect(hotScore(10, later) - hotScore(10, base)).toBeCloseTo(1, 10);
+  });
+});
+
+describe('sortByHotScore — 정렬 (AC)', () => {
+  const deck = (id: string, like_count: number, created_at: string) => ({
+    id,
+    like_count,
+    created_at,
+  });
+
+  it('좋아요와 최신성을 함께 반영해 내림차순 정렬한다', () => {
+    const old = deck('old-popular', 1000, '2026-06-01T00:00:00Z');
+    const fresh = deck('fresh-few', 5, '2026-06-12T00:00:00Z');
+    // 11일 차이 = 950400s / 45000 ≈ 21.1점 > log10(1000/5) ≈ 2.3점 → 최신이 위
+    expect(sortByHotScore([old, fresh]).map((d) => d.id)).toEqual(['fresh-few', 'old-popular']);
+  });
+
+  it('같은 시각이면 좋아요 많은 쪽이 위', () => {
+    const a = deck('a', 3, '2026-06-12T00:00:00Z');
+    const b = deck('b', 30, '2026-06-12T00:00:00Z');
+    expect(sortByHotScore([a, b]).map((d) => d.id)).toEqual(['b', 'a']);
+  });
+
+  it('입력 배열을 변경하지 않는다', () => {
+    const items = [deck('a', 1, '2026-06-12T00:00:00Z'), deck('b', 9, '2026-06-12T01:00:00Z')];
+    const copy = [...items];
+    sortByHotScore(items);
+    expect(items).toEqual(copy);
+  });
+});

--- a/lib/hot-score.ts
+++ b/lib/hot-score.ts
@@ -1,0 +1,24 @@
+// Hot 점수 (#76): log10(max(likes, 1)) + (created_at - ref) / decay
+// reddit 스타일 — 좋아요는 로그 스케일, 최신성은 선형 가산.
+// ref와 decay는 고정 상수 — 같은 입력이면 항상 같은 점수 (결정성 AC).
+
+export const HOT_REF_EPOCH_MS = Date.UTC(2026, 0, 1); // 2026-01-01T00:00:00Z
+export const HOT_DECAY_SECONDS = 45000; // 12.5시간마다 +1점 (좋아요 10배와 등가)
+
+export function hotScore(likeCount: number, createdAt: string | Date): number {
+  const createdMs = new Date(createdAt).getTime();
+  return (
+    Math.log10(Math.max(likeCount, 1)) +
+    (createdMs - HOT_REF_EPOCH_MS) / 1000 / HOT_DECAY_SECONDS
+  );
+}
+
+export function sortByHotScore<T extends { like_count: number; created_at: string }>(
+  decks: readonly T[],
+): T[] {
+  return [...decks].sort((a, b) => {
+    const diff = hotScore(b.like_count, b.created_at) - hotScore(a.like_count, a.created_at);
+    if (diff !== 0) return diff;
+    return b.created_at.localeCompare(a.created_at); // 동점은 최신 우선 (결정적 tie-break)
+  });
+}

--- a/lib/search.test.ts
+++ b/lib/search.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { escapeLikePattern, normalizeSearchQuery, SEARCH_QUERY_MAX_LENGTH } from './search';
+
+describe('escapeLikePattern — 검색 매칭 안전성 (AC)', () => {
+  it('ILIKE 메타문자를 이스케이프한다', () => {
+    expect(escapeLikePattern('100%')).toBe('100\\%');
+    expect(escapeLikePattern('a_b')).toBe('a\\_b');
+    expect(escapeLikePattern('back\\slash')).toBe('back\\\\slash');
+  });
+
+  it('일반 키워드는 그대로 둔다', () => {
+    expect(escapeLikePattern('원피스')).toBe('원피스');
+  });
+});
+
+describe('normalizeSearchQuery', () => {
+  it('trim 후 비어있으면 null', () => {
+    expect(normalizeSearchQuery('  ')).toBeNull();
+    expect(normalizeSearchQuery('')).toBeNull();
+  });
+
+  it('최대 길이를 강제한다', () => {
+    expect(normalizeSearchQuery('a'.repeat(100))).toHaveLength(SEARCH_QUERY_MAX_LENGTH);
+  });
+
+  it('정상 키워드는 trim해서 반환', () => {
+    expect(normalizeSearchQuery(' 포켓몬 ')).toBe('포켓몬');
+  });
+});

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,13 @@
+// 덱 이름 키워드 검색 (#76) — 단어 내용 매칭은 의도적으로 없음 (ADR 0008)
+
+export const SEARCH_QUERY_MAX_LENGTH = 50;
+
+// ILIKE 패턴 메타문자 이스케이프 — 사용자 입력이 와일드카드로 해석되는 것 방지
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+export function normalizeSearchQuery(raw: string): string | null {
+  const trimmed = raw.trim().slice(0, SEARCH_QUERY_MAX_LENGTH);
+  return trimmed.length > 0 ? trimmed : null;
+}


### PR DESCRIPTION
Fixes #76

> [!NOTE]
> **Stacked PR** — base가 #108([T6a] 인덱스)입니다. 머지 순서: #108 → 본 PR. (#108 머지 후 base를 main으로 전환 — 제가 처리합니다)

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> hot-score 가중치와 검색 매칭 로직이 피드 정렬 의도에 부합하는가?

## Scope

### 포함 (12 files: semantic 10 + test 2)
- **`lib/hot-score.ts`** (+테스트): `log10(max(likes,1)) + (created − ref)/45000s` — 좋아요 10배 = 12.5시간 최신성과 등가, 결정적 tie-break
- **`lib/search.ts`** (+테스트): ILIKE 메타문자(`%`/`_`/`\`) 이스케이프 + 검색어 정규화(50자 제한)
- **`app/actions/feed.ts`**
  - `getFeed`: `likes`/`new`는 DB 정렬 + range cursor. **`hot`은 최신 window 200건을 JS 정렬** — hot이 computed score라 DB 정렬 불가, recency 가중이라 오래된 덱은 어차피 하위권이어서 window 근사로 충분 (MVP, 본문에 명시)
  - `searchDecks`: `name ILIKE '%q%'` — **단어 내용 검색 없음** (ADR 0008, AC)
  - `hidden = true` 덱 전 쿼리에서 제외 (AC)
- **UI**: `FeedTabs`(Hot 기본 + `?sort=likes|new`), `FeedDeckCard`(**LikeButton #107 통합** — AC), `SearchBar`(GET → `/search?q=`), `EmptyResult`("[q] 덱이 아직 없습니다" + 만들기 CTA — AC), `FeedList`(SSR 첫 페이지 + 무한 스크롤 cursor)
- `app/page.tsx`: T0 placeholder → 피드 홈, `app/search/page.tsx` 신규

### 선언 scope 대비 편차 (scope checker 권고로 명시)
- `lib/feed.ts` → **`app/actions/feed.ts`**: 쿼리는 server action — 기존 6개 액션 파일 패턴과 일관
- **`FeedList` 컨테이너 추가**: 무한 스크롤 — T1c 이전부터 있던 `useIntersectionObserver` 훅 재사용

### 제외
- SSR/SEO 최적화(sitemap, OG, slug) — T8 #51
- hidden 덱 소비자 UX(배너 등) — T7a #55

## Scope Check

```
verdict: APPROVE
primary layer: discovery
secondary layers: test
ADR count: 0
file count: 12 (semantic 10 + test 2)
decision interlock: interlocked (탭·hot-score·검색이 단일 discovery 기능)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #76 AC)

- [x] `/` Hot 탭 기본 / `?sort=likes` / `?sort=new`
- [x] `/search?q=` 덱 이름 매칭만 (단어 내용 X)
- [x] hidden 덱 전 피드/검색 제외
- [x] 무한 스크롤 cursor (offset 기반, dedupe 가드)
- [x] 빈 결과 만들기 CTA
- [x] Vitest: hot score 결정성·정렬, 검색 이스케이프 (신규 11개, 총 175개 통과)
- [x] `pnpm test` / `pnpm build`(`/search` 라우트 확인) / typecheck / lint 통과

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_