### PR TITLE
feat(moderation): [T7a] hidden 덱 consumer UX — 배너/noindex/인터랙션 차단

### DIFF
--- a/app/actions/challenge.ts
+++ b/app/actions/challenge.ts
@@ -101,11 +101,15 @@ async function loadRunContext(
 
   const { data: deck } = await admin
     .from("decks")
-    .select("id, script")
+    .select("id, script, hidden")
     .eq("id", deckId)
     .single();
   if (!deck || !isSupportedScript(deck.script)) {
     return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+  // 신고로 가려진 덱은 플레이 차단 — 작성자 예외 없음 (#55 기본값)
+  if (deck.hidden) {
+    return { ok: false, message: "비공개 덱은 플레이할 수 없습니다." };
   }
   const adapter = getScriptAdapter(deck.script);
 

--- a/app/actions/comment.ts
+++ b/app/actions/comment.ts
@@ -147,8 +147,16 @@ export async function createComment(input: {
     }
 
     const admin = createAdminClient();
-    const { data: deck } = await admin.from("decks").select("id").eq("id", deckId).single();
+    const { data: deck } = await admin
+      .from("decks")
+      .select("id, hidden")
+      .eq("id", deckId)
+      .single();
     if (!deck) return { success: false, message: "덱을 찾을 수 없습니다." };
+    // 가시성 게이트와 별도 — 신고로 가려진 덱에는 새 댓글 작성 차단 (#55)
+    if (deck.hidden) {
+      return { success: false, message: "비공개 덱에는 댓글을 쓸 수 없습니다." };
+    }
 
     const pwHash = await hashPassword(password);
     const { error } = await admin.from("comments").insert({

--- a/app/actions/daily.ts
+++ b/app/actions/daily.ts
@@ -87,11 +87,15 @@ async function loadRoundContext(
 
   const { data: deck } = await admin
     .from("decks")
-    .select("id, script")
+    .select("id, script, hidden")
     .eq("id", deckId)
     .single();
   if (!deck || !isSupportedScript(deck.script)) {
     return { ok: false, message: "덱을 찾을 수 없습니다." };
+  }
+  // 신고로 가려진 덱은 플레이 차단 — 작성자 예외 없음 (#55 기본값)
+  if (deck.hidden) {
+    return { ok: false, message: "비공개 덱은 플레이할 수 없습니다." };
   }
   const adapter = getScriptAdapter(deck.script);
 

--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -70,6 +70,23 @@ export async function toggleLike(
 
     const admin = createAdminClient();
 
+    // 신고로 가려진 덱은 좋아요 토글 차단 — 기존 좋아요 카운트는 유지 (#55)
+    const { data: deck } = await admin
+      .from("decks")
+      .select("hidden")
+      .eq("id", deckId)
+      .single();
+    if (!deck) return { success: false, message: "덱을 찾을 수 없습니다." };
+    if (deck.hidden) {
+      const status = await currentStatus(deckId, ipHash);
+      return {
+        success: false,
+        conflict: true,
+        message: "비공개 덱에는 좋아요를 누를 수 없습니다.",
+        ...(status ? { data: status } : {}),
+      };
+    }
+
     if (like) {
       const { error } = await admin
         .from("likes")

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getDeckById } from "@/app/actions/deck";
@@ -5,10 +6,24 @@ import { DeckMetaCard } from "@/components/DeckMetaCard";
 import { CommentThread } from "@/components/CommentThread";
 import { LikeButton } from "@/components/LikeButton";
 import { ReportButton } from "@/components/ReportButton";
+import { HiddenDeckBanner } from "@/components/HiddenDeckBanner";
 import { Button } from "@/components/ui/button";
 
 interface DeckPageProps {
   params: Promise<{ id: string }>;
+}
+
+// 가려진 덱은 검색 엔진 인덱싱 차단 (#55 — noindex)
+export async function generateMetadata({ params }: DeckPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const result = await getDeckById(id);
+  if (!result.success || !result.data) return { title: "wordledecks" };
+
+  const { deck } = result.data;
+  return {
+    title: `${deck.name} | wordledecks`,
+    ...(deck.hidden ? { robots: { index: false, follow: false } } : {}),
+  };
 }
 
 export default async function DeckPage({ params }: DeckPageProps) {
@@ -18,6 +33,16 @@ export default async function DeckPage({ params }: DeckPageProps) {
 
   const { deck, words } = result.data;
   const activeWordCount = words.filter((w) => w.active).length;
+
+  // 직접 링크는 살아있되 인터랙션은 전부 차단 — 작성자 대응 경로만 노출 (ADR 0013)
+  if (deck.hidden) {
+    return (
+      <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+        <HiddenDeckBanner deckId={deck.id} />
+        <DeckMetaCard deck={deck} activeWordCount={activeWordCount} />
+      </main>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">

--- a/app/d/[id]/play/page.tsx
+++ b/app/d/[id]/play/page.tsx
@@ -17,12 +17,21 @@ export default async function PlayPage({ params, searchParams }: PlayPageProps) 
   const supabase = await createClient();
   const { data: deck } = await supabase
     .from("decks")
-    .select("id, name, script")
+    .select("id, name, script, hidden")
     .eq("id", id)
     .single();
   if (!deck || !isSupportedScript(deck.script)) notFound();
 
   if (mode !== "daily" && mode !== "challenge") notFound();
+
+  // 가려진 덱은 플레이 차단 — server action도 동일하게 거부한다 (#55)
+  if (deck.hidden) {
+    return (
+      <main className="mx-auto max-w-xl px-4 py-8 text-center text-sm text-muted-foreground">
+        비공개 덱은 플레이할 수 없습니다.
+      </main>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">

--- a/components/HiddenDeckBanner.tsx
+++ b/components/HiddenDeckBanner.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface HiddenDeckBannerProps {
+  deckId: string;
+}
+
+// 신고 누적으로 가려진 덱의 직접 링크 방문자 안내 (#55, ADR 0013)
+// 작성자는 nick+pw로 편집 페이지에 들어가 모더레이션 대응이 가능하다.
+export function HiddenDeckBanner({ deckId }: HiddenDeckBannerProps) {
+  return (
+    <div className="space-y-3 rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-center">
+      <p className="font-medium">🚧 이 덱은 신고로 비공개됐습니다.</p>
+      <p className="text-sm text-muted-foreground">
+        플레이·좋아요·댓글이 차단된 상태입니다. 덱을 만든 분이라면 내용을 수정해
+        검토에 대응할 수 있습니다.
+      </p>
+      <Button asChild variant="outline" size="sm">
+        <Link href={`/d/${deckId}/edit`}>작성자 수정 페이지</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #55

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> hidden 덱의 모든 consumer 인터랙션 경로(플레이 daily/challenge, 좋아요, 댓글, 검색 인덱싱)가 빠짐없이 차단되는가?

## Scope

### 포함 (7 files)
- **상세 페이지** `/d/[id]`
  - hidden이면 `HiddenDeckBanner`("이 덱은 신고로 비공개됐습니다") + 메타 카드만 — 플레이/좋아요/신고/댓글 전부 미노출 (AC: 인터랙션 차단)
  - **작성자 수정 페이지 링크** 노출 — nick+pw 게이트가 있어 본인만 진입 가능 (AC: 모더레이션 대응 경로)
  - `generateMetadata` → **robots noindex** (AC)
- **게임 시작 차단**: daily/challenge `loadContext`에서 `hidden` reject("비공개 덱은 플레이할 수 없습니다") — **작성자 예외 없음(이슈 기본값 채택)**. play 페이지도 서버 레벨 동일 가드 (UI+action 이중)
- **좋아요**: `toggleLike` hidden reject(conflict + 서버 진실 동봉) — **기존 좋아요 카운트는 유지, 롤백 X** (AC)
- **댓글**: `createComment` hidden reject — 가시성 게이트와 별도 (AC). **기존 댓글 표시는 유지** (AC)
- **복구 흐름**: 모든 가드가 `hidden` 플래그 단일 기준 → `hidden = false` 복구 시 전 인터랙션 자연 복귀 (AC)

### OG (AC 항목 — T8 위임)
현재 `/api/og` 라우트는 덱 정보를 렌더하지 않아(generic 텍스트만) **hidden 덱 정보가 노출될 경로 자체가 없음**. 덱별 OG 이미지는 T8(#51)에서 구현하며 그때 hidden 체크를 포함 — sitemap 제외도 T8의 sitemap 구현에서 `hidden = false` 필터로 처리.

### Known gap
- server action 가드 4곳은 DB 의존이라 단위 테스트 없음 — E2E 스모크(T10c #66)에서 커버 예정

## Scope Check

```
verdict: APPROVE
primary layer: moderation (hidden 덱 enforcement)
secondary layers: game-state (play 경로 가드)
ADR count: 0
file count: 7 (선언 ~8과의 차이: OG 라우트 변경이 불필요해짐)
decision interlock: interlocked (UI 차단과 action 가드는 한쪽만 머지 시 우회 경로 발생)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증

- [x] typecheck / lint / 테스트 181개 / build 통과
- [ ] hidden 덱 시나리오 라이브 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_