### PR TITLE
feat: [#63] i18n 인증/검증 메시지 + script charDescription 키 추출

### DIFF
--- a/app/actions/comment.ts
+++ b/app/actions/comment.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getTranslations } from "next-intl/server";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { safeAction } from "@/lib/safe-action";
 import { ActionResponse } from "@/types/action";
@@ -11,6 +12,9 @@ import {
   validateNick,
   validatePasswordLength,
   formatDisplayNick,
+  NICK_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_MAX_LENGTH,
 } from "@/lib/identity";
 
 // 댓글의 모든 read/write/delete/report는 server action only (ADR 0007, #47).
@@ -58,11 +62,12 @@ export async function getComments(
   readerToday: string,
 ): Promise<ActionResponse<CommentThreadsView>> {
   return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
     if (!DATE_PATTERN.test(readerToday)) {
-      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+      return { success: false, message: tAuth("error.invalidDate") };
     }
     const anonId = await getOrCreateAnonUserId();
-    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+    if (!anonId) return { success: false, message: tAuth("error.sessionFailedShort") };
 
     const todayStatus = await dailyStatusFor(deckId, readerToday, anonId);
     const todayGate = checkThreadVisibility(readerToday, readerToday, todayStatus);
@@ -120,24 +125,29 @@ export async function createComment(input: {
   writerToday: string;
 }): Promise<ActionResponse> {
   return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
     const { deckId, text, nick, password, writerToday } = input;
 
     if (!DATE_PATTERN.test(writerToday)) {
-      return { success: false, message: "날짜 형식이 올바르지 않습니다." };
+      return { success: false, message: tAuth("error.invalidDate") };
     }
     const trimmed = text.trim();
     const fieldErrors: { [key: string]: string[] } = {};
     if (!trimmed || trimmed.length > COMMENT_MAX_LENGTH) {
-      fieldErrors.text = [`댓글은 1~${COMMENT_MAX_LENGTH}자여야 합니다.`];
+      fieldErrors.text = [tAuth("validation.commentLength", { max: COMMENT_MAX_LENGTH })];
     }
-    if (!validateNick(nick.trim())) fieldErrors.nick = ["닉네임은 1~20자, '#' 없이 입력해야 합니다."];
-    if (!validatePasswordLength(password)) fieldErrors.password = ["비밀번호는 4~64자여야 합니다."];
+    if (!validateNick(nick.trim())) {
+      fieldErrors.nick = [tAuth("validation.nickFormat", { max: NICK_MAX_LENGTH })];
+    }
+    if (!validatePasswordLength(password)) {
+      fieldErrors.password = [tAuth("validation.passwordLength", { min: PASSWORD_MIN_LENGTH, max: PASSWORD_MAX_LENGTH })];
+    }
     if (Object.keys(fieldErrors).length > 0) {
-      return { success: false, message: "입력값을 확인해주세요.", fieldErrors };
+      return { success: false, message: tAuth("error.invalidInput"), fieldErrors };
     }
 
     const anonId = await getOrCreateAnonUserId();
-    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
+    if (!anonId) return { success: false, message: tAuth("error.sessionFailedShort") };
 
     // 작성도 가시성 게이트를 통과해야 한다 (잠긴 thread에 작성 불가)
     const todayStatus = await dailyStatusFor(deckId, writerToday, anonId);
@@ -171,7 +181,7 @@ export async function createComment(input: {
       return { success: false, message: `댓글 작성에 실패했습니다: ${error.message}` };
     }
 
-    return { success: true, message: "댓글을 남겼습니다." };
+    return { success: true, message: tAuth("success.commentPosted") };
   });
 }
 
