### PR TITLE
feat: [#40] 가나 덱 전용 규칙 안내 (첫 방문 모달 + 상시 ? 버튼)

### DIFF
--- a/components/ChallengeGame.tsx
+++ b/components/ChallengeGame.tsx
@@ -17,6 +17,7 @@ import {
 import { deriveKeyStates } from "@/lib/game-keyboard";
 import { getScriptAdapter } from "@/lib/scripts";
 import type { ScriptId } from "@/lib/scripts/types";
+import { KanaRulesHelp } from "@/components/KanaRulesHelp";
 
 function localDate(): string {
   const now = new Date();
@@ -134,6 +135,7 @@ export function ChallengeGame({ deckId, deckName, script }: ChallengeGameProps) 
 
   return (
     <div className="space-y-6">
+      {script === "kana" && <KanaRulesHelp />}
       <p className="text-center text-sm text-muted-foreground">
         라운드 {Math.min(view.currentRound + 1, view.totalRounds)} / {view.totalRounds} · 점수{" "}
         {view.score}

--- a/components/DailyGame.tsx
+++ b/components/DailyGame.tsx
@@ -16,6 +16,7 @@ import {
 import { deriveKeyStates } from "@/lib/game-keyboard";
 import { getScriptAdapter } from "@/lib/scripts";
 import type { ScriptId } from "@/lib/scripts/types";
+import { KanaRulesHelp } from "@/components/KanaRulesHelp";
 
 // 데일리는 client-local date 기준 (ADR 0015 — date는 보안 경계가 아님)
 function localDate(): string {
@@ -120,6 +121,7 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
 
   return (
     <div className="space-y-6">
+      {script === "kana" && <KanaRulesHelp />}
       <GameBoard
         attempts={view.attempts}
         currentUnits={currentUnits}

--- a/components/KanaRulesHelp.tsx
+++ b/components/KanaRulesHelp.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+const STORAGE_KEY = "kana-rules-seen";
+
+const RULES_CONTENT = (
+  <div className="space-y-4 text-sm">
+    <div>
+      <p className="font-semibold text-base">日本語(かな)モード ルール</p>
+      <ol className="mt-2 list-decimal pl-4 space-y-1">
+        <li>
+          カタカナとひらがなは同じ文字として扱われます。
+          <span className="ml-1 text-muted-foreground">例: カ = か, ア = あ</span>
+        </li>
+        <li>
+          小さい仮名も1マスを使います。
+          <span className="ml-1 text-muted-foreground">例: きゃ = き + ゃ, ふぉ = ふ + ぉ</span>
+        </li>
+        <li>
+          促音 っ, 長音 ー, 撥音 ん もそれぞれ1マスを使います。
+          <span className="ml-1 text-muted-foreground">例: がっこう = が + っ + こ + う / カード = か + ー + ど</span>
+        </li>
+      </ol>
+    </div>
+    <hr className="border-border" />
+    <div>
+      <p className="font-semibold text-base">일본어(가나) 모드 규칙</p>
+      <ol className="mt-2 list-decimal pl-4 space-y-1">
+        <li>
+          가타카나와 히라가나는 같은 글자로 취급됩니다.
+          <span className="ml-1 text-muted-foreground">예: カ = か, ア = あ</span>
+        </li>
+        <li>
+          작은 가나도 한 칸을 차지합니다.
+          <span className="ml-1 text-muted-foreground">예: きゃ = き + ゃ, ふぉ = ふ + ぉ</span>
+        </li>
+        <li>
+          촉음 っ, 장음 ー, 발음 ん 도 각각 한 칸을 차지합니다.
+          <span className="ml-1 text-muted-foreground">예: がっこう = が + っ + こ + う / カード = か + ー + ど</span>
+        </li>
+      </ol>
+    </div>
+  </div>
+);
+
+/** 최초 방문 모달: localStorage에 확인 기록이 없을 때 1회 표시. */
+function KanaFirstPlayModal({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kana-rules-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="bg-background border rounded-lg shadow-lg max-w-md w-full p-6 space-y-4">
+        <h2 id="kana-rules-title" className="text-lg font-bold">
+          かな모드 규칙 안내
+        </h2>
+        {RULES_CONTENT}
+        <div className="pt-2 text-center">
+          <Button type="button" onClick={onDismiss}>
+            확인했습니다
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 화면에 상시 표시되는 물음표(?) 도움말 버튼 + Popover. */
+function KanaHelpButton() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="가나 모드 규칙 보기"
+          className="rounded-full"
+        >
+          ?
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 max-h-[80vh] overflow-y-auto">
+        {RULES_CONTENT}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * 가나(kana) 덱 전용 규칙 안내 컴포넌트.
+ * - 첫 방문 시 모달을 1회 표시하고 localStorage에 기록.
+ * - 상시 노출되는 ? 버튼으로 규칙을 다시 볼 수 있음.
+ * - 이 컴포넌트는 script === 'kana'인 경우에만 마운트한다.
+ */
+export function KanaRulesHelp() {
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setShowModal(true);
+      }
+    } catch {
+      // localStorage 접근 불가 환경 (e.g. SSR 잔재, private mode 제한) — 무시
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // ignore
+    }
+    setShowModal(false);
+  };
+
+  return (
+    <>
+      {showModal && <KanaFirstPlayModal onDismiss={handleDismiss} />}
+      <div className="flex justify-end">
+        <KanaHelpButton />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## PR Type
- [x] implementation

## Main Review Question

> 가나 규칙 안내(첫 방문 모달 + 상시 `?` 버튼, ko+ja 병기, localStorage dismiss)가 올바르게 구현되고 가나 덱에만 마운트되는가?

## Scope

### 포함
- `components/KanaRulesHelp.tsx` 신규 — 첫 방문 모달 + 상시 `?` 팝오버, ko+ja 병기 규칙 텍스트, localStorage 기반 1회 dismiss
- `components/ChallengeGame.tsx` / `components/DailyGame.tsx` — `script === "kana"` 조건부 마운트

### 제외
- 어댑터 정규화/분해 로직 (#38 확정, 미변경)
- 일반화된 어댑터 `rulesHelp` 필드 (이번엔 가나 전용)
- 한글 모드 도움말 (별도 이슈)
- 영어 텍스트 / 전체 i18n 인프라

## Scope Check

```
verdict: APPROVE
primary layer: game-state
secondary layers: (none)
ADR count: 0
file count: 3
decision interlock: interlocked (KanaRulesHelp 컴포넌트와 ChallengeGame/DailyGame 마운트 지점이 상호 의존 — 한쪽만으로 의미 없음; 단일 feature)
reason: 단일 feature, primary layer 1개(game-state), ADR 0개, 파일 3개, behavior change 없음(순수 additive UI, script === "kana" gated), 리뷰 질문 1문장. scope 선언과 diff 일치.
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 체크리스트
- [x] `pnpm typecheck` / `pnpm lint` 통과
- [x] `pnpm test` 통과 (196)
- [x] `pnpm build` 통과
- [ ] (Supabase 복구 후) 가나 덱 첫 진입 → 모달 1회, dismiss 후 재진입 안 뜸 / 라틴·한글 덱 미표시 수동 확인

Fixes #40

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6bWd6SPQvTN63cuXqSYWa)_