### PR TITLE
feat(deck): add deck images and OG previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Supabase CLI / GitHub Actions migration deploy
+# SUPABASE_PROJECT_REF is the project id prefix from NEXT_PUBLIC_SUPABASE_URL.
+# Example: https://<ref>.supabase.co
+SUPABASE_PROJECT_REF=
+SUPABASE_ACCESS_TOKEN=
+SUPABASE_DB_PASSWORD=
+
 # 좋아요 IP 해시 salt (ADR 0002) — 회전 시 기존 좋아요 전부 무효화. 영구 고정.
 IP_HASH_SALT=
 

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -46,7 +46,7 @@ type CredentialCheck =
   | { ok: false; message: string };
 
 type DeckImageUpload =
-  | { ok: true; imageUrl: string }
+  | { ok: true; imageUrl: string; objectPath: string }
   | { ok: false; message: string };
 
 // verifyCredentials는 request context 밖에서 호출될 수도 있어
@@ -97,14 +97,6 @@ async function uploadDeckImage(deckId: string, file: File): Promise<DeckImageUpl
   const objectPrefix = `${deckId}/`;
   const objectPath = `${objectPrefix}cover-${Date.now()}.${ext}`;
 
-  const { data: existing } = await admin.storage
-    .from(DECK_IMAGE_BUCKET)
-    .list(deckId, { limit: 20 });
-  const oldPaths = (existing ?? []).map((object) => `${objectPrefix}${object.name}`);
-  if (oldPaths.length > 0) {
-    await admin.storage.from(DECK_IMAGE_BUCKET).remove(oldPaths);
-  }
-
   const { error } = await admin.storage
     .from(DECK_IMAGE_BUCKET)
     .upload(objectPath, file, {
@@ -118,7 +110,22 @@ async function uploadDeckImage(deckId: string, file: File): Promise<DeckImageUpl
   }
 
   const { data } = admin.storage.from(DECK_IMAGE_BUCKET).getPublicUrl(objectPath);
-  return { ok: true, imageUrl: data.publicUrl };
+  return { ok: true, imageUrl: data.publicUrl, objectPath };
+}
+
+async function listDeckImagePaths(deckId: string): Promise<string[]> {
+  const admin = createAdminClient();
+  const objectPrefix = `${deckId}/`;
+  const { data } = await admin.storage
+    .from(DECK_IMAGE_BUCKET)
+    .list(deckId, { limit: 100 });
+  return (data ?? []).map((object) => `${objectPrefix}${object.name}`);
+}
+
+async function removeDeckImagePaths(paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+  const admin = createAdminClient();
+  await admin.storage.from(DECK_IMAGE_BUCKET).remove(paths);
 }
 
 export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
@@ -204,6 +211,7 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
         .update({ image_url: upload.imageUrl })
         .eq("id", deck.id);
       if (imageError) {
+        await removeDeckImagePaths([upload.objectPath]);
         await admin.from("decks").delete().eq("id", deck.id);
         return { success: false, message: `이미지 저장에 실패했습니다: ${imageError.message}` };
       }
@@ -357,6 +365,7 @@ export async function updateDeckImage(formData: FormData): Promise<ActionRespons
     });
     if (!check.ok) return { success: false, message: check.message };
 
+    const existingImagePaths = await listDeckImagePaths(deckId);
     const upload = await uploadDeckImage(deckId, image);
     if (!upload.ok) return { success: false, message: upload.message };
 
@@ -366,9 +375,11 @@ export async function updateDeckImage(formData: FormData): Promise<ActionRespons
       .update({ image_url: upload.imageUrl, updated_at: new Date().toISOString() })
       .eq("id", deckId);
     if (error) {
+      await removeDeckImagePaths([upload.objectPath]);
       return { success: false, message: `이미지 저장에 실패했습니다: ${error.message}` };
     }
 
+    await removeDeckImagePaths(existingImagePaths.filter((path) => path !== upload.objectPath));
     revalidatePath(`/d/${deckId}`);
     revalidatePath(`/d/${deckId}/edit`);
     return { success: true, data: { imageUrl: upload.imageUrl }, message: "이미지를 저장했습니다." };

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -23,7 +23,15 @@ import type { Tables } from "@/types/database";
 
 // creator_pw_hash 노출 방지용 화이트리스트
 const DECK_PUBLIC_COLUMNS =
-  "id, name, script, creator_id, creator_nick, like_count, hidden, report_count, created_at, updated_at";
+  "id, name, script, creator_id, creator_nick, image_url, like_count, hidden, report_count, created_at, updated_at";
+
+const DECK_IMAGE_BUCKET = "deck-images";
+const MAX_DECK_IMAGE_BYTES = 2 * 1024 * 1024;
+const DECK_IMAGE_TYPES: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
 
 export type PublicDeck = Omit<Tables<"decks">, "creator_pw_hash">;
 export type DeckWord = Tables<"words">;