@@ -182,6 +192,7 @@ export async function deleteComment(input: {
   password: string;
 }): Promise<ActionResponse> {
   return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
     const { commentId, nick, password } = input;
     const admin = createAdminClient();
 
@@ -198,7 +209,7 @@ export async function deleteComment(input: {
     const nickMatches = comment.nick === nick.trim();
     const pwMatches = await verifyPassword(password, comment.pw_hash);
     if (!nickMatches || !pwMatches) {
-      return { success: false, message: "닉네임 또는 비밀번호가 올바르지 않습니다." };
+      return { success: false, message: tAuth("error.invalidCredentials") };
     }
 
     const { error } = await admin
@@ -208,7 +219,7 @@ export async function deleteComment(input: {
     if (error) {
       return { success: false, message: `댓글 삭제에 실패했습니다: ${error.message}` };
     }
-    return { success: true, message: "댓글을 삭제했습니다." };
+    return { success: true, message: tAuth("success.commentDeleted") };
   });
 }
 

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { getTranslations } from "next-intl/server";
 import { createClient } from "@/lib/supabase-server";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { safeAction } from "@/lib/safe-action";
@@ -36,10 +37,13 @@ type CredentialCheck =
   | { ok: true }
   | { ok: false; message: string };
 
+// verifyCredentials는 request context 밖에서 호출될 수도 있어
+// 번역된 메시지를 호출자로부터 주입받는다.
 async function verifyCredentials(
   deckId: string,
   nick: string,
   password: string,
+  messages: { deckNotFound: string; invalidCredentials: string },
 ): Promise<CredentialCheck> {
   const admin = createAdminClient();
   const { data: deck, error } = await admin
@@ -49,20 +53,24 @@ async function verifyCredentials(
     .single();
 
   if (error || !deck) {
-    return { ok: false, message: "덱을 찾을 수 없습니다." };
+    return { ok: false, message: messages.deckNotFound };
   }
 
   // enumeration 방어: 닉/비밀번호 중 무엇이 틀렸는지 구분해 알려주지 않는다 (ADR 0001)
   const nickMatches = deck.creator_nick === nick;
   const pwMatches = await verifyPassword(password, deck.creator_pw_hash);
   if (!nickMatches || !pwMatches) {
-    return { ok: false, message: "닉네임 또는 비밀번호가 올바르지 않습니다." };
+    return { ok: false, message: messages.invalidCredentials };
   }
   return { ok: true };
 }
 
 export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
   return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
+    const tDeckForm = await getTranslations("deck.form");
+    const tDeckAction = await getTranslations("deck.action");
+
     const name = String(formData.get("name") ?? "").trim();
     const script = String(formData.get("script") ?? "latin");
     const nick = String(formData.get("nick") ?? "").trim();
@@ -70,16 +78,16 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
     const wordsText = String(formData.get("words_text") ?? "");
 
     const fieldErrors: { [key: string]: string[] } = {};
-    if (!name || name.length > 100) fieldErrors.name = ["덱 이름은 1~100자여야 합니다."];
-    if (!isSupportedScript(script)) fieldErrors.script = ["지원하지 않는 쓰기체계입니다."];
+    if (!name || name.length > 100) fieldErrors.name = [tDeckForm("error.nameLength")];
+    if (!isSupportedScript(script)) fieldErrors.script = [tDeckForm("error.unsupportedScript")];
     if (!validateNick(nick)) {
-      fieldErrors.nick = [`닉네임은 1~${NICK_MAX_LENGTH}자, '#' 없이 입력해야 합니다.`];
+      fieldErrors.nick = [tAuth("validation.nickFormat", { max: NICK_MAX_LENGTH })];
     } else if (isBotNick(nick)) {
       // bot_ prefix는 운영자 시드 전용 — 일반 경로 차단 (#77, API는 토큰으로 허용)
-      fieldErrors.nick = ["bot_ prefix 닉네임은 사용할 수 없습니다."];
+      fieldErrors.nick = [tAuth("validation.botNickForbidden")];
     }
     if (!validatePasswordLength(password)) {
-      fieldErrors.password = [`비밀번호는 ${PASSWORD_MIN_LENGTH}~${PASSWORD_MAX_LENGTH}자여야 합니다.`];
+      fieldErrors.password = [tAuth("validation.passwordLength", { min: PASSWORD_MIN_LENGTH, max: PASSWORD_MAX_LENGTH })];
     }
 
     const wordsValidation = isSupportedScript(script)
@@ -90,12 +98,12 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
     }
 
     if (Object.keys(fieldErrors).length > 0) {
-      return { success: false, message: "입력값을 확인해주세요.", fieldErrors };
+      return { success: false, message: tAuth("error.invalidInput"), fieldErrors };
     }
 
     const creatorId = await getOrCreateAnonUserId();
     if (!creatorId) {
-      return { success: false, message: "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요." };
+      return { success: false, message: tAuth("error.sessionFailed") };
     }
 
     const pwHash = await hashPassword(password);
@@ -129,7 +137,7 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
     }
 
     revalidatePath(`/d/${deck.id}`);
-    return { success: true, data: { id: deck.id }, message: "덱을 만들었습니다." };
+    return { success: true, data: { id: deck.id }, message: tDeckAction("created") };
   });
 }
 
