### PR TITLE
feat(moderation): [T7] 신고 + 자동 가림 — reports 테이블, 임계 트리거, ReportButton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # 좋아요 IP 해시 salt (ADR 0002) — 회전 시 기존 좋아요 전부 무효화. 영구 고정.
 IP_HASH_SALT=
+
+# 신고 자동 가림 임계치 (ADR 0013) — 미설정 시 덱 5 / 댓글 3
+REPORT_THRESHOLD_DECK=5
+REPORT_THRESHOLD_COMMENT=3
+# 자동 가림 시 운영자 알림 webhook (선택)
+MODERATION_WEBHOOK_URL=

--- a/app/actions/comment.ts
+++ b/app/actions/comment.ts
@@ -23,6 +23,8 @@ export interface CommentView {
   text: string;
   createdAt: string;
   isMine: boolean;
+  /** 신고 누적으로 가려진 댓글 — text는 서버에서 마스킹됨 (ADR 0013) */
+  hidden: boolean;
 }
 
 export interface CommentThreadsView {
@@ -71,10 +73,9 @@ export async function getComments(
     const maxDate = todayGate.visible ? readerToday : readerToday; // lte 기준
     let query = admin
       .from("comments")
-      .select("id, thread_date, anon_id, nick, text, created_at")
+      .select("id, thread_date, anon_id, nick, text, created_at, hidden")
       .eq("deck_id", deckId)
       .eq("deleted", false)
-      .eq("hidden", false)
       .order("thread_date", { ascending: false })
       .order("created_at", { ascending: false })
       .limit(200);
@@ -91,9 +92,11 @@ export async function getComments(
         id: row.id,
         threadDate: row.thread_date,
         displayNick: formatDisplayNick(row.nick, row.anon_id),
-        text: row.text,
+        // 가려진 댓글 본문은 클라이언트로 보내지 않는다 — server action 레벨 마스킹 (#50 AC)
+        text: row.hidden ? "이 댓글은 신고로 가려졌습니다." : row.text,
         createdAt: row.created_at,
         isMine: row.anon_id === anonId,
+        hidden: row.hidden,
       };
       const last = threads[threads.length - 1];
       if (last && last.date === row.thread_date) last.comments.push(view);
@@ -201,29 +204,4 @@ export async function deleteComment(input: {
   });
 }
 
-// 신고 — report_count 증가만 수행. 자동 가림 임계치 처리는 T7(#50) 모더레이션 트랙.
-export async function reportComment(commentId: string): Promise<ActionResponse> {
-  return safeAction(async () => {
-    const anonId = await getOrCreateAnonUserId();
-    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
-
-    const admin = createAdminClient();
-    const { data: comment } = await admin
-      .from("comments")
-      .select("id, report_count, deleted")
-      .eq("id", commentId)
-      .single();
-    if (!comment || comment.deleted) {
-      return { success: false, message: "댓글을 찾을 수 없습니다." };
-    }
-
-    const { error } = await admin
-      .from("comments")
-      .update({ report_count: comment.report_count + 1 })
-      .eq("id", commentId);
-    if (error) {
-      return { success: false, message: `신고에 실패했습니다: ${error.message}` };
-    }
-    return { success: true, message: "신고가 접수되었습니다." };
-  });
-}
+// 신고는 reportTarget(app/actions/report.ts)으로 통합되었다 — 중복 차단·자동 가림 포함 (#50)

--- a/app/actions/report.ts
+++ b/app/actions/report.ts
@@ -1,0 +1,91 @@
+"use server";
+
+import { createAdminClient } from "@/lib/supabase-admin";
+import { safeAction } from "@/lib/safe-action";
+import { ActionResponse } from "@/types/action";
+import { getOrCreateAnonUserId } from "@/lib/anon-session";
+import { applyReport, reportThreshold, type ReportTargetType } from "@/lib/moderation";
+
+// 신고 + 자동 가림 (#50, ADR 0013)
+// reports.target_id가 polymorphic이라 report_count/hidden 갱신을
+// DB 트리거 대신 여기서 명시적으로 수행한다.
+
+const PG_UNIQUE_VIOLATION = "23505";
+const TARGET_TABLE: Record<ReportTargetType, "decks" | "comments"> = {
+  deck: "decks",
+  comment: "comments",
+};
+
+// 자동 가림 시 운영자 알림 — MVP는 환경변수 가드 stub (V2에서 정식 webhook)
+async function notifyModeration(targetType: ReportTargetType, targetId: string): Promise<void> {
+  const url = process.env.MODERATION_WEBHOOK_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `[wordledecks] ${targetType} ${targetId} 자동 가림 (신고 임계 도달)`,
+      }),
+    });
+  } catch (error) {
+    console.error("[moderation] webhook 알림 실패:", error);
+  }
+}
+
+export async function reportTarget(input: {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason?: string;
+}): Promise<ActionResponse> {
+  return safeAction(async () => {
+    const { targetType, targetId } = input;
+    const reason = input.reason?.trim().slice(0, 200) || null;
+
+    if (targetType !== "deck" && targetType !== "comment") {
+      return { success: false, message: "지원하지 않는 신고 대상입니다." };
+    }
+
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+
+    const admin = createAdminClient();
+    const table = TARGET_TABLE[targetType];
+
+    const { data: target } = await admin
+      .from(table)
+      .select("id, report_count, hidden")
+      .eq("id", targetId)
+      .single();
+    if (!target) return { success: false, message: "신고 대상을 찾을 수 없습니다." };
+
+    // 같은 사용자의 같은 대상 재신고는 유니크 제약이 차단 — 멱등 no-op (AC)
+    const { error: insertError } = await admin.from("reports").insert({
+      target_type: targetType,
+      target_id: targetId,
+      reporter_anon_id: anonId,
+      reason,
+    });
+    if (insertError?.code === PG_UNIQUE_VIOLATION) {
+      return { success: true, message: "이미 신고가 접수되어 있습니다." };
+    }
+    if (insertError) {
+      return { success: false, message: `신고에 실패했습니다: ${insertError.message}` };
+    }
+
+    const { newCount, hide } = applyReport(target.report_count, reportThreshold(targetType));
+    const { error: updateError } = await admin
+      .from(table)
+      .update({ report_count: newCount, ...(hide ? { hidden: true } : {}) })
+      .eq("id", targetId);
+    if (updateError) {
+      return { success: false, message: `신고 반영에 실패했습니다: ${updateError.message}` };
+    }
+
+    if (hide && !target.hidden) {
+      await notifyModeration(targetType, targetId);
+    }
+
+    return { success: true, message: "신고가 접수되었습니다." };
+  });
+}

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getDeckById } from "@/app/actions/deck";
 import { DeckMetaCard } from "@/components/DeckMetaCard";
 import { CommentThread } from "@/components/CommentThread";
 import { LikeButton } from "@/components/LikeButton";
