### PR TITLE
test: [T10c] Playwright E2E 스모크 7개 시나리오

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: E2E
+
+# Playwright 스모크 (이슈 #66 [T10c]). 라이브 Supabase가 필요하므로 시크릿이
+# 설정된 경우에만 실제로 실행하고, 미설정 시(현재 프로젝트 일시정지) 빠르게 통과한다.
+# 테스트 자체도 env 가드로 skip되지만, 시크릿 부재 시 브라우저 설치를 건너뛰어
+# 불필요한 비용을 줄인다.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      IP_HASH_SALT: ${{ secrets.IP_HASH_SALT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect Supabase secrets
+        id: guard
+        run: |
+          if [ -n "${NEXT_PUBLIC_SUPABASE_URL}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Supabase secrets not configured — skipping E2E (env guard)."
+          fi
+
+      - if: steps.guard.outputs.configured == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - if: steps.guard.outputs.configured == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Run E2E smoke
+        run: pnpm test:e2e
+
+      - if: ${{ steps.guard.outputs.configured == 'true' && !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 # testing
 /coverage
 
+# playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/blob-report/
+
 # next.js
 /.next/
 /out/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,61 @@
+# E2E 스모크 (Playwright)
+
+이슈 #66 [T10c]. 골든 패스 7개 시나리오를 실제 서버 액션 위에서 검증한다.
+
+## 시나리오 ↔ 파일
+
+| # | 시나리오 | 파일 |
+| - | -------- | ---- |
+| 1 | 익명 세션 자동 발급 → 메인 피드 진입 | `discovery.spec.ts` |
+| 2 | 검색으로 덱 발견 → 덱 상세 진입 | `discovery.spec.ts` |
+| 3 | 데일리 시작 → 풀이 완료 | `gameplay.spec.ts` |
+| 4 | 챌린지 잠금 해제 → 시작 → perfect | `gameplay.spec.ts` |
+| 5 | 댓글 작성 (nick + pw) | `social.spec.ts` |
+| 6 | 좋아요 클릭 → 증가 → 새로고침 후 유지 | `social.spec.ts` |
+| 7 | 결과 클립보드 복사 | `gameplay.spec.ts` |
+
+## 결정적 정답 (one-word deck)
+
+각 테스트는 `/d/new` 폼으로 **단어 1개짜리 latin 덱**을 만든다. `pickDailyWordId`가
+`seed % 1` → 항상 그 단어를 고르므로, ADR 0008(라운드 종료 전 단어 비노출)을 깨지 않고도
+테스트가 정답(`smoketest`)을 알 수 있다. 키 입력은 화면 키보드 클릭으로 수행한다
+(물리 키 핸들러 없음).
+
+## 실행
+
+```bash
+# 1. env 준비 (.env.local) — 아래 "환경변수" 참조
+# 2. 브라우저 1회 설치
+pnpm exec playwright install chromium
+# 3. 실행 (dev 서버 자동 기동)
+pnpm test:e2e
+pnpm test:e2e:ui   # 디버그
+```
+
+이미 `pnpm dev`가 떠 있으면 재사용한다. 원격 환경 대상이면
+`E2E_BASE_URL=https://...` 로 dev 서버 기동을 건너뛴다.
+
+## 환경변수 분리 / 가드
+
+라이브 Supabase가 필요하다. `NEXT_PUBLIC_SUPABASE_URL`이 없거나 `example.supabase.co`면
+**모든 스펙이 자동 skip**된다 (`requireLiveSupabase`). 동일 판정을 `playwright.config.ts`가
+공유해 미설정 시 dev 서버 기동도 생략한다.
+
+| 변수 | 용도 |
+| ---- | ---- |
+| `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 가드 판정 + 클라이언트 |
+| `SUPABASE_SERVICE_ROLE_KEY` | 서버 액션(admin) |
+| `IP_HASH_SALT` | 좋아요 IP 해시 (ADR 0002) |
+
+좋아요는 클라이언트 IP가 있어야 한다. `next dev`는 IP를 전달하지 않으므로 config가
+`x-forwarded-for` 헤더를 주입한다. 클립보드 시나리오는 config의 `clipboard-read/write`
+권한에 의존한다.
+
+## 현재 검증 상태 (블로킹)
+
+> **이 환경에서는 실행 검증 불가.**
+> 1) Supabase 프로젝트 일시정지 → 라이브 DB 없음.
+> 2) 컨테이너 네트워크 정책상 `cdn.playwright.dev` 차단 → 브라우저 다운로드 불가.
+>
+> 스펙은 env 가드로 CI에서 안전하게 skip되며, Supabase 복구 + 브라우저 설치 후
+> `pnpm test:e2e`로 검증해야 한다. (PR 체크리스트에 "Supabase 복구 후" 보류로 명시)

--- a/e2e/discovery.spec.ts
+++ b/e2e/discovery.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect, requireLiveSupabase, createDeck, uniqueDeckName } from "./fixtures";
+
+// Scenarios 1 & 2 from issue #66: anonymous session + feed entry, and
+// discovering a deck through search.
+test.describe("discovery", () => {
+  requireLiveSupabase();
+
+  // Scenario 1: 익명 세션 자동 발급 → 메인 피드 진입
+  test("feed renders and the first write lazily issues an anon session", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "wordledecks" })).toBeVisible();
+    await expect(page.getByRole("searchbox", { name: "덱 이름 검색" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "새 덱" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "🔥 Hot" })).toBeVisible();
+
+    // ADR 0001: no anon session until the first write/play. Browsing the feed
+    // alone must not mint one.
+    const hasAuthCookie = async () =>
+      (await page.context().cookies()).some((c) => /sb-.*auth-token/.test(c.name));
+    expect(await hasAuthCookie()).toBe(false);
+
+    // Creating a deck is a write → getOrCreateAnonUserId() signs in anonymously.
+    await createDeck(page, { name: uniqueDeckName("anon"), word: "smoketest" });
+    expect(await hasAuthCookie()).toBe(true);
+  });
+
+  // Scenario 2: 검색으로 덱 발견 → 덱 상세 진입
+  test("search surfaces a deck and links into its detail page", async ({ page }) => {
+    const name = uniqueDeckName("search");
+    const id = await createDeck(page, { name, word: "smoketest" });
+
+    await page.goto("/");
+    await page.getByRole("searchbox", { name: "덱 이름 검색" }).fill(name);
+    await page.getByRole("searchbox", { name: "덱 이름 검색" }).press("Enter");
+
+    await page.waitForURL(/\/search\?q=/);
+    await page.getByText(name).first().click();
+
+    await page.waitForURL(new RegExp(`/d/${id}(\\?|$|/)`));
+    await expect(page.getByRole("link", { name: "오늘의 데일리 플레이" })).toBeVisible();
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,77 @@
+import { test as base, expect, type Page } from "@playwright/test";
+
+// --- Live-Supabase guard -----------------------------------------------------
+// The smoke suite drives real server actions (anon auth, daily locks, likes,
+// comments) that require a live Supabase project. While the project is paused
+// these specs skip instead of failing — keep this predicate in sync with the
+// `hasLiveSupabase` mirror in playwright.config.ts.
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+export const liveSupabaseConfigured =
+  /^https?:\/\//.test(supabaseUrl) && !supabaseUrl.includes("example.supabase.co");
+
+export const test = base;
+export { expect };
+
+/** Skip every test in the enclosing describe when no live Supabase is wired. */
+export function requireLiveSupabase(): void {
+  test.skip(
+    !liveSupabaseConfigured,
+    "requires a live Supabase project (T10c: project paused — see e2e/README.md)",
+  );
+}
+
+let deckSeq = 0;
+
+/** Collision-resistant deck name so search (scenario 2) finds exactly one. */
+export function uniqueDeckName(label: string): string {
+  deckSeq += 1;
+  return `e2e-${label}-${Date.now()}-${deckSeq}`;
+}
+
+interface CreateDeckOptions {
+  name: string;
+  /** Single latin word (a-z). One active word ⇒ deterministic daily target. */
+  word: string;
+}
+
+/**
+ * Create a latin deck through the real /d/new form and return its id.
+ *
+ * A one-word deck is intentional: `pickDailyWordId` does `seed % 1`, so the
+ * daily/challenge target is always `word` — letting the smoke tests type a
+ * known answer without reading server state (ADR 0008 keeps the word off the
+ * client until the round ends).
+ */
+export async function createDeck(page: Page, { name, word }: CreateDeckOptions): Promise<string> {
+  await page.goto("/d/new");
+  await page.getByLabel("덱 이름").fill(name);
+  // script defaults to latin — leave the Select untouched.
+  await page.getByLabel("닉네임").fill("e2e");
+  await page.getByLabel("비밀번호 (덱 전용 PIN)").fill("e2epw");
+  await page.getByLabel("단어 목록 (줄당 1개)").fill(word);
+  await page.getByRole("button", { name: "덱 만들기" }).click();
+
+  await page.waitForURL(/\/d\/[^/]+$/);
+  const id = page.url().split("/d/")[1]?.split(/[/?#]/)[0];
+  if (!id) throw new Error(`createDeck: could not parse deck id from ${page.url()}`);
+  return id;
+}
+
+/**
+ * Type a latin word on the on-screen keyboard and submit it.
+ *
+ * Keys render as uppercase single chars (lib/scripts/latin.ts). SmartKeyboard
+ * also renders a dedicated ENTER button *after* the rows, so the functional
+ * submit is the last "ENTER" — `.last()` avoids the row-embedded duplicate.
+ */
+export async function typeAndSubmit(page: Page, word: string): Promise<void> {
+  for (const ch of word.toUpperCase()) {
+    await page.getByRole("button", { name: ch, exact: true }).click();
+  }
+  await page.getByRole("button", { name: "ENTER", exact: true }).last().click();
+}
+
+/** Wait until the latin keyboard is interactive (game finished loading). */
+export async function waitForKeyboard(page: Page): Promise<void> {
+  await expect(page.getByRole("button", { name: "A", exact: true })).toBeVisible();
+}

--- a/e2e/gameplay.spec.ts
+++ b/e2e/gameplay.spec.ts
@@ -1,0 +1,68 @@
+import {
+  test,
+  expect,
+  requireLiveSupabase,
+  createDeck,
+  uniqueDeckName,
+  typeAndSubmit,
+  waitForKeyboard,
+} from "./fixtures";
+
+// Scenarios 3, 4 & 7 from issue #66: daily solve, challenge perfect-clear,
+// and copying the result to the clipboard.
+test.describe("gameplay", () => {
+  requireLiveSupabase();
+
+  // Scenario 3 + 7: 데일리 시작 → 풀이 완료 → 결과 클립보드 복사
+  test("daily round can be solved and the result copied", async ({ page }) => {
+    const id = await createDeck(page, { name: uniqueDeckName("daily"), word: "smoketest" });
+
+    await page.goto(`/d/${id}`);
+    await page.getByRole("link", { name: "오늘의 데일리 플레이" }).click();
+    await page.waitForURL(/mode=daily/);
+
+    await waitForKeyboard(page);
+    await typeAndSubmit(page, "smoketest");
+
+    await expect(page.getByText("🎉 정답!")).toBeVisible();
+    await expect(page.getByText(/정답:\s*smoketest/)).toBeVisible();
+
+    // Scenario 7: copy result → toast + clipboard payload (ResultScreen).
+    await page.getByRole("button", { name: "결과 복사" }).click();
+    await expect(page.getByText("결과를 복사했습니다.")).toBeVisible();
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("데일리");
+    expect(clipboard).toContain("🟩");
+  });
+
+  // Scenario 4: 챌린지 잠금 해제 → 시작 → 진행 → perfect
+  test("clearing the daily unlocks a challenge that perfect-clears", async ({ page }) => {
+    const id = await createDeck(page, { name: uniqueDeckName("challenge"), word: "smoketest" });
+
+    // Daily must end before the challenge gate opens (ADR 0006).
+    await page.goto(`/d/${id}/play?mode=daily`);
+    await waitForKeyboard(page);
+    await typeAndSubmit(page, "smoketest");
+    await expect(page.getByText("🎉 정답!")).toBeVisible();
+
+    await page.getByRole("link", { name: /챌린지 도전/ }).click();
+    await page.waitForURL(/mode=challenge/);
+
+    // One active word ⇒ a single-round run; solving it is a perfect clear.
+    await waitForKeyboard(page);
+    await typeAndSubmit(page, "smoketest");
+
+    await expect(page.getByText("PERFECT CLEAR")).toBeVisible();
+  });
+
+  // Guard: visiting the challenge before the daily ends shows the locked gate.
+  test("challenge is gated until the daily is completed", async ({ page }) => {
+    const id = await createDeck(page, { name: uniqueDeckName("gate"), word: "smoketest" });
+
+    await page.goto(`/d/${id}/play?mode=challenge`);
+
+    await expect(page.getByText("오늘의 데일리를 먼저 풀어야 챌린지가 열립니다.")).toBeVisible();
+    await expect(page.getByRole("link", { name: "오늘의 데일리 풀러 가기" })).toBeVisible();
+  });
+});

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -1,0 +1,57 @@
+import {
+  test,
+  expect,
+  requireLiveSupabase,
+  createDeck,
+  uniqueDeckName,
+  typeAndSubmit,
+  waitForKeyboard,
+} from "./fixtures";
+
+// Scenarios 5 & 6 from issue #66: commenting (nick + pw) and liking.
+test.describe("social", () => {
+  requireLiveSupabase();
+
+  // Scenario 5: 댓글 작성 (nick + pw)
+  test("a comment can be posted after the daily gate opens", async ({ page }) => {
+    const id = await createDeck(page, { name: uniqueDeckName("comment"), word: "smoketest" });
+
+    // Today's thread stays locked until the reader finishes today's daily
+    // (CONTEXT.md 가시성 게이트). Solve it first to reveal the comment form.
+    await page.goto(`/d/${id}/play?mode=daily`);
+    await waitForKeyboard(page);
+    await typeAndSubmit(page, "smoketest");
+    await expect(page.getByText("🎉 정답!")).toBeVisible();
+
+    await page.goto(`/d/${id}`);
+
+    const body = `e2e 댓글 ${Date.now()}`;
+    await page.getByPlaceholder("오늘의 단어에 대해 한마디 (결과를 붙여넣어도 좋아요)").fill(body);
+    await page.getByPlaceholder("닉네임").fill("e2e작성자");
+    await page.getByPlaceholder("비밀번호").fill("pw1234");
+    await page.getByRole("button", { name: "댓글 남기기" }).click();
+
+    await expect(page.getByText(body)).toBeVisible();
+    await expect(page.getByText(/e2e작성자#[0-9a-f]{4}/)).toBeVisible();
+  });
+
+  // Scenario 6: 좋아요 클릭 → 카운트 증가 → 새로고침 후 유지
+  test("liking increments the count and persists across a reload", async ({ page }) => {
+    const id = await createDeck(page, { name: uniqueDeckName("like"), word: "smoketest" });
+    await page.goto(`/d/${id}`);
+
+    // The deck detail page renders exactly one aria-pressed button (LikeButton).
+    const like = page.locator("button[aria-pressed]");
+    await expect(like).toHaveAttribute("aria-pressed", "false");
+    await expect(like).toContainText("0");
+
+    await like.click();
+    await expect(like).toHaveAttribute("aria-pressed", "true");
+    await expect(like).toContainText("1");
+
+    await page.reload();
+    const likeAfter = page.locator("button[aria-pressed]");
+    await expect(likeAfter).toHaveAttribute("aria-pressed", "true");
+    await expect(likeAfter).toContainText("1");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "ai:propose-topics": "tsx scripts/ai/propose-topics.ts",
     "ai:generate-decks": "tsx scripts/ai/generate-decks.ts"
   },
@@ -36,6 +38,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,67 @@
+import { defineConfig, devices } from "@playwright/test";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Playwright (unlike Next.js) does not auto-load .env files. Load the same
+// files Next reads so the live-Supabase guard (e2e/fixtures.ts) and the
+// webServer below see identical env. CI provides these via secrets instead.
+for (const file of [".env.local", ".env"]) {
+  const path = resolve(__dirname, file);
+  if (!existsSync(path)) continue;
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const match = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/.exec(line);
+    if (!match) continue;
+    const key = match[1];
+    if (process.env[key] !== undefined) continue;
+    let value = (match[2] ?? "").trim();
+    if (/^(['"]).*\1$/.test(value)) value = value.slice(1, -1);
+    process.env[key] = value;
+  }
+}
+
+// Mirror of e2e/fixtures.ts `liveSupabaseConfigured`. Without a live project the
+// whole suite is skipped, so we also skip booting the dev server (it cannot
+// render the feed without Supabase). Keep both predicates in sync.
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const hasLiveSupabase =
+  /^https?:\/\//.test(supabaseUrl) && !supabaseUrl.includes("example.supabase.co");
+
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Smoke suite is intentionally serial: anon sessions, daily locks and like
+  // counters share global (deck, date) state per ADR 0006/0015.
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    locale: "ko-KR",
+    // ResultScreen / PerfectClearScreen copy via navigator.clipboard (scenario 7).
+    permissions: ["clipboard-read", "clipboard-write"],
+    // IP-hash likes (ADR 0002) need a client IP. `next dev` does not forward one,
+    // so supply a deterministic test IP for the like-persistence flow (scenario 6).
+    extraHTTPHeaders: { "x-forwarded-for": "203.0.113.42" },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Reuse a locally-running server; in CI boot a fresh one. Skipped when pointing
+  // at a remote env (E2E_BASE_URL) or when Supabase is not configured.
+  webServer:
+    process.env.E2E_BASE_URL || !hasLiveSupabase
+      ? undefined
+      : {
+          command: "pnpm dev",
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120_000,
+        },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,10 +40,10 @@ importers:
         version: 0.544.0(react@19.2.4)
       next:
         specifier: 15.5.14
-        version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.14(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.14(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -72,6 +72,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.14
@@ -729,6 +732,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2055,6 +2063,11 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2688,6 +2701,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -3692,6 +3715,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5088,6 +5115,9 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5535,14 +5565,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.11.0(next@15.5.14(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.4
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.32
       icu-minify: 4.11.0
       negotiator: 1.0.0
-      next: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.5.14(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl-swc-plugin-extractor: 4.11.0
       po-parser: 2.1.1
       react: 19.2.4
@@ -5557,7 +5587,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.14(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.14
       '@swc/helpers': 0.5.15
@@ -5575,6 +5605,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.14
       '@next/swc-win32-arm64-msvc': 15.5.14
       '@next/swc-win32-x64-msvc': 15.5.14
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5678,6 +5709,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, configDefaults } from "vitest/config";
+
+// Playwright E2E specs live in e2e/ and import @playwright/test, which Vitest
+// cannot run. Vitest's default glob matches *.spec.ts, so exclude e2e/ here.
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "e2e/**"],
+  },
+});


### PR DESCRIPTION
## PR Type
- [ ] decision
- [x] implementation
- [ ] mechanical
- [ ] docs
- [ ] mixed

## Justification
<!-- mixed PR일 때만 작성. 왜 분리하지 않는가? -->
(해당 없음)

## Main Review Question

이 PR에서 리뷰어가 판단해야 하는 핵심 질문 1개:

> 골든 패스 7개 시나리오가 올바르게 구성되고, env 가드(Supabase 미설정 시 skip)가 CI에서 안전하게 동작하는가?

## Scope

### 포함
- `e2e/` Playwright 스모크 7개 시나리오 (#66 본문 1~7) + 공유 fixtures/README
  - `discovery.spec.ts`: 1 익명 세션 lazy 발급+피드 · 2 검색→덱 상세
  - `gameplay.spec.ts`: 3 데일리 풀이 · 4 챌린지 perfect · 7 결과 복사 (+게이트 가드)
  - `social.spec.ts`: 5 댓글(nick+pw) · 6 좋아요 증가·유지
- `playwright.config.ts` — dev 서버 자동 기동, 클립보드 권한, 좋아요용 `x-forwarded-for` 주입
- `vitest.config.ts` — vitest 기본 glob이 `*.spec.ts`를 잡지 않도록 `e2e/**` 제외 (기존 187 테스트 무영향)
- `.github/workflows/e2e.yml` — 시크릿 설정 시에만 실행하는 가드형 CI 잡
- `package.json`(`test:e2e` 스크립트 + `@playwright/test`), `.gitignore`(playwright 산출물)

### 제외
- 앱 런타임 코드(app/, components/, lib/) 변경 — 없음 (test 인프라 한정)
- 단어 다수 덱 / 한글·가나 script 시나리오 — 결정적 정답 확보 위해 단어 1개 latin 덱만 사용

## Scope Check

<!-- pr-scope-checker 출력 붙여넣기 -->

```
verdict: APPROVE
primary layer: test
secondary layers: infra (playwright/vitest config, e2e.yml CI), lockfile (pnpm-lock.yaml), meta (.gitignore)
ADR count: 0
file count: 11
decision interlock: interlocked
  - 모든 변경이 단일 목적(E2E 스모크 추가)에 종속. config/CI 없이 spec만 merge하면 실행 불가, spec 없이 config/CI만 merge하면 무의미. independent decision 아님.
split suggestion: -
```

## 설계 메모

- **결정적 정답**: 각 테스트가 `/d/new`로 **단어 1개짜리 latin 덱**을 생성 → `pickDailyWordId`가 `seed % 1`로 항상 그 단어를 골라, ADR 0008(라운드 종료 전 단어 비노출)을 깨지 않고 정답(`smoketest`)을 타이핑한다.
- **환경변수 분리/가드**: `NEXT_PUBLIC_SUPABASE_URL` 미설정/`example.supabase.co`면 전 스펙 자동 skip(`requireLiveSupabase`). `playwright.config.ts`도 동일 판정으로 dev 서버 기동을 생략.

## 검증 체크리스트

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (187 passed — e2e 제외 확인)
- [x] `pnpm build` (dummy env)
- [x] `pnpm test:e2e` → 7 skipped, exit 0 (env 가드 정상 동작)
- [ ] **Supabase 복구 후 보류**: 실제 E2E 7개 통과 — 이 환경은 Supabase 일시정지 + `cdn.playwright.dev` egress 차단으로 브라우저 다운로드 불가하여 라이브 실행 미검증. 복구 + `pnpm exec playwright install chromium` 후 `pnpm test:e2e`로 검증 필요.

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| (scope-checker) `e2e.yml`이 PR/main에 광범위 트리거되나 secret 미설정 시 guard step만 통과 — 비용·노이즈 영향 낮음 | B | 본 PR 유지 (그대로 진행) | - |

Fixes #66

https://claude.ai/code/session_01BHwG3bksFekDWVKKuXCYcS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHwG3bksFekDWVKKuXCYcS)_