@@ -171,9 +179,13 @@ export async function verifyDeckCredentials(
   password: string,
 ): Promise<ActionResponse> {
   return safeAction(async () => {
-    const check = await verifyCredentials(deckId, nick, password);
+    const tAuth = await getTranslations("auth");
+    const check = await verifyCredentials(deckId, nick, password, {
+      deckNotFound: "덱을 찾을 수 없습니다.",
+      invalidCredentials: tAuth("error.invalidCredentials"),
+    });
     if (!check.ok) return { success: false, message: check.message };
-    return { success: true, message: "확인되었습니다." };
+    return { success: true, message: tAuth("success.verified") };
   });
 }
 
@@ -185,9 +197,14 @@ export async function updateDeckWords(input: {
   deactivateIds: string[];
 }): Promise<ActionResponse> {
   return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
+    const tDeckAction = await getTranslations("deck.action");
     const { deckId, nick, password, addWordsText, deactivateIds } = input;
 
-    const check = await verifyCredentials(deckId, nick, password);
+    const check = await verifyCredentials(deckId, nick, password, {
+      deckNotFound: "덱을 찾을 수 없습니다.",
+      invalidCredentials: tAuth("error.invalidCredentials"),
+    });
     if (!check.ok) return { success: false, message: check.message };
 
     const admin = createAdminClient();
@@ -245,6 +262,6 @@ export async function updateDeckWords(input: {
       .eq("id", deckId);
 
     revalidatePath(`/d/${deckId}`);
-    return { success: true, message: "덱을 수정했습니다." };
+    return { success: true, message: tDeckAction("updated") };
   });
 }