+import { ReportButton } from "@/components/ReportButton";
 import { Button } from "@/components/ui/button";
 
 interface DeckPageProps {
@@ -29,6 +30,7 @@ export default async function DeckPage({ params }: DeckPageProps) {
           <Link href={`/d/${deck.id}/edit`}>편집</Link>
         </Button>
         <LikeButton deckId={deck.id} initialCount={deck.like_count} />
+        <ReportButton targetType="deck" targetId={deck.id} />
       </div>
 
       <CommentThread deckId={deck.id} />

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
 import { CommentForm } from "@/components/CommentForm";
 import { CommentDeleteButton } from "@/components/CommentDeleteButton";
-import { getComments, reportComment, type CommentThreadsView } from "@/app/actions/comment";
-import { actionWithToast } from "@/lib/action-with-toast";
+import { ReportButton } from "@/components/ReportButton";
+import { getComments, type CommentThreadsView } from "@/app/actions/comment";
+import { cn } from "@/lib/utils";
 
 function localDate(): string {
   const now = new Date();
@@ -40,10 +40,6 @@ export function CommentThread({ deckId }: CommentThreadProps) {
     void reload();
   }, [reload]);
 
-  const handleReport = async (commentId: string) => {
-    await actionWithToast(() => reportComment(commentId));
-  };
-
   if (loadError) return <p className="text-sm text-destructive">{loadError}</p>;
   if (!view) return <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>;
 
@@ -72,19 +68,20 @@ export function CommentThread({ deckId }: CommentThreadProps) {
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-sm font-medium">{comment.displayNick}</span>
                   <div className="flex items-center gap-1">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 px-2 text-xs text-muted-foreground"
-                      onClick={() => handleReport(comment.id)}
-                    >
-                      신고
-                    </Button>
+                    {!comment.hidden && (
+                      <ReportButton targetType="comment" targetId={comment.id} />
+                    )}
                     <CommentDeleteButton commentId={comment.id} onDeleted={reload} />
                   </div>
                 </div>
-                <p className="mt-1 whitespace-pre-wrap text-sm">{comment.text}</p>
+                <p
+                  className={cn(
+                    "mt-1 whitespace-pre-wrap text-sm",
+                    comment.hidden && "italic text-muted-foreground",
+                  )}
+                >
+                  {comment.text}
+                </p>
               </li>
             ))}
           </ul>