@@ -35,6 +43,10 @@ export interface DeckWithWords {
 
 type CredentialCheck =
   | { ok: true }
+  | { ok: false; message: string };
+
+type DeckImageUpload =
+  | { ok: true; imageUrl: string }
   | { ok: false; message: string };
 
 // verifyCredentials는 request context 밖에서 호출될 수도 있어
@@ -65,6 +77,50 @@ async function verifyCredentials(
   return { ok: true };
 }
 
+function readOptionalImage(formData: FormData): File | null {
+  const file = formData.get("image");
+  if (!(file instanceof File) || file.size === 0) return null;
+  return file;
+}
+
+async function uploadDeckImage(deckId: string, file: File): Promise<DeckImageUpload> {
+  if (file.size > MAX_DECK_IMAGE_BYTES) {
+    return { ok: false, message: "이미지는 2MB 이하만 업로드할 수 있습니다." };
+  }
+
+  const ext = DECK_IMAGE_TYPES[file.type];
+  if (!ext) {
+    return { ok: false, message: "이미지는 JPG, PNG, WebP 형식만 업로드할 수 있습니다." };
+  }
+
+  const admin = createAdminClient();
+  const objectPrefix = `${deckId}/`;
+  const objectPath = `${objectPrefix}cover-${Date.now()}.${ext}`;
+
+  const { data: existing } = await admin.storage
+    .from(DECK_IMAGE_BUCKET)
+    .list(deckId, { limit: 20 });
+  const oldPaths = (existing ?? []).map((object) => `${objectPrefix}${object.name}`);
+  if (oldPaths.length > 0) {
+    await admin.storage.from(DECK_IMAGE_BUCKET).remove(oldPaths);
+  }
+
+  const { error } = await admin.storage
+    .from(DECK_IMAGE_BUCKET)
+    .upload(objectPath, file, {
+      contentType: file.type,
+      cacheControl: "31536000",
+      upsert: true,
+    });
+
+  if (error) {
+    return { ok: false, message: `이미지 업로드에 실패했습니다: ${error.message}` };
+  }
+
+  const { data } = admin.storage.from(DECK_IMAGE_BUCKET).getPublicUrl(objectPath);
+  return { ok: true, imageUrl: data.publicUrl };
+}
+
 export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
   return safeAction(async () => {
     const tAuth = await getTranslations("auth");
@@ -76,6 +132,7 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
     const nick = String(formData.get("nick") ?? "").trim();
     const password = String(formData.get("password") ?? "");
     const wordsText = String(formData.get("words_text") ?? "");
+    const image = readOptionalImage(formData);
 
     const fieldErrors: { [key: string]: string[] } = {};
     if (!name || name.length > 100) fieldErrors.name = [tDeckForm("error.nameLength")];
@@ -134,6 +191,22 @@ export async function createDeck(formData: FormData): Promise<ActionResponse<{ i
       // 단어 없는 덱은 invariant 위반 — 덱을 남기지 않는다
       await admin.from("decks").delete().eq("id", deck.id);
       return { success: false, message: `단어 저장에 실패했습니다: ${wordsError.message}` };
+    }
+
+    if (image) {
+      const upload = await uploadDeckImage(deck.id, image);
+      if (!upload.ok) {
+        await admin.from("decks").delete().eq("id", deck.id);
+        return { success: false, message: upload.message };
+      }
+      const { error: imageError } = await admin
+        .from("decks")
+        .update({ image_url: upload.imageUrl })
+        .eq("id", deck.id);
+      if (imageError) {
+        await admin.from("decks").delete().eq("id", deck.id);
+        return { success: false, message: `이미지 저장에 실패했습니다: ${imageError.message}` };
+      }
     }
 
     revalidatePath(`/d/${deck.id}`);
@@ -263,5 +336,41 @@ export async function updateDeckWords(input: {
 
     revalidatePath(`/d/${deckId}`);
     return { success: true, message: tDeckAction("updated") };
+  });
+}
+
+export async function updateDeckImage(formData: FormData): Promise<ActionResponse<{ imageUrl: string }>> {
+  return safeAction(async () => {
+    const tAuth = await getTranslations("auth");
+    const deckId = String(formData.get("deckId") ?? "");
+    const nick = String(formData.get("nick") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+    const image = readOptionalImage(formData);
+
+    if (!deckId || !image) {
+      return { success: false, message: "업로드할 이미지를 선택해주세요." };
+    }
+
+    const check = await verifyCredentials(deckId, nick, password, {
+      deckNotFound: "덱을 찾을 수 없습니다.",
+      invalidCredentials: tAuth("error.invalidCredentials"),
+    });
+    if (!check.ok) return { success: false, message: check.message };
+
+    const upload = await uploadDeckImage(deckId, image);
+    if (!upload.ok) return { success: false, message: upload.message };
+
+    const admin = createAdminClient();
+    const { error } = await admin
+      .from("decks")
+      .update({ image_url: upload.imageUrl, updated_at: new Date().toISOString() })
+      .eq("id", deckId);
+    if (error) {
+      return { success: false, message: `이미지 저장에 실패했습니다: ${error.message}` };
+    }
+
+    revalidatePath(`/d/${deckId}`);
+    revalidatePath(`/d/${deckId}/edit`);
+    return { success: true, data: { imageUrl: upload.imageUrl }, message: "이미지를 저장했습니다." };
   });
 }

--- a/app/actions/feed.ts
+++ b/app/actions/feed.ts
@@ -10,7 +10,7 @@ import { escapeLikePattern, normalizeSearchQuery } from "@/lib/search";
 // creator_pw_hash는 화이트리스트로 제외한다.
 
 const FEED_COLUMNS =
-  "id, name, script, creator_id, creator_nick, like_count, created_at";
+  "id, name, script, creator_id, creator_nick, image_url, like_count, created_at";
 // Hot은 computed score라 DB 정렬 불가 — 최신 window를 가져와 서버(JS)에서 정렬한다.
 // hot 점수는 recency 가중이라 오래된 덱은 어차피 하위권 → window 근사로 충분 (MVP)
 const HOT_WINDOW = 200;
@@ -24,6 +24,7 @@ export interface FeedDeck {
   script: string;
   creator_id: string;
   creator_nick: string;
+  image_url: string | null;
   like_count: number;
   created_at: string;
 }

--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { safeAction } from "@/lib/safe-action";
 import { ActionResponse } from "@/types/action";
-import { hashIp, parseForwardedFor } from "@/lib/ip";
+import { hashIp, requestIpFromHeaders } from "@/lib/ip";
 
 // IP 해시 단독 식별 좋아요 (ADR 0002). likes 테이블은 RLS 정책이 없어
 // client direct 접근이 차단된다 — 모든 read/write는 본 server action만.
@@ -19,18 +19,20 @@ export type LikeActionResponse = ActionResponse<LikeStatus> & { conflict?: boole
 
 const PG_UNIQUE_VIOLATION = "23505";
 
-async function requestIpHash(): Promise<string | null> {
+type IpHashResult =
+  | { ok: true; ipHash: string }
+  | { ok: false; message: string };
+
+async function requestIpHash(): Promise<IpHashResult> {
   const salt = process.env.IP_HASH_SALT;
   if (!salt) {
     console.error("[like] IP_HASH_SALT 환경변수가 설정되지 않았습니다.");
-    return null;
+    return { ok: false, message: "좋아요 설정이 누락되었습니다." };
   }
   const headerStore = await headers();
-  const ip =
-    parseForwardedFor(headerStore.get("x-forwarded-for")) ??
-    headerStore.get("x-real-ip");
-  if (!ip) return null;
-  return hashIp(ip, salt);
+  const ip = requestIpFromHeaders(headerStore);
+  if (!ip) return { ok: false, message: "요청 IP를 확인할 수 없습니다." };
+  return { ok: true, ipHash: hashIp(ip, salt) };
 }
 
 async function currentStatus(deckId: string, ipHash: string): Promise<LikeStatus | null> {
@@ -51,9 +53,9 @@ async function currentStatus(deckId: string, ipHash: string): Promise<LikeStatus
 export async function getLikeStatus(deckId: string): Promise<LikeActionResponse> {
   return safeAction(async () => {
     const ipHash = await requestIpHash();
-    if (!ipHash) return { success: false, message: "요청 IP를 확인할 수 없습니다." };
+    if (!ipHash.ok) return { success: false, message: ipHash.message };
 
-    const status = await currentStatus(deckId, ipHash);
+    const status = await currentStatus(deckId, ipHash.ipHash);
     if (!status) return { success: false, message: "덱을 찾을 수 없습니다." };
     return { success: true, data: status, message: "좋아요 상태를 가져왔습니다." };
   });
@@ -66,7 +68,7 @@ export async function toggleLike(
 ): Promise<LikeActionResponse> {
   return safeAction(async () => {
     const ipHash = await requestIpHash();
-    if (!ipHash) return { success: false, message: "요청 IP를 확인할 수 없습니다." };
+    if (!ipHash.ok) return { success: false, message: ipHash.message };
 
     const admin = createAdminClient();
 
@@ -78,7 +80,7 @@ export async function toggleLike(
       .single();
     if (!deck) return { success: false, message: "덱을 찾을 수 없습니다." };
     if (deck.hidden) {
-      const status = await currentStatus(deckId, ipHash);
+      const status = await currentStatus(deckId, ipHash.ipHash);
       return {
         success: false,
         conflict: true,
@@ -90,9 +92,9 @@ export async function toggleLike(
     if (like) {
       const { error } = await admin
         .from("likes")
-        .insert({ deck_id: deckId, ip_hash: ipHash });
+        .insert({ deck_id: deckId, ip_hash: ipHash.ipHash });
       if (error?.code === PG_UNIQUE_VIOLATION) {
-        const status = await currentStatus(deckId, ipHash);
+        const status = await currentStatus(deckId, ipHash.ipHash);
         return {
           success: false,
           conflict: true,
@@ -108,14 +110,14 @@ export async function toggleLike(
         .from("likes")
         .delete()
         .eq("deck_id", deckId)
-        .eq("ip_hash", ipHash);
+        .eq("ip_hash", ipHash.ipHash);
       if (error) {
         return { success: false, message: `좋아요 취소에 실패했습니다: ${error.message}` };
       }
     }
 
     // 트리거 반영 후 서버 진실을 반환 — 클라이언트가 이 값으로 동기화한다
-    const status = await currentStatus(deckId, ipHash);
+    const status = await currentStatus(deckId, ipHash.ipHash);
     if (!status) return { success: false, message: "덱을 찾을 수 없습니다." };
     return {
       success: true,

--- a/app/og/[file]/route.tsx
+++ b/app/og/[file]/route.tsx
@@ -23,7 +23,7 @@ export async function GET(
   const [{ data: deck }, { count: wordCount }] = await Promise.all([
     supabase
       .from("decks")
-      .select("name, script, like_count, hidden")
+      .select("name, script, image_url, like_count, hidden")
       .eq("id", deckId)
       .single(),
     supabase
@@ -49,23 +49,51 @@ export async function GET(
           alignItems: "center",
           justifyContent: "center",
           gap: 24,
+          position: "relative",
           backgroundColor: "#0f172a",
           color: "#f8fafc",
           fontSize: 36,
+          overflow: "hidden",
         }}
       >
-        <div style={{ display: "flex", gap: 12, fontSize: 28, color: "#94a3b8" }}>
-          wordledecks · {SCRIPT_LABELS[deck.script] ?? deck.script}
-        </div>
-        <div style={{ display: "flex", fontSize: 72, fontWeight: 700, padding: "0 60px" }}>
-          {deck.name}
-        </div>
-        <div style={{ display: "flex", gap: 40, fontSize: 32, color: "#cbd5e1" }}>
-          <span>단어 {wordCount ?? 0}개</span>
-          <span>❤️ {deck.like_count}</span>
-        </div>
-        <div style={{ display: "flex", fontSize: 24, color: "#64748b" }}>
-          오늘의 단어에 도전해보세요
+        {deck.image_url && (
+          // eslint-disable-next-line @next/next/no-img-element -- next/og ImageResponse renders raw img tags.
+          <img
+            src={deck.image_url}
+            alt=""
+            width="1200"
+            height="630"
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              opacity: 0.42,
+            }}
+          />
+        )}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background: "linear-gradient(180deg, rgba(15,23,42,0.52), rgba(15,23,42,0.92))",
+          }}
+        />
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 24, zIndex: 1 }}>
+          <div style={{ display: "flex", gap: 12, fontSize: 28, color: "#cbd5e1" }}>
+            wordledecks · {SCRIPT_LABELS[deck.script] ?? deck.script}
+          </div>
+          <div style={{ display: "flex", fontSize: 72, fontWeight: 700, padding: "0 60px", textAlign: "center" }}>
+            {deck.name}
+          </div>
+          <div style={{ display: "flex", gap: 40, fontSize: 32, color: "#e2e8f0" }}>
+            <span>단어 {wordCount ?? 0}개</span>
+            <span>❤️ {deck.like_count}</span>
+          </div>
+          <div style={{ display: "flex", fontSize: 24, color: "#cbd5e1" }}>
+            오늘의 단어에 도전해보세요
+          </div>
         </div>
       </div>
     ),

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { CommentForm } from "@/components/CommentForm";
 import { CommentDeleteButton } from "@/components/CommentDeleteButton";
 import { ReportButton } from "@/components/ReportButton";
@@ -22,6 +23,7 @@ interface CommentThreadProps {
 // (deck, date) 단위 thread를 날짜 헤더로 그룹해 최신순 표시 (#47).
 // 가시성 게이트는 server action(getComments)이 계산한다 — 클라이언트는 결과만 렌더.
 export function CommentThread({ deckId }: CommentThreadProps) {
+  const t = useTranslations("comments");
   const [view, setView] = useState<CommentThreadsView | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [today] = useState(localDate);
@@ -41,22 +43,22 @@ export function CommentThread({ deckId }: CommentThreadProps) {
   }, [reload]);
 
   if (loadError) return <p className="text-sm text-destructive">{loadError}</p>;
-  if (!view) return <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>;
+  if (!view) return <p className="text-sm text-muted-foreground">{t("loading")}</p>;
 
   return (
     <section className="space-y-6">
-      <h2 className="text-lg font-bold">댓글</h2>
+      <h2 className="text-lg font-bold">{t("title")}</h2>
 
       {view.todayLocked ? (
         <div className="rounded-lg border p-4 text-center text-sm text-muted-foreground">
-          🔒 오늘의 데일리를 완료하면 오늘 댓글을 보고 쓸 수 있습니다.
+          {t("todayLocked")}
         </div>
       ) : (
         <CommentForm deckId={deckId} writerToday={today} onCreated={reload} />
       )}
 
       {view.threads.length === 0 && !view.todayLocked && (
-        <p className="text-sm text-muted-foreground">아직 댓글이 없습니다. 첫 댓글을 남겨보세요!</p>
+        <p className="text-sm text-muted-foreground">{t("empty")}</p>
       )}
 
       {view.threads.map((thread) => (

--- a/components/DeckEditForm.tsx
+++ b/components/DeckEditForm.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { actionWithToast } from "@/lib/action-with-toast";
-import { verifyDeckCredentials, updateDeckWords, type DeckWord } from "@/app/actions/deck";
+import { verifyDeckCredentials, updateDeckImage, updateDeckWords, type DeckWord } from "@/app/actions/deck";
 import { loadCachedCredentials, saveCachedCredentials } from "@/lib/credentialCache";
 import { cn } from "@/lib/utils";
 
@@ -26,6 +26,8 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
   const [unlocked, setUnlocked] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [uploadingImage, setUploadingImage] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
   // 저장 전까지 보류되는 비활성화/재활성화 토글 (id 집합)
   const [toggledIds, setToggledIds] = useState<Set<string>>(new Set());
   const [addWordsText, setAddWordsText] = useState("");
@@ -87,6 +89,26 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
       }
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleImageSave = async () => {
+    if (!imageFile) return;
+    setUploadingImage(true);
+    try {
+      const formData = new FormData();
+      formData.set("deckId", deckId);
+      formData.set("nick", nick.trim());
+      formData.set("password", password);
+      formData.set("image", imageFile);
+
+      const result = await actionWithToast(() => updateDeckImage(formData));
+      if (result.success) {
+        setImageFile(null);
+        router.refresh();
+      }
+    } finally {
+      setUploadingImage(false);
     }
   };
 
@@ -162,6 +184,27 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
           onChange={(e) => setAddWordsText(e.target.value)}
           rows={4}
         />
+      </section>
+
+      <section className="space-y-2">
+        <Label htmlFor="edit-image">{t("label.image")}</Label>
+        <div className="flex gap-2">
+          <Input
+            id="edit-image"
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!imageFile || uploadingImage}
+            onClick={handleImageSave}
+          >
+            {uploadingImage ? t("button.uploadingImage") : t("button.uploadImage")}
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">{t("hint.image")}</p>
       </section>
 
       <Button onClick={handleSave} disabled={saving || activeAfterToggle < 1}>

--- a/components/DeckForm.tsx
+++ b/components/DeckForm.tsx
@@ -52,6 +52,13 @@ export function DeckForm() {
     [wordsText, script],
   );
   const validWords = wordsValidation.ok ? wordsValidation.words : [];
+  const wordsValidationMessage = wordsValidation.ok
+    ? null
+    : wordsValidation.reason === "invalidChars"
+      ? tValidation("invalidChars", { lines: wordsValidation.invalidLines.join(", ") })
+      : wordsValidation.reason === "duplicateWords"
+        ? tValidation("duplicateWords", { lines: wordsValidation.invalidLines.join(", ") })
+        : tValidation("minOneWord");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -140,11 +147,7 @@ export function DeckForm() {
           required
         />
         {!wordsValidation.ok && (
-          <p className="text-sm text-destructive">
-            {wordsValidation.invalidLines.length > 0
-              ? tValidation("invalidChars", { lines: wordsValidation.invalidLines.join(", ") })
-              : tValidation("minOneWord")}
-          </p>
+          <p className="text-sm text-destructive">{wordsValidationMessage}</p>
         )}
         {wordsValidation.ok && (
           <p className="text-sm text-muted-foreground">{t("hint.validWordCount", { count: validWords.length })}</p>

--- a/components/DeckForm.tsx
+++ b/components/DeckForm.tsx
@@ -35,6 +35,7 @@ export function DeckForm() {
   const [nick, setNick] = useState("");
   const [password, setPassword] = useState("");
   const [wordsText, setWordsText] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSimulator, setShowSimulator] = useState(false);
 
@@ -70,6 +71,7 @@ export function DeckForm() {
       formData.set("nick", nick);
       formData.set("password", password);
       formData.set("words_text", wordsText);
+      if (imageFile) formData.set("image", imageFile);
 
       const result = await actionWithToast(() => createDeck(formData));
       if (result.success && result.data) {
@@ -152,6 +154,17 @@ export function DeckForm() {
         {wordsValidation.ok && (
           <p className="text-sm text-muted-foreground">{t("hint.validWordCount", { count: validWords.length })}</p>
         )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="deck-image">{t("label.image")}</Label>
+        <Input
+          id="deck-image"
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+        />
+        <p className="text-sm text-muted-foreground">{t("hint.image")}</p>
       </div>
 
       <div className="flex gap-2">

--- a/components/DeckMetaCard.tsx
+++ b/components/DeckMetaCard.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -14,6 +15,17 @@ export async function DeckMetaCard({ deck, activeWordCount }: DeckMetaCardProps)
 
   return (
     <Card>
+      {deck.image_url && (
+        <div className="relative aspect-[16/9] overflow-hidden rounded-t-lg bg-muted">
+          <Image
+            src={deck.image_url}
+            alt={deck.name}
+            fill
+            sizes="(max-width: 640px) 100vw, 640px"
+            className="object-cover"
+          />
+        </div>
+      )}
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           {deck.name}

--- a/components/FeedDeckCard.tsx
+++ b/components/FeedDeckCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +13,17 @@ export function FeedDeckCard({ deck }: { deck: FeedDeck }) {
 
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border p-4">
+      {deck.image_url && (
+        <Link href={`/d/${deck.id}`} className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
+          <Image
+            src={deck.image_url}
+            alt={deck.name}
+            fill
+            sizes="56px"
+            className="object-cover"
+          />
+        </Link>
+      )}
       <Link href={`/d/${deck.id}`} className="min-w-0 flex-1 space-y-1">
         <p className="truncate font-semibold">{deck.name}</p>
         <p className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/components/FeedDeckCard.tsx
+++ b/components/FeedDeckCard.tsx
@@ -1,22 +1,21 @@
+"use client";
+
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { LikeButton } from "@/components/LikeButton";
 import { formatDisplayNick } from "@/lib/identity";
 import type { FeedDeck } from "@/app/actions/feed";
 
-const SCRIPT_LABELS: Record<string, string> = {
-  latin: "로마자",
-  hangul: "한글",
-  kana: "가나",
-};
-
 export function FeedDeckCard({ deck }: { deck: FeedDeck }) {
+  const t = useTranslations("deck.meta.scriptLabel");
+
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border p-4">
       <Link href={`/d/${deck.id}`} className="min-w-0 flex-1 space-y-1">
         <p className="truncate font-semibold">{deck.name}</p>
         <p className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Badge variant="secondary">{SCRIPT_LABELS[deck.script] ?? deck.script}</Badge>
+          <Badge variant="secondary">{t(deck.script, { defaultValue: deck.script })}</Badge>
           {formatDisplayNick(deck.creator_nick, deck.creator_id)}
         </p>
       </Link>

--- a/components/ReportButton.tsx
+++ b/components/ReportButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -18,6 +19,7 @@ interface ReportButtonProps {
 }
 
 export function ReportButton({ targetType, targetId }: ReportButtonProps) {
+  const t = useTranslations("report");
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -47,22 +49,22 @@ export function ReportButton({ targetType, targetId }: ReportButtonProps) {
           size="sm"
           className="h-7 px-2 text-xs text-muted-foreground"
         >
-          신고
+          {t("trigger")}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64">
         <form onSubmit={handleSubmit} className="space-y-2">
           <p className="text-xs text-muted-foreground">
-            부적절한 {targetType === "deck" ? "덱" : "댓글"}을 신고합니다.
+            {t("description", { target: t(`target.${targetType}`) })}
           </p>
           <Input
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            placeholder="사유 (선택)"
+            placeholder={t("reasonPlaceholder")}
             maxLength={200}
           />
           <Button type="submit" size="sm" disabled={submitting} className="w-full">
-            {submitting ? "신고 중..." : "신고하기"}
+            {submitting ? t("submitting") : t("submit")}
           </Button>
         </form>
       </PopoverContent>

--- a/lib/deckWords.test.ts
+++ b/lib/deckWords.test.ts
@@ -6,8 +6,17 @@ function row(id: string, text: string, active: boolean): DeckWordRow {
 }
 
 describe('parseWordLines', () => {
-  it('정규화(NFC+lowercase) 후 dedupe한다', () => {
+  it('정규화(NFC+lowercase) 후 중복 단어를 거부한다', () => {
     const result = parseWordLines('LoL\nlol\npikachu', 'latin');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('duplicateWords');
+      expect(result.invalidLines).toEqual(['lol']);
+    }
+  });
+
+  it('유효 단어는 정규화해서 반환한다', () => {
+    const result = parseWordLines('LoL\npikachu', 'latin');
     expect(result).toEqual({ ok: true, words: ['lol', 'pikachu'] });
   });
 
@@ -19,13 +28,19 @@ describe('parseWordLines', () => {
   it('허용 문자 외 단어는 원본 줄을 들어 거부한다', () => {
     const result = parseWordLines('pikachu\nstar wars', 'latin');
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.invalidLines).toEqual(['star wars']);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalidChars');
+      expect(result.invalidLines).toEqual(['star wars']);
+    }
   });
 
   it('유효 단어 0개면 "최소 1개 단어 필요" 에러 (AC)', () => {
     const result = parseWordLines('', 'latin');
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.message).toContain('최소 1개');
+    if (!result.ok) {
+      expect(result.reason).toBe('minOneWord');
+      expect(result.message).toContain('최소 1개');
+    }
   });
 
   it('requireMin: false면 0개를 허용한다 (편집 시 추가 없음 케이스)', () => {

--- a/lib/deckWords.ts
+++ b/lib/deckWords.ts
@@ -21,7 +21,12 @@ export interface WordUpdatePlan {
 
 export type WordsValidation =
   | { ok: true; words: string[] }
-  | { ok: false; message: string; invalidLines: string[] };
+  | {
+      ok: false;
+      reason: "invalidChars" | "duplicateWords" | "minOneWord";
+      message: string;
+      invalidLines: string[];
+    };
 
 export type PlanResult =
   | { ok: true; plan: WordUpdatePlan }
@@ -29,7 +34,7 @@ export type PlanResult =
 
 export const MIN_ACTIVE_WORDS = 1;
 
-// 줄 단위 입력을 canonical form으로 정규화·검증·dedupe한다.
+// 줄 단위 입력을 canonical form으로 정규화·검증한다.
 // requireMin이 true면 유효 단어 0개를 에러로 처리한다 (덱 생성 경로).
 // 덱 로드/검증 경계에서 호출되므로 미등록 script id는 hard-fail한다 (assertKnownScript).
 export function parseWordLines(
@@ -42,6 +47,7 @@ export function parseWordLines(
   assertKnownScript(scriptId);
 
   const invalidLines: string[] = [];
+  const duplicateLines: string[] = [];
   const seen = new Set<string>();
   const words: string[] = [];
 
@@ -53,7 +59,10 @@ export function parseWordLines(
       invalidLines.push(trimmed);
       continue;
     }
-    if (seen.has(normalized)) continue; // 정규화 후 중복은 조용히 dedupe
+    if (seen.has(normalized)) {
+      duplicateLines.push(trimmed);
+      continue;
+    }
     seen.add(normalized);
     words.push(normalized);
   }
@@ -61,12 +70,21 @@ export function parseWordLines(
   if (invalidLines.length > 0) {
     return {
       ok: false,
+      reason: "invalidChars",
       message: `허용되지 않는 문자가 포함된 단어가 있습니다: ${invalidLines.join(", ")}`,
       invalidLines,
     };
   }
+  if (duplicateLines.length > 0) {
+    return {
+      ok: false,
+      reason: "duplicateWords",
+      message: `중복 단어가 있습니다: ${duplicateLines.join(", ")}`,
+      invalidLines: duplicateLines,
+    };
+  }
   if (requireMin && words.length < MIN_ACTIVE_WORDS) {
-    return { ok: false, message: "최소 1개 단어 필요", invalidLines: [] };
+    return { ok: false, reason: "minOneWord", message: "최소 1개 단어 필요", invalidLines: [] };
   }
   return { ok: true, words };
 }

--- a/lib/ip.test.ts
+++ b/lib/ip.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hashIp, parseForwardedFor } from './ip';
+import { hashIp, parseForwardedFor, requestIpFromHeaders } from './ip';
 
 describe('hashIp — 결정성 (AC)', () => {
   it('같은 (ip, salt)면 항상 같은 해시', () => {
@@ -29,5 +29,33 @@ describe('parseForwardedFor', () => {
   it('없거나 비어있으면 null', () => {
     expect(parseForwardedFor(null)).toBeNull();
     expect(parseForwardedFor('')).toBeNull();
+  });
+});
+
+describe('requestIpFromHeaders', () => {
+  function headers(values: Record<string, string | null>) {
+    return {
+      get(name: string) {
+        return values[name] ?? null;
+      },
+    };
+  }
+
+  it('x-forwarded-for 첫 항목을 우선한다', () => {
+    expect(requestIpFromHeaders(headers({
+      'x-forwarded-for': '203.0.113.7, 10.0.0.1',
+      'x-real-ip': '198.51.100.1',
+    }))).toBe('203.0.113.7');
+  });
+
+  it('프록시별 대체 헤더를 순서대로 사용한다', () => {
+    expect(requestIpFromHeaders(headers({ 'x-real-ip': '198.51.100.1' }))).toBe('198.51.100.1');
+    expect(requestIpFromHeaders(headers({ 'x-vercel-forwarded-for': '198.51.100.2' }))).toBe('198.51.100.2');
+    expect(requestIpFromHeaders(headers({ 'cf-connecting-ip': '198.51.100.3' }))).toBe('198.51.100.3');
+    expect(requestIpFromHeaders(headers({ 'true-client-ip': '198.51.100.4' }))).toBe('198.51.100.4');
+  });
+
+  it('IP 헤더가 없으면 null', () => {
+    expect(requestIpFromHeaders(headers({}))).toBeNull();
   });
 });

--- a/lib/ip.ts
+++ b/lib/ip.ts
@@ -13,3 +13,17 @@ export function parseForwardedFor(headerValue: string | null): string | null {
   const first = headerValue.split(",")[0]?.trim();
   return first || null;
 }
+
+type HeaderReader = {
+  get(name: string): string | null;
+};
+
+export function requestIpFromHeaders(headers: HeaderReader): string | null {
+  return (
+    parseForwardedFor(headers.get("x-forwarded-for")) ??
+    headers.get("x-real-ip") ??
+    headers.get("x-vercel-forwarded-for") ??
+    headers.get("cf-connecting-ip") ??
+    headers.get("true-client-ip")
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -65,7 +65,8 @@
         "nick": "Nickname",
         "password": "Password (deck PIN)",
         "words": "Word list (one per line)",
-        "addWords": "Add words (one per line)"
+        "addWords": "Add words (one per line)",
+        "image": "Cover image"
       },
       "scriptOption": {
         "latin": "Latin (a-z)",
@@ -81,12 +82,15 @@
         "verify": "Verify",
         "verifying": "Verifying...",
         "deactivate": "Deactivate",
-        "reactivate": "Reactivate"
+        "reactivate": "Reactivate",
+        "uploadImage": "Save image",
+        "uploadingImage": "Saving..."
       },
       "hint": {
         "validWordCount": "{count} valid words",
         "wordChanged": "Changed",
-        "editCredentials": "Enter the nickname and password you used when creating this deck."
+        "editCredentials": "Enter the nickname and password you used when creating this deck.",
+        "image": "JPG, PNG, or WebP. Max 2MB."
       },
       "error": {
         "minActiveWords": "At least 1 active word is required.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -177,9 +177,27 @@
       "commentPosted": "Comment posted."
     }
   },
+  "comments": {
+    "title": "Comments",
+    "loading": "Loading comments...",
+    "todayLocked": "🔒 Complete today's daily to read and write today's comments.",
+    "empty": "No comments yet. Leave the first one!"
+  },
+  "report": {
+    "trigger": "Report",
+    "description": "Report inappropriate {target}.",
+    "reasonPlaceholder": "Reason (optional)",
+    "submit": "Submit report",
+    "submitting": "Reporting...",
+    "target": {
+      "deck": "deck",
+      "comment": "comment"
+    }
+  },
   "validation": {
     "error": {
       "invalidChars": "Some words contain unsupported characters: {lines}",
+      "duplicateWords": "Duplicate words are not allowed: {lines}",
       "minOneWord": "At least 1 word required",
       "lastActiveWord": "Cannot deactivate the last active word. At least 1 active word is required.",
       "minOneActiveWord": "At least 1 active word is required."

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -65,7 +65,8 @@
         "nick": "ニックネーム",
         "password": "パスワード（デッキ専用PIN）",
         "words": "単語リスト（1行1単語）",
-        "addWords": "単語を追加（1行1単語）"
+        "addWords": "単語を追加（1行1単語）",
+        "image": "代表画像"
       },
       "scriptOption": {
         "latin": "ローマ字 (a-z)",
@@ -81,12 +82,15 @@
         "verify": "確認",
         "verifying": "確認中...",
         "deactivate": "無効化",
-        "reactivate": "再有効化"
+        "reactivate": "再有効化",
+        "uploadImage": "画像を保存",
+        "uploadingImage": "保存中..."
       },
       "hint": {
         "validWordCount": "有効な単語 {count}個",
         "wordChanged": "変更済み",
-        "editCredentials": "デッキ作成時に使用したニックネームとパスワードを入力してください。"
+        "editCredentials": "デッキ作成時に使用したニックネームとパスワードを入力してください。",
+        "image": "JPG、PNG、WebP形式。最大2MB。"
       },
       "error": {
         "minActiveWords": "有効な単語が最低1つ必要です。",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -177,9 +177,27 @@
       "commentPosted": "コメントを投稿しました。"
     }
   },
+  "comments": {
+    "title": "コメント",
+    "loading": "コメントを読み込んでいます...",
+    "todayLocked": "🔒 今日のデイリーを完了すると、今日のコメントを読んだり書いたりできます。",
+    "empty": "まだコメントがありません。最初のコメントを投稿してみましょう！"
+  },
+  "report": {
+    "trigger": "報告",
+    "description": "不適切な{target}を報告します。",
+    "reasonPlaceholder": "理由（任意）",
+    "submit": "報告する",
+    "submitting": "報告中...",
+    "target": {
+      "deck": "デッキ",
+      "comment": "コメント"
+    }
+  },
   "validation": {
     "error": {
       "invalidChars": "使用できない文字が含まれている単語があります：{lines}",
+      "duplicateWords": "重複した単語があります：{lines}",
       "minOneWord": "単語が最低1つ必要です",
       "lastActiveWord": "最後の有効な単語は無効化できません。有効な単語が最低1つ必要です。",
       "minOneActiveWord": "有効な単語が最低1つ必要です。"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -65,7 +65,8 @@
         "nick": "닉네임",
         "password": "비밀번호 (덱 전용 PIN)",
         "words": "단어 목록 (줄당 1개)",
-        "addWords": "단어 추가 (줄당 1개)"
+        "addWords": "단어 추가 (줄당 1개)",
+        "image": "대표 이미지"
       },
       "scriptOption": {
         "latin": "로마자 (a-z)",
@@ -81,12 +82,15 @@
         "verify": "확인",
         "verifying": "확인 중...",
         "deactivate": "비활성화",
-        "reactivate": "재활성화"
+        "reactivate": "재활성화",
+        "uploadImage": "이미지 저장",
+        "uploadingImage": "저장 중..."
       },
       "hint": {
         "validWordCount": "유효 단어 {count}개",
         "wordChanged": "변경됨",
-        "editCredentials": "덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요."
+        "editCredentials": "덱을 만들 때 사용한 닉네임과 비밀번호를 입력하세요.",
+        "image": "JPG, PNG, WebP 형식. 최대 2MB."
       },
       "error": {
         "minActiveWords": "활성 단어가 최소 1개 필요합니다.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -177,9 +177,27 @@
       "commentPosted": "댓글을 남겼습니다."
     }
   },
+  "comments": {
+    "title": "댓글",
+    "loading": "댓글 불러오는 중...",
+    "todayLocked": "🔒 오늘의 데일리를 완료하면 오늘 댓글을 보고 쓸 수 있습니다.",
+    "empty": "아직 댓글이 없습니다. 첫 댓글을 남겨보세요!"
+  },
+  "report": {
+    "trigger": "신고",
+    "description": "부적절한 {target}을 신고합니다.",
+    "reasonPlaceholder": "사유 (선택)",
+    "submit": "신고하기",
+    "submitting": "신고 중...",
+    "target": {
+      "deck": "덱",
+      "comment": "댓글"
+    }
+  },
   "validation": {
     "error": {
       "invalidChars": "허용되지 않는 문자가 포함된 단어가 있습니다: {lines}",
+      "duplicateWords": "중복 단어가 있습니다: {lines}",
       "minOneWord": "최소 1개 단어 필요",
       "lastActiveWord": "마지막 활성 단어는 비활성화할 수 없습니다. 활성 단어가 최소 1개 필요합니다.",
       "minOneActiveWord": "최소 1개의 활성 단어가 필요합니다."

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,22 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
-const nextConfig: NextConfig = {};
+const supabaseImageHostname = process.env.NEXT_PUBLIC_SUPABASE_URL
+  ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+  : undefined;
+
+const nextConfig: NextConfig = {
+  images: supabaseImageHostname
+    ? {
+        remotePatterns: [
+          {
+            protocol: "https",
+            hostname: supabaseImageHostname,
+            pathname: "/storage/v1/object/public/**",
+          },
+        ],
+      }
+    : undefined,
+};
 
 export default withNextIntl(nextConfig);

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,11 @@ const supabaseImageHostname = process.env.NEXT_PUBLIC_SUPABASE_URL
   : undefined;
 
 const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "3mb",
+    },
+  },
   images: supabaseImageHostname
     ? {
         remotePatterns: [

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -135,7 +135,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.

--- a/supabase/migrations/20260612000001_drop_legacy_domain.sql
+++ b/supabase/migrations/20260612000001_drop_legacy_domain.sql
@@ -12,6 +12,6 @@ DROP POLICY IF EXISTS "인증된 사용자 썸네일 업로드 가능" ON storag
 DROP POLICY IF EXISTS "인증된 사용자 썸네일 수정 가능" ON storage.objects;
 DROP POLICY IF EXISTS "인증된 사용자 썸네일 삭제 가능" ON storage.objects;
 
--- 3. deck-thumbnails 버킷 비우고 삭제
-DELETE FROM storage.objects WHERE bucket_id = 'deck-thumbnails';
-DELETE FROM storage.buckets WHERE id = 'deck-thumbnails';
+-- 3. deck-thumbnails 버킷 삭제는 Storage API로만 가능하다.
+-- Supabase hosted Postgres는 storage.objects/storage.buckets 직접 DELETE를 막으므로
+-- DB reset migration에서는 정책만 제거하고 버킷 데이터는 운영자가 대시보드에서 정리한다.

--- a/supabase/migrations/20260616000001_deck_images.sql
+++ b/supabase/migrations/20260616000001_deck_images.sql
@@ -1,0 +1,23 @@
+-- 덱 대표 이미지. 쓰기는 server action(service_role)만 수행하고, 읽기는 공개 URL로 제공한다.
+
+ALTER TABLE public.decks
+  ADD COLUMN IF NOT EXISTS image_url text;
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'deck-images',
+  'deck-images',
+  true,
+  2097152,
+  ARRAY['image/jpeg', 'image/png', 'image/webp']::text[]
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+DROP POLICY IF EXISTS "deck_images_public_read" ON storage.objects;
+CREATE POLICY "deck_images_public_read" ON storage.objects
+  FOR SELECT
+  USING (bucket_id = 'deck-images');

--- a/types/database.ts
+++ b/types/database.ts
@@ -251,6 +251,7 @@ export type Database = {
           creator_pw_hash: string
           hidden: boolean
           id: string
+          image_url: string | null
           like_count: number
           name: string
           report_count: number
@@ -264,6 +265,7 @@ export type Database = {
           creator_pw_hash: string
           hidden?: boolean
           id?: string
+          image_url?: string | null
           like_count?: number
           name: string
           report_count?: number
@@ -277,6 +279,7 @@ export type Database = {
           creator_pw_hash?: string
           hidden?: boolean
           id?: string
+          image_url?: string | null
           like_count?: number
           name?: string
           report_count?: number


### PR DESCRIPTION
## Summary

덱 대표 이미지를 다시 도입합니다. 기존 `deck-thumbnails` 기반 구 구현을 복구하지 않고, 현재 nick/password 기반 덱 모델에 맞춰 새 `deck-images` Storage 버킷과 `decks.image_url` 컬럼으로 구현했습니다.

## Changes

- Supabase migration 추가
  - `decks.image_url` 컬럼 추가
  - public read 가능한 `deck-images` Storage bucket 생성
  - Storage object SELECT policy 추가
- 덱 이미지 업로드
  - 덱 생성 시 선택 이미지 업로드
  - 덱 수정 화면에서 nick/password 검증 후 대표 이미지 교체
  - JPG/PNG/WebP, 최대 2MB 제한
  - 기존 덱 이미지 교체 시 이전 object 정리
- 덱 이미지 표시
  - 피드 카드 썸네일 표시
  - 덱 상세 메타 카드 상단 대표 이미지 표시
  - `next/image` remotePatterns를 Supabase Storage host에 맞춰 설정
- OG 이미지 생성 개선
  - `/og/{deck_id}.png`가 `image_url`을 조회
  - 대표 이미지가 있으면 배경으로 사용하고 기존 덱명/단어수/좋아요 오버레이 유지

## Related context

이미지 업로드 기능은 과거 `deck-thumbnails`/`app/actions/storage.ts` 기반으로 존재했지만, T0 reset에서 구 도메인 정리 범위로 제거되었습니다.

- #43: Foundation reset에서 `deck-thumbnails` bucket 삭제 명시
- #98: T0 reset PR에서 구 storage/action/dialog 제거
- #90/#95: 과거 thumbnail 업로드/삭제 소유권 검증 취약점 수정 기록

이번 구현은 과거 구조를 그대로 복원하지 않고, 현재 익명 세션 + 덱 전용 nick/password 소유권 모델에 맞춰 server action에서 credential 검증 후 service role로 업로드합니다.

## Verification

- [x] `TMPDIR=/tmp npm test -- lib/ip.test.ts lib/deckWords.test.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Deployment note

배포 후 Supabase migration 적용이 필요합니다. `deck-images` bucket과 `decks.image_url` 컬럼이 생성되어야 업로드가 동작합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 덱 생성/편집 시 대표 커버 이미지 업로드 및 수정 지원
  * 피드/덱 카드/OG 메타 카드에 커버 이미지 표시
* **Bug Fixes**
  * 좋아요 처리 시 사용자 IP 판별 로직을 개선해 상태 반영을 안정화
* **Documentation**
  * 덱/댓글/신고/검증 메시지 등 다국어 문구 확장 및 이미지 형식·용량 안내 추가
* **Chores**
  * 커버 이미지 저장용 설정 및 데이터 스키마(이미지 URL, Storage 버킷) 업데이트
  * 배포용 환경 변수 예시 및 서버 설정(이미지 호스트 허용, 요청 크기 제한) 반영
* **Tests**
  * 단어 파싱 및 IP 헤더 처리에 대한 테스트 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->