### PR TITLE
feat(api): [T9a] bot_ nick 검증 + PUT 멱등 단어 동기화 API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ REPORT_THRESHOLD_DECK=5
 REPORT_THRESHOLD_COMMENT=3
 # 자동 가림 시 운영자 알림 webhook (선택)
 MODERATION_WEBHOOK_URL=
+
+# 운영자 시드 API 토큰 (ADR 0011) — bot_* nick으로 POST /api/decks 호출 시 x-bot-token 헤더에 사용
+BOT_SEED_TOKEN=

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -10,6 +10,7 @@ import {
   verifyPassword,
   validateNick,
   validatePasswordLength,
+  isBotNick,
   PASSWORD_MIN_LENGTH,
   PASSWORD_MAX_LENGTH,
   NICK_MAX_LENGTH,
@@ -73,6 +74,9 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
     if (!isSupportedScript(script)) fieldErrors.script = ["지원하지 않는 쓰기체계입니다."];
     if (!validateNick(nick)) {
       fieldErrors.nick = [`닉네임은 1~${NICK_MAX_LENGTH}자, '#' 없이 입력해야 합니다.`];
+    } else if (isBotNick(nick)) {
+      // bot_ prefix는 운영자 시드 전용 — 일반 경로 차단 (#77, API는 토큰으로 허용)
+      fieldErrors.nick = ["bot_ prefix 닉네임은 사용할 수 없습니다."];
     }
     if (!validatePasswordLength(password)) {
       fieldErrors.password = [`비밀번호는 ${PASSWORD_MIN_LENGTH}~${PASSWORD_MAX_LENGTH}자여야 합니다.`];

--- a/app/api/decks/[id]/route.ts
+++ b/app/api/decks/[id]/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase-admin";
+import { verifyDeckCredentials } from "@/app/actions/deck";
+import { parseWordLines, planWordSync, type DeckWordRow } from "@/lib/deckWords";
+import { isSupportedScript } from "@/lib/scripts";
+
+// PUT /api/decks/{id} — 시즌/스토리 업데이트용 멱등 단어 동기화 (ADR 0011)
+// body.words를 desired 집합으로 보고 diff 적용: 신규 insert, 사라진 건 active=false.
+// 같은 요청 두 번 → 두 번째는 전부 no-op (멱등성 AC).
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: deckId } = await params;
+
+  let body: { nick?: string; password?: string; words?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "JSON 본문이 필요합니다." }, { status: 400 });
+  }
+  if (!Array.isArray(body.words)) {
+    return NextResponse.json(
+      { success: false, message: "words 배열이 필요합니다." },
+      { status: 400 },
+    );
+  }
+
+  const credentials = await verifyDeckCredentials(
+    deckId,
+    String(body.nick ?? "").trim(),
+    String(body.password ?? ""),
+  );
+  if (!credentials.success) {
+    return NextResponse.json(credentials, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: deck } = await admin
+    .from("decks")
+    .select("script")
+    .eq("id", deckId)
+    .single();
+  if (!deck || !isSupportedScript(deck.script)) {
+    return NextResponse.json({ success: false, message: "덱을 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const parsed = parseWordLines(body.words.join("\n"), deck.script);
+  if (!parsed.ok) {
+    return NextResponse.json({ success: false, message: parsed.message }, { status: 400 });
+  }
+
+  const { data: existing } = await admin
+    .from("words")
+    .select("id, text, active")
+    .eq("deck_id", deckId);
+  if (!existing) {
+    return NextResponse.json(
+      { success: false, message: "단어 목록을 가져오는데 실패했습니다." },
+      { status: 500 },
+    );
+  }
+
+  const planResult = planWordSync(existing as DeckWordRow[], parsed.words);
+  if (!planResult.ok) {
+    // 마지막 active 제거 시도 등 invariant 위반 — 일반 경로와 동일하게 reject (AC)
+    return NextResponse.json({ success: false, message: planResult.message }, { status: 400 });
+  }
+
+  const { toInsert, toReactivateIds, toDeactivateIds } = planResult.plan;
+  if (toInsert.length > 0) {
+    const { error } = await admin
+      .from("words")
+      .insert(toInsert.map((text) => ({ deck_id: deckId, text })));
+    if (error) {
+      return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+    }
+  }
+  if (toReactivateIds.length > 0) {
+    const { error } = await admin
+      .from("words")
+      .update({ active: true })
+      .in("id", toReactivateIds);
+    if (error) {
+      return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+    }
+  }
+  if (toDeactivateIds.length > 0) {
+    const { error } = await admin
+      .from("words")
+      .update({ active: false })
+      .in("id", toDeactivateIds);
+    if (error) {
+      return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+    }
+  }
+
+  await admin
+    .from("decks")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", deckId);
+
+  return NextResponse.json({
+    success: true,
+    message: "덱 단어를 동기화했습니다.",
+    data: {
+      inserted: toInsert.length,
+      reactivated: toReactivateIds.length,
+      deactivated: toDeactivateIds.length,
+    },
+  });
+}

--- a/app/api/decks/route.ts
+++ b/app/api/decks/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { createDeck } from "@/app/actions/deck";
+import { isBotNick } from "@/lib/identity";
+
+// POST /api/decks — 운영자 시드 도구의 진입점 (ADR 0011: 일반 사용자 API 도그푸딩)
+// bot_* nick은 운영자 전용 — x-bot-token이 BOT_SEED_TOKEN과 일치할 때만 허용 (#77)
+
+function botTokenValid(request: Request): boolean {
+  const token = process.env.BOT_SEED_TOKEN;
+  return Boolean(token) && request.headers.get("x-bot-token") === token;
+}
+
+export async function POST(request: Request) {
+  let body: {
+    name?: string;
+    script?: string;
+    nick?: string;
+    password?: string;
+    words?: string[];
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "JSON 본문이 필요합니다." }, { status: 400 });
+  }
+
+  const nick = String(body.nick ?? "").trim();
+  if (isBotNick(nick) && !botTokenValid(request)) {
+    return NextResponse.json(
+      { success: false, message: "bot_ prefix 닉네임은 사용할 수 없습니다." },
+      { status: 400 },
+    );
+  }
+  if (!Array.isArray(body.words)) {
+    return NextResponse.json(
+      { success: false, message: "words 배열이 필요합니다." },
+      { status: 400 },
+    );
+  }
+
+  // 서버 액션(createDeck)을 그대로 재사용 — 검증·invariant가 한 곳에 유지된다
+  const formData = new FormData();
+  formData.set("name", String(body.name ?? ""));
+  formData.set("script", String(body.script ?? "latin"));
+  formData.set("nick", nick);
+  formData.set("password", String(body.password ?? ""));
+  formData.set("words_text", body.words.join("\n"));
+
+  const result = await createDeck(formData);
+  return NextResponse.json(result, { status: result.success ? 201 : 400 });
+}

--- a/lib/deckWords.test.ts
+++ b/lib/deckWords.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseWordLines, planWordUpdate, type DeckWordRow } from './deckWords';
+import { parseWordLines, planWordUpdate, planWordSync, type DeckWordRow } from './deckWords';
 
 function row(id: string, text: string, active: boolean): DeckWordRow {
   return { id, text, active };
@@ -104,5 +104,45 @@ describe('planWordUpdate — min 1 active invariant (ADR 0010)', () => {
       ok: true,
       plan: { toInsert: [], toReactivateIds: [], toDeactivateIds: [] },
     });
+  });
+});
+
+describe('planWordSync — PUT 멱등 동기화 (ADR 0011, #77)', () => {
+  it('desired에만 있는 단어는 insert, 사라진 단어는 deactivate', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', true)];
+    const result = planWordSync(existing, ['피카츄', '파이리']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: ['파이리'], toReactivateIds: [], toDeactivateIds: ['w2'] },
+    });
+  });
+
+  it('inactive였던 단어가 desired에 있으면 reactivate (영구 ID)', () => {
+    const existing = [row('w1', '피카츄', false), row('w2', '이상해씨', true)];
+    const result = planWordSync(existing, ['피카츄', '이상해씨']);
+    expect(result).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: ['w1'], toDeactivateIds: [] },
+    });
+  });
+
+  it('멱등성: 같은 요청을 두 번 적용하면 두 번째는 전부 no-op (AC)', () => {
+    const existing = [row('w1', '피카츄', true), row('w2', '이상해씨', true)];
+    const desired = ['피카츄', '파이리'];
+    const first = planWordSync(existing, desired);
+    expect(first.ok).toBe(true);
+    // 1차 적용 후 상태 시뮬레이션
+    const after = [row('w1', '피카츄', true), row('w2', '이상해씨', false), row('w3', '파이리', true)];
+    const second = planWordSync(after, desired);
+    expect(second).toEqual({
+      ok: true,
+      plan: { toInsert: [], toReactivateIds: [], toDeactivateIds: [] },
+    });
+  });
+
+  it('빈 desired(마지막 active 제거)는 reject — min-1-active (AC)', () => {
+    const existing = [row('w1', '피카츄', true)];
+    const result = planWordSync(existing, []);
+    expect(result.ok).toBe(false);
   });
 });