--- a/components/ReportButton.tsx
+++ b/components/ReportButton.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { actionWithToast } from "@/lib/action-with-toast";
+import { reportTarget } from "@/app/actions/report";
+import type { ReportTargetType } from "@/lib/moderation";
+
+interface ReportButtonProps {
+  targetType: ReportTargetType;
+  targetId: string;
+}
+
+export function ReportButton({ targetType, targetId }: ReportButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const result = await actionWithToast(() =>
+        reportTarget({ targetType, targetId, reason }),
+      );
+      if (result.success) {
+        setOpen(false);
+        setReason("");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+        >
+          신고
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64">
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            부적절한 {targetType === "deck" ? "덱" : "댓글"}을 신고합니다.
+          </p>
+          <Input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="사유 (선택)"
+            maxLength={200}
+          />
+          <Button type="submit" size="sm" disabled={submitting} className="w-full">
+            {submitting ? "신고 중..." : "신고하기"}
+          </Button>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/lib/moderation.test.ts
+++ b/lib/moderation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reportThreshold,
+  applyReport,
+  DEFAULT_REPORT_THRESHOLDS,
+} from './moderation';
+
+describe('reportThreshold — 환경변수 임계치 (AC)', () => {
+  it('기본값: 덱 5회, 댓글 3회 (ADR 0013)', () => {
+    expect(reportThreshold('deck', {})).toBe(5);
+    expect(reportThreshold('comment', {})).toBe(3);
+  });
+
+  it('환경변수로 코드 변경 없이 조정 가능', () => {
+    expect(reportThreshold('deck', { REPORT_THRESHOLD_DECK: '10' })).toBe(10);
+    expect(reportThreshold('comment', { REPORT_THRESHOLD_COMMENT: '1' })).toBe(1);
+  });
+
+  it('잘못된 값은 기본값으로 fallback', () => {
+    expect(reportThreshold('deck', { REPORT_THRESHOLD_DECK: 'abc' })).toBe(
+      DEFAULT_REPORT_THRESHOLDS.deck,
+    );
+    expect(reportThreshold('deck', { REPORT_THRESHOLD_DECK: '0' })).toBe(
+      DEFAULT_REPORT_THRESHOLDS.deck,
+    );
+    expect(reportThreshold('deck', { REPORT_THRESHOLD_DECK: '-1' })).toBe(
+      DEFAULT_REPORT_THRESHOLDS.deck,
+    );
+  });
+});
+
+describe('applyReport — 임계 도달 가림 (AC)', () => {
+  it('임계 도달 시 hide', () => {
+    expect(applyReport(4, 5)).toEqual({ newCount: 5, hide: true });
+    expect(applyReport(2, 3)).toEqual({ newCount: 3, hide: true });
+  });
+
+  it('임계 미만이면 카운트만 증가', () => {
+    expect(applyReport(0, 5)).toEqual({ newCount: 1, hide: false });
+    expect(applyReport(3, 5)).toEqual({ newCount: 4, hide: false });
+  });
+
+  it('임계 초과 상태에서도 hide 유지 (멱등)', () => {
+    expect(applyReport(7, 5)).toEqual({ newCount: 8, hide: true });
+  });
+});

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -1,0 +1,32 @@
+// 신고 누적 자동 가림 규칙 (ADR 0013)
+// 임계치는 환경변수로 분리 — 코드 변경 없이 운영 중 조정 가능.
+
+export type ReportTargetType = "deck" | "comment";
+
+export const DEFAULT_REPORT_THRESHOLDS: Record<ReportTargetType, number> = {
+  deck: 5, // 피드/검색 제외, 직접 링크는 유지 (consumer UX는 #55)
+  comment: 3, // 즉시 숨김
+};
+
+export function reportThreshold(
+  targetType: ReportTargetType,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw =
+    targetType === "deck" ? env.REPORT_THRESHOLD_DECK : env.REPORT_THRESHOLD_COMMENT;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_REPORT_THRESHOLDS[targetType];
+}
+
+export interface ReportApplication {
+  newCount: number;
+  hide: boolean;
+}
+
+// 신고 1건 반영 결과 — 임계 도달 시 hide. 이미 임계 초과 상태도 hide 유지.
+export function applyReport(currentCount: number, threshold: number): ReportApplication {
+  const newCount = currentCount + 1;
+  return { newCount, hide: newCount >= threshold };
+}

--- a/supabase/migrations/20260612000008_t7_reports.sql
+++ b/supabase/migrations/20260612000008_t7_reports.sql
@@ -1,0 +1,19 @@
+-- [T7] Reports: 신고 + 자동 가림 (#50, ADR 0013)
+-- target_id가 polymorphic(deck/comment)이라 report_count/hidden 갱신은
+-- DB 트리거가 아닌 server action에서 명시적으로 수행한다.
+
+CREATE TABLE IF NOT EXISTS public.reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  target_type text NOT NULL CHECK (target_type IN ('deck', 'comment')),
+  target_id uuid NOT NULL,
+  reporter_anon_id uuid NOT NULL,
+  reason text CHECK (reason IS NULL OR char_length(reason) <= 200),
+  resolved boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- 같은 사용자가 같은 대상을 중복 신고해도 1회로 카운트 (ADR 0013 spam 방어)
+  CONSTRAINT reports_unique_per_reporter UNIQUE (target_type, target_id, reporter_anon_id)
+);
+
+-- RLS: 정책 없음 = client direct 접근 전면 차단 (reporter_anon_id 노출 방지,
+-- comments/likes와 동일 패턴). 모든 접근은 server action(service_role)만.
+ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;

--- a/types/database.ts
+++ b/types/database.ts
@@ -14,6 +14,36 @@ export type Database = {
   }
   public: {
     Tables: {
+      reports: {
+        Row: {
+          created_at: string
+          id: string
+          reason: string | null
+          reporter_anon_id: string
+          resolved: boolean
+          target_id: string
+          target_type: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          reason?: string | null
+          reporter_anon_id: string
+          resolved?: boolean
+          target_id: string
+          target_type: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          reason?: string | null
+          reporter_anon_id?: string
+          resolved?: boolean
+          target_id?: string
+          target_type?: string
+        }
+        Relationships: []
+      }
       likes: {
         Row: {
           created_at: string


### PR DESCRIPTION
Fixes #50

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> 신고 → 임계 자동 가림 vertical(중복 차단·polymorphic 갱신·서버 마스킹)이 ADR 0013을 올바르게 구현하는가?

## Scope

### 포함 (10 files)
- **마이그레이션** `20260612000008_t7_reports.sql`
  - `reports`: polymorphic(`target_type` deck/comment + `target_id`), **`(target_type, target_id, reporter_anon_id)` 유니크** — 중복 신고 차단 (AC)
  - RLS 정책 없음 — 신고자 익명성 보호, server action only
- **`lib/moderation.ts`** (+테스트 6개): `reportThreshold` — **`REPORT_THRESHOLD_DECK=5` / `COMMENT=3` 환경변수** (AC), 잘못된 값 fallback / `applyReport` 순수 함수
- **`app/actions/report.ts`** `reportTarget`
  - 유니크 위반 → **멱등 no-op** ("이미 신고가 접수되어 있습니다", AC)
  - `report_count`/`hidden` 갱신을 server action에서 — **polymorphic이라 DB 트리거 X** (이슈 명세)
  - 자동 가림 시 운영자 알림 **webhook stub** (`MODERATION_WEBHOOK_URL` 환경변수 가드 — 이슈의 MVP 옵션)
- **가려진 댓글**: `getComments`가 본문을 서버에서 마스킹("이 댓글은 신고로 가려졌습니다") — 원문은 클라이언트로 안 감 (AC "server action 레벨")
- **T4 임시 `reportComment` 제거** → `reportTarget`으로 통합 (신고 경로 단일화)
- `ReportButton` (덱 상세 + 댓글, 사유 선택 입력), `.env.example` 갱신

### 제외 (이슈 명시 분리)
- hidden 덱 consumer UX (banner/noindex/인터랙션 차단/OG) — **#55 [T7a]**
- 가려진 덱의 피드/검색 제외 — T6(#109)에서 이미 `hidden = false` 필터로 구현 완료 (정합 확인만)
- rate limit 수치 — redesign 문서의 보류 항목 (유니크 제약이 대상당 1회 제한)
- AI 모더레이션/금칙어 — ADR 0013 V2

## Scope Check

```
verdict: APPROVE
primary layer: moderation
secondary layers: test, infra(.env.example), mechanical(types), game-state(wiring)
ADR count: 0
file count: 10
decision interlock: interlocked (reportComment 제거 ↔ reportTarget 신설은 동일 decision의 양면)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #50 AC)

- [x] reports 마이그레이션 + 유니크
- [x] 중복 신고 멱등 no-op
- [x] 덱 5회 / 댓글 3회 → `hidden = true` (applyReport 테스트)
- [x] 피드/검색 제외 — T6 `hidden = false` 필터와 정합
- [x] deck row SELECT RLS 유지 (직접 링크 생존 — consumer UX는 #55)
- [x] 가려진 댓글 서버 레벨 마스킹
- [x] 임계 환경변수 + Vitest (신규 6개, 총 181개 통과)
- [x] typecheck / lint / build 통과
- [ ] 라이브 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_