### PR TITLE
refactor: [#18] 키보드 특수키 식별자/라벨 분리 (i18n 준비)

### DIFF
--- a/components/SmartKeyboard.tsx
+++ b/components/SmartKeyboard.tsx
@@ -38,6 +38,33 @@ export function SmartKeyboard({
   const adapter = useMemo(() => getScriptAdapter(script), [script]);
 
   const renderKey = (char: string) => {
+    const { enterKeyId, backspaceKeyId, enterLabel } = adapter.keyboard;
+    if (char === enterKeyId) {
+      return (
+        <button
+          key={char}
+          type="button"
+          disabled={disabled}
+          onClick={onEnter}
+          className={cn("rounded bg-muted px-4 py-3 text-sm font-semibold", disabled && "opacity-50")}
+        >
+          {enterLabel}
+        </button>
+      );
+    }
+    if (char === backspaceKeyId) {
+      return (
+        <button
+          key={char}
+          type="button"
+          disabled={disabled}
+          onClick={onBackspace}
+          className={cn("rounded bg-muted px-4 py-3 text-sm font-semibold", disabled && "opacity-50")}
+        >
+          ⌫
+        </button>
+      );
+    }
     const state = keyStates[adapter.keyId(char)];
     return (
       <button

--- a/lib/scripts/hangul.ts
+++ b/lib/scripts/hangul.ts
@@ -109,6 +109,8 @@ export const hangul: ScriptAdapter = {
     rows: KEYBOARD_ROWS,
     enterLabel: 'ENTER',
     backspaceLabel: 'BACKSPACE',
+    enterKeyId: 'ENTER',
+    backspaceKeyId: 'BACKSPACE',
   },
   keyId: (ch) => ch,
   charDescription: '한글',

--- a/lib/scripts/kana.ts
+++ b/lib/scripts/kana.ts
@@ -80,6 +80,8 @@ export const kana: ScriptAdapter = {
     rows: KEYBOARD_ROWS,
     enterLabel: 'ENTER',
     backspaceLabel: 'BACKSPACE',
+    enterKeyId: 'ENTER',
+    backspaceKeyId: 'BACKSPACE',
   },
   keyId: (ch) => toHiragana(ch),
   charDescription: '가나(히라가나/가타카나)',

--- a/lib/scripts/latin.ts
+++ b/lib/scripts/latin.ts
@@ -18,6 +18,8 @@ export const latin: ScriptAdapter = {
     rows: KEYBOARD_ROWS,
     enterLabel: 'ENTER',
     backspaceLabel: 'BACKSPACE',
+    enterKeyId: 'ENTER',
+    backspaceKeyId: 'BACKSPACE',
   },
   keyId: (ch) => ch.toUpperCase(),
   charDescription: '영문자(a-z, A-Z)',

--- a/lib/scripts/types.ts
+++ b/lib/scripts/types.ts
@@ -11,6 +11,10 @@ export interface KeyboardLayout {
   rows: string[][];
   enterLabel: string;
   backspaceLabel: string;
+  /** Stable identifier for the Enter key, independent of display label (i18n-safe). */
+  enterKeyId: string;
+  /** Stable identifier for the Backspace key, independent of display label (i18n-safe). */
+  backspaceKeyId: string;
 }
 
 export interface ScriptAdapter {


### PR DESCRIPTION
## PR Type
- [x] implementation

## Main Review Question

> 키보드 특수키를 표시 라벨이 아닌 안정적 식별자(`enterKeyId`/`backspaceKeyId`)로 판별하도록 분리한 것이 올바른가?

## Scope

### 포함
- `lib/scripts/types.ts` — `KeyboardLayout`에 `enterKeyId`/`backspaceKeyId` 추가 (표시 라벨과 분리)
- `lib/scripts/{latin,hangul,kana}.ts` — 신규 필드 채움
- `components/SmartKeyboard.tsx` — 식별자 기반 특수키 판별로 `onEnter`/`onBackspace` 라우팅

### 제외
- 라벨 i18n 실제 번역 (i18n 트랙)
- 새 script 어댑터 추가

## Scope Check

```
verdict: APPROVE
primary layer: game-state
secondary layers: (none — all 5 files are semantic changes serving one question)
ADR count: 0
file count: 5
decision interlock: interlocked (SmartKeyboard routing depends on the new keyId fields; adapters populate them; type defines them — none mergeable in isolation without breaking the others)
reason: 단일 i18n-prep 리팩터. primary layer 1개, ADR 0, 파일 5개, 리뷰 질문 1개(keyId/label 분리가 올바른가). scope 선언과 diff 일치.
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 체크리스트
- [x] `pnpm typecheck` / `pnpm lint` 통과
- [x] `pnpm test` 통과 (196)
- [x] `pnpm build` 통과
- [x] 현 라틴/한글/가나 어댑터 모두 신규 필드 구현 (typecheck로 누락 검출됨 — 통과)

Fixes #18

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6bWd6SPQvTN63cuXqSYWa)_