### PR TITLE
fix(hangul): 이중모음을 두벌식 입력 자모로 분해

### DIFF
--- a/lib/__tests__/gameEngine.test.ts
+++ b/lib/__tests__/gameEngine.test.ts
@@ -105,10 +105,10 @@ describe('GameEngine.removeLetter', () => {
     expect(engine.removeLetter()).toBe(engine);
   });
 
-  it('한글은 자모 단위로 제거한다 (복합 모음은 한 단위)', () => {
-    // '사과' = ㅅㅏㄱㅘ → 마지막 자모 ㅘ만 제거되어 ㅅㅏㄱ
+  it('한글은 자모 단위로 제거한다 (이중모음은 입력 자모 2개로 분해)', () => {
+    // '사과' = ㅅㅏㄱㅗㅏ → 마지막 입력 자모 ㅏ만 제거되어 ㅅㅏㄱㅗ
     const engine = typeWord(createEngine('사과', { adapter: 'hangul' }), '사과').removeLetter();
-    expect(hangul.splitUnits(engine.state.currentGuess)).toEqual(['ㅅ', 'ㅏ', 'ㄱ']);
+    expect(hangul.splitUnits(engine.state.currentGuess)).toEqual(['ㅅ', 'ㅏ', 'ㄱ', 'ㅗ']);
   });
 });
 
@@ -137,10 +137,11 @@ describe('GameEngine.submitGuess — 판정 (correct/present/absent)', () => {
     expect(lastRowStates(engine)).toEqual(['absent', 'present', 'correct', 'present', 'present']);
   });
 