--- a/components/DeckForm.tsx
+++ b/components/DeckForm.tsx
@@ -29,6 +29,7 @@ import {
 export function DeckForm() {
   const router = useRouter();
   const t = useTranslations("deck.form");
+  const tValidation = useTranslations("validation.error");
   const [name, setName] = useState("");
   const [script, setScript] = useState<ScriptId>("latin");
   const [nick, setNick] = useState("");
@@ -139,7 +140,11 @@ export function DeckForm() {
           required
         />
         {!wordsValidation.ok && (
-          <p className="text-sm text-destructive">{wordsValidation.message}</p>
+          <p className="text-sm text-destructive">
+            {wordsValidation.invalidLines.length > 0
+              ? tValidation("invalidChars", { lines: wordsValidation.invalidLines.join(", ") })
+              : tValidation("minOneWord")}
+          </p>
         )}
         {wordsValidation.ok && (
           <p className="text-sm text-muted-foreground">{t("hint.validWordCount", { count: validWords.length })}</p>

--- a/messages/en.json
+++ b/messages/en.json
@@ -86,8 +86,14 @@
         "editCredentials": "덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요."
       },
       "error": {
-        "minActiveWords": "활성 단어가 최소 1개 필요합니다."
+        "minActiveWords": "활성 단어가 최소 1개 필요합니다.",
+        "nameLength": "덱 이름은 1~100자여야 합니다.",
+        "unsupportedScript": "지원하지 않는 쓰기체계입니다."
       }
+    },
+    "action": {
+      "created": "덱을 만들었습니다.",
+      "updated": "덱을 수정했습니다."
     },
     "list": {
       "loading": "불러오는 중...",
@@ -146,6 +152,45 @@
       "copySuccess": "결과를 복사했습니다.",
       "copyFailure": "클립보드 복사에 실패했습니다.",
       "shareText": "🎉 PERFECT CLEAR — {deckName} 챌린지 {date} {total}/{total}"
+    }
+  },
+  "auth": {
+    "error": {
+      "invalidCredentials": "닉네임 또는 비밀번호가 올바르지 않습니다.",
+      "invalidDate": "날짜 형식이 올바르지 않습니다.",
+      "sessionFailed": "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      "sessionFailedShort": "세션 발급에 실패했습니다.",
+      "invalidInput": "입력값을 확인해주세요."
+    },
+    "validation": {
+      "nickFormat": "닉네임은 1~{max}자, '#' 없이 입력해야 합니다.",
+      "botNickForbidden": "bot_ prefix 닉네임은 사용할 수 없습니다.",
+      "passwordLength": "비밀번호는 {min}~{max}자여야 합니다.",
+      "commentLength": "댓글은 1~{max}자여야 합니다."
+    },
+    "success": {
+      "verified": "확인되었습니다.",
+      "commentDeleted": "댓글을 삭제했습니다.",
+      "commentPosted": "댓글을 남겼습니다."
+    }
+  },
+  "validation": {
+    "error": {
+      "invalidChars": "허용되지 않는 문자가 포함된 단어가 있습니다: {lines}",
+      "minOneWord": "최소 1개 단어 필요",
+      "lastActiveWord": "마지막 활성 단어는 비활성화할 수 없습니다. 활성 단어가 최소 1개 필요합니다.",
+      "minOneActiveWord": "최소 1개의 활성 단어가 필요합니다."
+    }
+  },
+  "script": {
+    "latin": {
+      "charDescription": "영문자(a-z, A-Z)"
+    },
+    "hangul": {
+      "charDescription": "한글"
+    },
+    "kana": {
+      "charDescription": "가나(히라가나/가타카나)"
     }
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -86,8 +86,14 @@
         "editCredentials": "덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요."
       },
       "error": {
-        "minActiveWords": "활성 단어가 최소 1개 필요합니다."
+        "minActiveWords": "활성 단어가 최소 1개 필요합니다.",
+        "nameLength": "덱 이름은 1~100자여야 합니다.",
+        "unsupportedScript": "지원하지 않는 쓰기체계입니다."
       }
+    },
+    "action": {
+      "created": "덱을 만들었습니다.",
+      "updated": "덱을 수정했습니다."
     },
     "list": {
       "loading": "불러오는 중...",
@@ -146,6 +152,45 @@
       "copySuccess": "결과를 복사했습니다.",
       "copyFailure": "클립보드 복사에 실패했습니다.",
       "shareText": "🎉 PERFECT CLEAR — {deckName} 챌린지 {date} {total}/{total}"
+    }
+  },
+  "auth": {
+    "error": {
+      "invalidCredentials": "닉네임 또는 비밀번호가 올바르지 않습니다.",
+      "invalidDate": "날짜 형식이 올바르지 않습니다.",
+      "sessionFailed": "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      "sessionFailedShort": "세션 발급에 실패했습니다.",
+      "invalidInput": "입력값을 확인해주세요."
+    },
+    "validation": {
+      "nickFormat": "닉네임은 1~{max}자, '#' 없이 입력해야 합니다.",
+      "botNickForbidden": "bot_ prefix 닉네임은 사용할 수 없습니다.",
+      "passwordLength": "비밀번호는 {min}~{max}자여야 합니다.",
+      "commentLength": "댓글은 1~{max}자여야 합니다."
+    },
+    "success": {
+      "verified": "확인되었습니다.",
+      "commentDeleted": "댓글을 삭제했습니다.",
+      "commentPosted": "댓글을 남겼습니다."
+    }
+  },
+  "validation": {
+    "error": {
+      "invalidChars": "허용되지 않는 문자가 포함된 단어가 있습니다: {lines}",
+      "minOneWord": "최소 1개 단어 필요",
+      "lastActiveWord": "마지막 활성 단어는 비활성화할 수 없습니다. 활성 단어가 최소 1개 필요합니다.",
+      "minOneActiveWord": "최소 1개의 활성 단어가 필요합니다."
+    }
+  },
+  "script": {
+    "latin": {
+      "charDescription": "영문자(a-z, A-Z)"
+    },
+    "hangul": {
+      "charDescription": "한글"
+    },
+    "kana": {
+      "charDescription": "가나(히라가나/가타카나)"
     }
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -86,8 +86,14 @@
         "editCredentials": "덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요."
       },
       "error": {
-        "minActiveWords": "활성 단어가 최소 1개 필요합니다."
+        "minActiveWords": "활성 단어가 최소 1개 필요합니다.",
+        "nameLength": "덱 이름은 1~100자여야 합니다.",
+        "unsupportedScript": "지원하지 않는 쓰기체계입니다."
       }
