### PR TITLE
feat: [#60] i18n 공통 메시지 키 추출 (layout/Toast/공통 버튼)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { getFeed, type FeedSort } from "@/app/actions/feed";
 import { FeedTabs } from "@/components/FeedTabs";
 import { FeedList } from "@/components/FeedList";
@@ -16,6 +17,7 @@ function resolveSort(raw: string | undefined): FeedSort {
 export default async function Home({ searchParams }: HomePageProps) {
   const { sort: rawSort } = await searchParams;
   const sort = resolveSort(rawSort);
+  const t = await getTranslations("layout.appbar");
 
   const result = await getFeed({ sort });
   const page = result.success && result.data ? result.data : { decks: [], nextOffset: null };
@@ -28,7 +30,7 @@ export default async function Home({ searchParams }: HomePageProps) {
           <SearchBar />
         </div>
         <Button asChild size="sm">
-          <Link href="/d/new">새 덱</Link>
+          <Link href="/d/new">{t("newDeck")}</Link>
         </Button>
       </div>
 

--- a/components/FeedTabs.tsx
+++ b/components/FeedTabs.tsx
@@ -1,17 +1,20 @@
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { FeedSort } from "@/app/actions/feed";
 
-const TABS: { sort: FeedSort; label: string; href: string }[] = [
-  { sort: "hot", label: "🔥 Hot", href: "/" },
-  { sort: "likes", label: "좋아요순", href: "/?sort=likes" },
-  { sort: "new", label: "최신순", href: "/?sort=new" },
+const TAB_SORTS: { sort: FeedSort; href: string }[] = [
+  { sort: "hot", href: "/" },
+  { sort: "likes", href: "/?sort=likes" },
+  { sort: "new", href: "/?sort=new" },
 ];
 
-export function FeedTabs({ active }: { active: FeedSort }) {
+export async function FeedTabs({ active }: { active: FeedSort }) {
+  const t = await getTranslations("layout.feedTabs");
+
   return (
     <nav className="flex gap-1 border-b">
-      {TABS.map((tab) => (
+      {TAB_SORTS.map((tab) => (
         <Link
           key={tab.sort}
           href={tab.href}
@@ -22,7 +25,7 @@ export function FeedTabs({ active }: { active: FeedSort }) {
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          {tab.label}
+          {t(tab.sort)}
         </Link>
       ))}
     </nav>

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ interface LikeButtonProps {
 }
 
 export function LikeButton({ deckId, initialCount }: LikeButtonProps) {
+  const t = useTranslations('common');
   const [state, setState] = useState<LikeState>(() => initialLikeState(false, initialCount));
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -58,7 +60,7 @@ export function LikeButton({ deckId, initialCount }: LikeButtonProps) {
       }));
     } else {
       setState((prev) => applyRollback(prev));
-      toast.error(result?.message ?? "네트워크 오류로 좋아요를 반영하지 못했습니다.");
+      toast.error(result?.message ?? t('networkError'));
     }
   };
 

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,16 +1,19 @@
+import { getTranslations } from "next-intl/server";
 import { Input } from "@/components/ui/input";
 
 // GET form — /search?q=... 로 이동 (서버 컴포넌트에서 사용 가능)
-export function SearchBar({ defaultValue = "" }: { defaultValue?: string }) {
+export async function SearchBar({ defaultValue = "" }: { defaultValue?: string }) {
+  const t = await getTranslations("layout.searchBar");
+
   return (
     <form action="/search" className="w-full">
       <Input
         type="search"
         name="q"
         defaultValue={defaultValue}
-        placeholder="덱 이름 검색"
+        placeholder={t("placeholder")}
         maxLength={50}
-        aria-label="덱 이름 검색"
+        aria-label={t("ariaLabel")}
       />
     </form>
   );

--- a/components/common/ErrorFallback.tsx
+++ b/components/common/ErrorFallback.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { FallbackProps } from 'react-error-boundary';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const t = useTranslations('common');
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
@@ -25,18 +28,18 @@ export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
               />
             </svg>
           </div>
-          <CardTitle className="text-2xl">오류가 발생했습니다</CardTitle>
+          <CardTitle className="text-2xl">{t('error.title')}</CardTitle>
           <CardDescription>
-            페이지를 불러오는 중 문제가 발생했습니다.
+            {t('error.description')}
           </CardDescription>
         </CardHeader>
 
         <CardContent className="space-y-4">
           <Alert variant="destructive">
-            <AlertTitle>오류 상세 정보</AlertTitle>
+            <AlertTitle>{t('error.detailsTitle')}</AlertTitle>
             <AlertDescription>
               <details className="mt-2">
-                <summary className="cursor-pointer font-medium">오류 메시지 보기</summary>
+                <summary className="cursor-pointer font-medium">{t('error.showMessage')}</summary>
                 <pre className="mt-2 text-xs bg-muted p-2 rounded overflow-auto whitespace-pre-wrap">
                   {error.message}
                 </pre>
@@ -48,7 +51,7 @@ export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
             onClick={resetErrorBoundary}
             className="w-full"
           >
-            다시 시도
+            {t('button.retry')}
           </Button>
         </CardContent>
       </Card>

--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,6 +1,9 @@
+import { getTranslations } from 'next-intl/server';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
-export default function Loading() {
+export default async function Loading() {
+  const t = await getTranslations('common');
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
@@ -26,9 +29,9 @@ export default function Loading() {
               />
             </svg>
           </div>
-          <CardTitle className="text-2xl">로딩 중...</CardTitle>
+          <CardTitle className="text-2xl">{t('loading')}</CardTitle>
           <CardDescription>
-            사용자 정보를 불러오고 있습니다.
+            {t('loadingDescription')}
           </CardDescription>
         </CardHeader>
       </Card>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,1 +1,31 @@
-{}
+{
+  "common": {
+    "loading": "Loading...",
+    "loadingDescription": "Loading user information.",
+    "unknownError": "An unknown error occurred.",
+    "networkError": "Failed to update like due to network error.",
+    "button": {
+      "retry": "Try again"
+    },
+    "error": {
+      "title": "An error occurred",
+      "description": "A problem occurred while loading the page.",
+      "detailsTitle": "Error details",
+      "showMessage": "Show error message"
+    }
+  },
+  "layout": {
+    "appbar": {
+      "newDeck": "New Deck"
+    },
+    "feedTabs": {
+      "hot": "🔥 Hot",
+      "likes": "Most Liked",
+      "new": "Latest"
+    },
+    "searchBar": {
+      "placeholder": "Search decks",
+      "ariaLabel": "Search decks"
+    }
+  }
+}

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,1 +1,31 @@
-{}
+{
+  "common": {
+    "loading": "ロード中...",
+    "loadingDescription": "ユーザー情報を読み込んでいます。",
+    "unknownError": "不明なエラーが発生しました。",
+    "networkError": "ネットワークエラーにより、いいねを反映できませんでした。",
+    "button": {
+      "retry": "再試行"
+    },
+    "error": {
+      "title": "エラーが発生しました",
+      "description": "ページの読み込み中に問題が発生しました。",
+      "detailsTitle": "エラー詳細",
+      "showMessage": "エラーメッセージを見る"
+    }
+  },
+  "layout": {
+    "appbar": {
+      "newDeck": "新しいデッキ"
+    },
+    "feedTabs": {
+      "hot": "🔥 Hot",
+      "likes": "いいね順",
+      "new": "最新順"
+    },
+    "searchBar": {
+      "placeholder": "デッキ名で検索",
+      "ariaLabel": "デッキ名で検索"
+    }
+  }
+}

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,1 +1,31 @@
-{}
+{
+  "common": {
+    "loading": "로딩 중...",
+    "loadingDescription": "사용자 정보를 불러오고 있습니다.",
+    "unknownError": "알 수 없는 오류가 발생했습니다.",
+    "networkError": "네트워크 오류로 좋아요를 반영하지 못했습니다.",
+    "button": {
+      "retry": "다시 시도"
+    },
+    "error": {
+      "title": "오류가 발생했습니다",
+      "description": "페이지를 불러오는 중 문제가 발생했습니다.",
+      "detailsTitle": "오류 상세 정보",
+      "showMessage": "오류 메시지 보기"
+    }
+  },
+  "layout": {
+    "appbar": {
+      "newDeck": "새 덱"
+    },
+    "feedTabs": {
+      "hot": "🔥 Hot",
+      "likes": "좋아요순",
+      "new": "최신순"
+    },
+    "searchBar": {
+      "placeholder": "덱 이름 검색",
+      "ariaLabel": "덱 이름 검색"
+    }
+  }
+}


### PR DESCRIPTION
## PR Type
- [x] mechanical

## Justification
<!-- mechanical i18n 키 추출 — 동작 변경 없음 -->

## Main Review Question

> 한국어 문자열이 그대로 보존되고 next-intl 키가 올바르게 연결되었는가? (공통/layout 범위 한정)

## Scope

### 포함
- `messages/{ko,en,ja}.json` — `common.*` / `layout.*` 네임스페이스 추가 (ko = 기존 한국어 텍스트, en/ja 동일 구조)
- `t()` 연결 6개: `app/page.tsx`(layout.appbar), `components/FeedTabs.tsx`, `components/SearchBar.tsx`, `components/LikeButton.tsx`, `components/common/ErrorFallback.tsx`, `components/common/Loading.tsx`

### 제외
- deck/game/auth 메시지 (#61/#62/#63)
- en/ja 실제 번역 품질 (#35/#36) — 구조만 일치
- locale switcher UI (#37)

## Scope Check

```
verdict: APPROVE
primary layer: mechanical (i18n key extraction)
secondary layers: none (messages/*.json are i18n resources, part of the same mechanical change)
ADR count: 0
file count: 9
decision interlock: interlocked (message keys and their t() call sites must land together — components reference keys that only exist after the JSON change; reverting either half breaks the build)
reason: n/a
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 체크리스트
- [x] `pnpm typecheck` / `pnpm lint` 통과
- [x] `pnpm test` 통과 (232)
- [x] `pnpm build` 통과
- [x] 한국어 UI 표시 변화 없음 (ko 값 = 기존 하드코딩 텍스트)
- [x] ko/en/ja 키 구조 동일

## 참고
- 실제 AppBar 컴포넌트는 없고 `app/page.tsx` 인라인 — 해당 위치에서 처리. Footer 없음.
- `lib/action-with-toast.ts`의 하드코딩 fallback은 비-컴포넌트 유틸이라 미변경(키는 messages에 존재).

Fixes #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6bWd6SPQvTN63cuXqSYWa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 다국어 지원 추가: 영문과 일본어 인터페이스 제공
  * 새 덱 버튼, 피드 탭, 검색 바, 로딩 상태 표시, 오류 메시지 등 애플리케이션의 모든 사용자 인터페이스 텍스트가 선택한 언어로 표시되도록 업데이트됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->