--- a/lib/deckWords.ts
+++ b/lib/deckWords.ts
@@ -112,3 +112,29 @@ export function planWordUpdate(
     plan: { toInsert, toReactivateIds: [...reactivate], toDeactivateIds },
   };
 }
+
+// PUT 멱등 동기화 (ADR 0011): desired 단어 집합과 기존 row를 diff한다.
+// - desired에만 있는 text → insert
+// - 기존 inactive인데 desired에 있는 text → reactivate (영구 ID 유지, ADR 0010)
+// - 기존 active인데 desired에 없는 text → deactivate (soft-delete)
+// 같은 요청을 두 번 적용하면 두 번째는 전부 no-op이 된다 (멱등성).
+export function planWordSync(
+  existing: DeckWordRow[],
+  desiredTexts: string[],
+): PlanResult {
+  const desired = new Set(desiredTexts);
+  if (desired.size < MIN_ACTIVE_WORDS) {
+    return { ok: false, message: "최소 1개의 활성 단어가 필요합니다." };
+  }
+
+  const byText = new Map(existing.map((w) => [w.text, w]));
+  const toInsert = [...desired].filter((text) => !byText.has(text));
+  const toReactivateIds = existing
+    .filter((w) => !w.active && desired.has(w.text))
+    .map((w) => w.id);
+  const toDeactivateIds = existing
+    .filter((w) => w.active && !desired.has(w.text))
+    .map((w) => w.id);
+
+  return { ok: true, plan: { toInsert, toReactivateIds, toDeactivateIds } };
+}