+    },
+    "action": {
+      "created": "덱을 만들었습니다.",
+      "updated": "덱을 수정했습니다."
     },
     "list": {
       "loading": "불러오는 중...",
@@ -146,6 +152,45 @@
       "copySuccess": "결과를 복사했습니다.",
       "copyFailure": "클립보드 복사에 실패했습니다.",
       "shareText": "🎉 PERFECT CLEAR — {deckName} 챌린지 {date} {total}/{total}"
+    }
+  },
+  "auth": {
+    "error": {
+      "invalidCredentials": "닉네임 또는 비밀번호가 올바르지 않습니다.",
+      "invalidDate": "날짜 형식이 올바르지 않습니다.",
+      "sessionFailed": "세션 발급에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      "sessionFailedShort": "세션 발급에 실패했습니다.",
+      "invalidInput": "입력값을 확인해주세요."
+    },
+    "validation": {
+      "nickFormat": "닉네임은 1~{max}자, '#' 없이 입력해야 합니다.",
+      "botNickForbidden": "bot_ prefix 닉네임은 사용할 수 없습니다.",
+      "passwordLength": "비밀번호는 {min}~{max}자여야 합니다.",
+      "commentLength": "댓글은 1~{max}자여야 합니다."
+    },
+    "success": {
+      "verified": "확인되었습니다.",
+      "commentDeleted": "댓글을 삭제했습니다.",
+      "commentPosted": "댓글을 남겼습니다."
+    }
+  },
+  "validation": {
+    "error": {
+      "invalidChars": "허용되지 않는 문자가 포함된 단어가 있습니다: {lines}",
+      "minOneWord": "최소 1개 단어 필요",
+      "lastActiveWord": "마지막 활성 단어는 비활성화할 수 없습니다. 활성 단어가 최소 1개 필요합니다.",
+      "minOneActiveWord": "최소 1개의 활성 단어가 필요합니다."
+    }
+  },
+  "script": {
+    "latin": {
+      "charDescription": "영문자(a-z, A-Z)"
+    },
+    "hangul": {
+      "charDescription": "한글"
+    },
+    "kana": {
+      "charDescription": "가나(히라가나/가타카나)"
     }
   }
 }


### PR DESCRIPTION
## PR Type
- [x] mechanical

## Justification
<!-- mechanical i18n 키 추출 — 동작 변경 없음 -->

## Main Review Question

> 인증/검증/script 한국어 문자열이 `auth.*`/`validation.*`/`script.*` 키로 그대로 보존되며 추출되었는가?

## Scope

### 포함
- `messages/{ko,en,ja}.json` — `auth.*`, `validation.*`, `script.*` 네임스페이스 추가 (+ #61 이연분 `deck.form.error.*`, `deck.action.*`)
- `app/actions/deck.ts` / `app/actions/comment.ts` — 서버 액션에서 `getTranslations()`로 인증/검증 toast 번역
- `components/DeckForm.tsx` — `useTranslations('validation.error')` (컴포넌트 경계에서 검증 에러 번역)

### 제외
- common/layout/deck/game (#60/#61/#62, 머지됨)
- en/ja 실제 번역 품질 (#35/#36)
- 일부 lib 순수 유틸 검증 문자열의 서버 액션 경로(문서화된 이연), `script.*.charDescription` 소비처(현재 UI 미소비 — 키만 선등록)

## Scope Check

```
verdict: APPROVE
primary layer: mechanical (i18n key extraction)
secondary layers: identity (auth/validation toast wiring in app/actions/*, components/DeckForm.tsx)
ADR count: 0
file count: 6
decision interlock: interlocked (message keys, server-action getTranslations wiring, and DeckForm useTranslations are mutually dependent — keys without wiring are dead, wiring without keys breaks; verifyCredentials signature change exists only to inject translated messages, not an independent decision)
reason: mechanical i18n extraction, single review question, ko verbatim preserved (no behavior change), no decision/ADR change, 6 files ≤ 15. deck.form.error.* / deck.action.* (deferred #61) and script.*.charDescription (unconsumed) stay within the same i18n-namespace operation; residual Korean inline strings (deckNotFound, pure-util lib paths) are documented deferrals, not scope creep.
```

## Review Triage Log

- A. in-scope must-fix → 본 PR
- B. in-scope optional → 본 PR or issue
- C. out-of-scope → issue 생성, 본 PR 미반영
- default: C

| feedback | class | action | linked issue |
|---|---|---|---|
| | | | |

## 검증 체크리스트
- [x] `pnpm typecheck` / `pnpm lint` 통과
- [x] `pnpm test` 통과 (232)
- [x] `pnpm build` 통과
- [x] 한국어 메시지 출력 변화 없음 (ko 값 = 기존 텍스트)
- [x] ko/en/ja 키 구조 동일 (auth/common/deck/game/layout/script/validation)

## 참고
- next-intl v4 `getTranslations()`가 서버 액션(`safeAction` 클로저) 내에서 정상 동작 확인 — threading 불필요.
- `script.*.charDescription`는 현재 UI에서 소비되지 않아 키만 선등록(어댑터 field는 fallback 유지). 소비처 연결은 후속.
- 일부 순수 유틸 검증 문자열의 서버 액션 경로는 한국어 유지(테스트가 한국어 문자열에 assert) — 후속 PR에서 `getTranslations('validation')`로 전환 가능.

Fixes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6bWd6SPQvTN63cuXqSYWa)_