-  it('한글은 자모 단위로 판정한다', () => {
-    // 타깃 사과(ㅅㅏㄱㅘ) vs 추측 과자(ㄱㅘㅈㅏ)
+  it('한글은 자모 단위로 판정한다 (이중모음 분해 포함)', () => {
+    // 타깃 사과(ㅅㅏㄱㅗㅏ) vs 추측 과자(ㄱㅗㅏㅈㅏ)
+    // idx4 ㅏ→correct, ㄱ·ㅗ·ㅏ→present, ㅈ→absent
     const engine = typeWord(createEngine('사과', { adapter: 'hangul' }), '과자').submitGuess().engine;
-    expect(lastRowStates(engine)).toEqual(['present', 'present', 'absent', 'present']);
+    expect(lastRowStates(engine)).toEqual(['present', 'present', 'present', 'absent', 'correct']);
   });
 
   it('길이가 다르면 제출되지 않고 result 는 null 이다', () => {

--- a/lib/__tests__/wordleGame.test.ts
+++ b/lib/__tests__/wordleGame.test.ts
@@ -87,12 +87,12 @@ describe('removeLetterFromGuess', () => {
     expect(removeLetterFromGuess(state)).toBe(state);
   });
 
-  it('한글은 자모 단위로 제거한다 (복합 모음은 한 단위)', () => {
-    // '사과' = ㅅㅏㄱㅘ → 마지막 자모 ㅘ만 제거되어 ㅅㅏㄱ
+  it('한글은 자모 단위로 제거한다 (이중모음은 입력 자모 2개로 분해)', () => {
+    // '사과' = ㅅㅏㄱㅗㅏ → 마지막 입력 자모 ㅏ만 제거되어 ㅅㅏㄱㅗ
     const state = removeLetterFromGuess(
       withGuess(createGame('사과', { adapter: hangul }), '사과')
     );
-    expect(hangul.splitUnits(state.currentGuess)).toEqual(['ㅅ', 'ㅏ', 'ㄱ']);
+    expect(hangul.splitUnits(state.currentGuess)).toEqual(['ㅅ', 'ㅏ', 'ㄱ', 'ㅗ']);
   });
 });
 
@@ -130,11 +130,11 @@ describe('submitGuess — 판정 (correct/present/absent)', () => {
     expect(state.guesses).toHaveLength(0);
   });
 
-  it('한글은 자모 단위로 판정한다', () => {
-    // 타깃 사과(ㅅㅏㄱㅘ) vs 추측 과자(ㄱㅘㅈㅏ)
-    // ㄱ→present(idx2), ㅘ→present(idx3), ㅈ→absent, ㅏ→present(idx1)
+  it('한글은 자모 단위로 판정한다 (이중모음 분해 포함)', () => {
+    // 타깃 사과(ㅅㅏㄱㅗㅏ) vs 추측 과자(ㄱㅗㅏㅈㅏ)
+    // idx4 ㅏ→correct, ㄱ·ㅗ·ㅏ→present, ㅈ→absent
     const state = submitGuess(withGuess(createGame('사과', { adapter: hangul }), '과자'));
-    expect(states(state, 0)).toEqual(['present', 'present', 'absent', 'present']);
+    expect(states(state, 0)).toEqual(['present', 'present', 'present', 'absent', 'correct']);
   });
 });
 

--- a/lib/scripts/__tests__/hangul.test.ts
+++ b/lib/scripts/__tests__/hangul.test.ts
@@ -28,11 +28,19 @@ describe('hangul.splitUnits', () => {
     expect(hangul.splitUnits('잃')).toEqual(['ㅇ', 'ㅣ', 'ㄹ', 'ㅎ']);
   });
 
-  it('이중모음은 분해하지 않음', () => {
-    expect(hangul.splitUnits('과')).toEqual(['ㄱ', 'ㅘ']);
-    expect(hangul.splitUnits('워')).toEqual(['ㅇ', 'ㅝ']);
-    expect(hangul.splitUnits('의')).toEqual(['ㅇ', 'ㅢ']);
-    expect(hangul.splitUnits('왜')).toEqual(['ㅇ', 'ㅙ']);
+  it('이중모음은 두벌식 입력 자모 2개로 분해', () => {
+    expect(hangul.splitUnits('과')).toEqual(['ㄱ', 'ㅗ', 'ㅏ']);
+    expect(hangul.splitUnits('워')).toEqual(['ㅇ', 'ㅜ', 'ㅓ']);
+    expect(hangul.splitUnits('의')).toEqual(['ㅇ', 'ㅡ', 'ㅣ']);
+    expect(hangul.splitUnits('왜')).toEqual(['ㅇ', 'ㅗ', 'ㅐ']);
+    expect(hangul.splitUnits('외')).toEqual(['ㅇ', 'ㅗ', 'ㅣ']);
+    expect(hangul.splitUnits('웨')).toEqual(['ㅇ', 'ㅜ', 'ㅔ']);
+    expect(hangul.splitUnits('위')).toEqual(['ㅇ', 'ㅜ', 'ㅣ']);
+  });
+
+  it('이중모음 + 받침 조합도 분해', () => {
+    expect(hangul.splitUnits('관')).toEqual(['ㄱ', 'ㅗ', 'ㅏ', 'ㄴ']);
+    expect(hangul.splitUnits('뭣')).toEqual(['ㅁ', 'ㅜ', 'ㅓ', 'ㅅ']);
   });
 
   it('여러 음절', () => {

--- a/lib/scripts/hangul.ts
+++ b/lib/scripts/hangul.ts
@@ -11,7 +11,9 @@ import type { ScriptAdapter } from './types';
 // - splitUnits는 음절을 자모로 분해, 자모 직접 입력은 통과, 그 외 문자는 무시
 //   (입력은 isAllowedWord/isAllowedChar로 사전 검증되어야 함)
 // - 종성 겹받침은 단자모 2개로 추가 분해 (ㄳ→ㄱㅅ 등 11종)
-// - 중성의 이중모음(ㅘ, ㅝ, ㅢ 등)은 분해하지 않고 단일 자모로 보존 — 꼬들 표준
+// - 중성의 이중모음(ㅘ, ㅝ, ㅢ 등)도 두벌식 입력 자모 2개로 추가 분해 (ㅘ→ㅗㅏ 등 7종)
+//   ※ 두벌식 자판에는 이중모음 키가 없어 ㅗ→ㅏ 순으로 입력하므로, 입력 자모열과
+//      정답 분해 결과를 일치시키기 위해 분해한다
 const SBase = 0xac00;
 const LCount = 19;
 const VCount = 21;
@@ -37,7 +39,7 @@ const JONGSEONG: (string | null)[] = [
   'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
 ];
 
-// 꼬들 기준: 겹받침을 두 단자모로 분해 (이중모음은 분해하지 않음)
+// 겹받침을 두 단자모로 분해 (11종)
 const COMPOUND_JONGSEONG: Record<string, [string, string]> = {
   'ㄳ': ['ㄱ', 'ㅅ'],
   'ㄵ': ['ㄴ', 'ㅈ'],
@@ -52,6 +54,17 @@ const COMPOUND_JONGSEONG: Record<string, [string, string]> = {
   'ㅄ': ['ㅂ', 'ㅅ'],
 };
 
+// 이중모음을 두벌식 입력 자모 2개로 분해 (7종)
+const COMPOUND_JUNGSEONG: Record<string, [string, string]> = {
+  'ㅘ': ['ㅗ', 'ㅏ'],
+  'ㅙ': ['ㅗ', 'ㅐ'],
+  'ㅚ': ['ㅗ', 'ㅣ'],
+  'ㅝ': ['ㅜ', 'ㅓ'],
+  'ㅞ': ['ㅜ', 'ㅔ'],
+  'ㅟ': ['ㅜ', 'ㅣ'],
+  'ㅢ': ['ㅡ', 'ㅣ'],
+};
+
 function decomposeSyllable(syllable: string): string[] {
   const code = syllable.codePointAt(0);
   if (code === undefined || code < SBase || code > SEnd) {
@@ -62,7 +75,11 @@ function decomposeSyllable(syllable: string): string[] {
   const vIndex = Math.floor((sIndex % NCount) / TCount);
   const tIndex = sIndex % TCount;
 
-  const result: string[] = [CHOSEONG[lIndex], JUNGSEONG[vIndex]];
+  const v = JUNGSEONG[vIndex]!;
+  const compoundV = COMPOUND_JUNGSEONG[v];
+  const result: string[] = compoundV
+    ? [CHOSEONG[lIndex]!, compoundV[0], compoundV[1]]
+    : [CHOSEONG[lIndex]!, v];
   if (tIndex > 0) {
     const t = JONGSEONG[tIndex]!;
     const compound = COMPOUND_JONGSEONG[t];


### PR DESCRIPTION
## 문제

두벌식 자판에는 이중모음(ㅘ, ㅙ, ㅚ, ㅝ, ㅞ, ㅟ, ㅢ) 키가 없어 유저는 `ㅗ→ㅏ` 순으로 입력한다. 그런데 정답 분해(`splitUnits`)는 `ㅘ`를 **단일 자모로 보존**하고 있었다.

→ 정답 `과` = `['ㄱ','ㅘ']`(2칸)인데 유저가 만들 수 있는 입력은 `['ㄱ','ㅗ','ㅏ']`(3칸)뿐이라, **길이부터 어긋나 해당 음절이 포함된 단어를 영영 맞힐 수 없는** 상태였다.

## 변경

`decomposeSyllable`이 겹받침 분해와 동일한 방식으로 **이중모음 7종도 두벌식 입력 자모 2개로 분해**하도록 `COMPOUND_JUNGSEONG` 맵을 추가했다.

| 모음 | 분해 |
|------|------|
| ㅘ | ㅗ + ㅏ |
| ㅙ | ㅗ + ㅐ |
| ㅚ | ㅗ + ㅣ |
| ㅝ | ㅜ + ㅓ |
| ㅞ | ㅜ + ㅔ |
| ㅟ | ㅜ + ㅣ |
| ㅢ | ㅡ + ㅣ |

이제 `splitUnits('과')` → `['ㄱ','ㅗ','ㅏ']`로, 키보드 입력 자모열과 정답 판정이 일치한다.

## 영향

- 이중모음이 든 음절은 칸 수가 늘어남 (`과`: 2칸 → 3칸). 의도된 동작이며 키보드 입력과 일치.
- ㅚ·ㅟ 포함 **7종 전부** 분해 — 두벌식에서 ㅚ/ㅟ도 ㅗ+ㅣ, ㅜ+ㅣ로 입력하므로 일관성상 함께 분해.
- 덱 단어는 음절(가-힣)로 저장되고 런타임에 분해되므로 기존 데이터 마이그레이션 불필요.

## 테스트

- `hangul.test.ts` — 이중모음 분해 + 받침 조합(`관`→ㄱㅗㅏㄴ) 케이스 추가
- `gameEngine.test.ts`, `wordleGame.test.ts` — `사과` 관련 제거/판정 기대값 갱신
- 단위 테스트 전체 **233 passed**, `tsc --noEmit` 통과

https://claude.ai/code/session_014Je9TzFzXZanaR6xBffq6L

---
_Generated by [Claude Code](https://claude.ai/code/session_014Je9TzFzXZanaR6xBffq6L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 한글 이중모음(ㅘ, ㅝ, ㅢ 등) 처리 개선으로 게임 내 글자 제거 및 정답 판정이 더 정확해졌습니다.
  * 단어 게임에서 한글 자모 분해 로직을 업데이트하여 이중모음이 입력 자모 단위로 올바르게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->