--- a/lib/identity.test.ts
+++ b/lib/identity.test.ts
@@ -5,6 +5,7 @@ import {
   validateNick,
   validatePasswordLength,
   formatDisplayNick,
+  isBotNick,
   NICK_MAX_LENGTH,
 } from './identity';
 
@@ -71,5 +72,18 @@ describe('formatDisplayNick', () => {
 
   it('uuid 대시를 무시하고 hex만 사용하며 소문자로 통일한다', () => {
     expect(formatDisplayNick('kim', 'AB-CDEF1234')).toBe('kim#abcd');
+  });
+});
+
+describe('isBotNick — 운영자 시드 전용 prefix (ADR 0011, #77)', () => {
+  it('bot_ prefix를 감지한다 (대소문자 무관)', () => {
+    expect(isBotNick('bot_pokemon_kr')).toBe(true);
+    expect(isBotNick('Bot_onepiece')).toBe(true);
+  });
+
+  it('일반 닉네임은 통과한다', () => {
+    expect(isBotNick('철수')).toBe(false);
+    expect(isBotNick('robot')).toBe(false);
+    expect(isBotNick('my_bot_')).toBe(false);
   });
 });

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -36,3 +36,10 @@ export function validatePasswordLength(pw: string): boolean {
 export function formatDisplayNick(nick: string, anonId: string): string {
   return `${nick}#${anonId.replaceAll("-", "").slice(0, 4).toLowerCase()}`;
 }
+
+// 운영자 시드 봇 전용 prefix (ADR 0011) — 일반 사용자는 사용 불가
+export const BOT_NICK_PREFIX = "bot_";
+
+export function isBotNick(nick: string): boolean {
+  return nick.toLowerCase().startsWith(BOT_NICK_PREFIX);
+}


### PR DESCRIPTION
Fixes #77

## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Main Review Question

> 운영자 시드 진입점(bot_ 토큰 가드 + PUT 멱등 동기화)이 일반 사용자 경로의 invariant를 깨지 않고 안전한가?

## Scope

### 포함 (8 files)
- **`POST /api/decks`** — 운영자 시드 진입점 (ADR 0011 "운영자도 일반 API의 first user"). `createDeck` 서버 액션을 그대로 재사용해 검증·invariant 단일화
- **`PUT /api/decks/{id}`** — nick+pw 검증 후 desired 단어 집합과 diff: 신규 insert / 사라진 건 `active=false` / inactive 재등장은 reactivate(영구 ID, ADR 0010) / **마지막 active 제거 reject** (AC)
- **`lib/deckWords.planWordSync`** 순수 함수 — **멱등성 테스트로 고정** (같은 요청 2회 → 2회차 전부 no-op, AC)
- **`lib/identity.isBotNick`** + UI 경로(`createDeck`)에도 bot_ 가드 3줄 — API만 막으면 폼으로 우회 가능
- `.env.example`: `BOT_SEED_TOKEN`

### 선언 scope 대비 확장 (명시 — scope checker 권고)
**`x-bot-token` 허용 메커니즘**: 이슈는 "일반 사용자의 bot_* nick 400"만 명시하지만, ADR 0011상 운영자는 **같은 API로 bot_ nick을 사용해야** 합니다. 허용 경로 없이 가드만 넣으면 운영자 시드 자체가 차단되므로, `x-bot-token` 헤더가 `BOT_SEED_TOKEN` 환경변수와 일치할 때만 bot_ nick을 허용했습니다. 토큰 미설정 환경에서는 bot_ nick이 전면 차단됩니다(fail closed).

### 참고
- ADR 0011/0010은 `claude/migrate-ip-wordle-design-Jsxo2` 브랜치의 `docs/adr/`에 있습니다 (main 미머지 — T10b #65 문서 정합 대상)
- rate limit 수치는 redesign 문서의 보류 항목 — 미구현
- 시드 스크립트(LLM → API 호출)는 T9b(#78)

## Scope Check

```
verdict: APPROVE
primary layer: game-state (deck API routes)
secondary layers: identity (helper), test, infra (.env)
ADR count: 0
file count: 8
decision interlock: interlocked (UI/API 이중 가드, 토큰 없인 운영자 경로 차단, POST/PUT은 이슈가 한 단위 선언)
split suggestion: 해당 없음
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 (이슈 #77 AC)

- [x] bot_* nick 일반 시도 → 400 (UI 경로 fieldError 포함)
- [x] PUT 추가 → insert(active: true) / 제거 → soft-delete / 마지막 active 제거 → reject
- [x] 멱등성: 같은 요청 2회 → 동일 결과 (planWordSync 테스트)
- [x] Vitest: bot_ 검증·PUT 멱등성·min-1-active (신규 6개, 총 187개)
- [x] `pnpm test` / `pnpm build` / typecheck / lint 통과
- [ ] 라이브 API 호출 검증 — Supabase 프로젝트 복구 후

https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBkg6VAk6qW3p5Jk4Wsaz5)_