### PR TITLE
feat(deck): add optimistic locking to edit actions

### DIFF
--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -130,30 +130,6 @@ async function removeDeckImagePaths(paths: string[]): Promise<void> {
   await admin.storage.from(DECK_IMAGE_BUCKET).remove(paths);
 }
 
-async function claimDeckVersion(
-  deckId: string,
-  expectedVersion: number,
-): Promise<{ ok: true; nextVersion: number } | { ok: false; message: string }> {
-  const admin = createAdminClient();
-  const { data, error } = await admin
-    .from("decks")
-    .update({
-      version: expectedVersion + 1,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", deckId)
-    .eq("version", expectedVersion)
-    .select("version");
-
-  if (error) {
-    return { ok: false, message: `덱 버전 갱신에 실패했습니다: ${error.message}` };
-  }
-  if (!data || data.length === 0) {
-    return { ok: false, message: "다른 저장 요청이 먼저 반영됐습니다. 새로고침 후 다시 시도해주세요." };
-  }
-  return { ok: true, nextVersion: data[0].version };
-}
-
 export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
   return safeAction(async () => {
     const tAuth = await getTranslations("auth");
@@ -341,32 +317,24 @@ export async function updateDeckWords(input: {
     const planResult = planWordUpdate(existing as DeckWordRow[], parsed.words, deactivateIds);
     if (!planResult.ok) return { success: false, message: planResult.message };
 
-    const versionClaim = await claimDeckVersion(deckId, expectedVersion);
-    if (!versionClaim.ok) {
-      return { success: false, conflict: true, message: versionClaim.message };
-    }
-
     const { toInsert, toReactivateIds, toDeactivateIds } = planResult.plan;
 
-    if (toInsert.length > 0) {
-      const { error } = await admin
-        .from("words")
-        .insert(toInsert.map((text) => ({ deck_id: deckId, text })));
-      if (error) return { success: false, message: `단어 추가에 실패했습니다: ${error.message}` };
+    const { data: updated, error: updateError } = await admin.rpc("update_deck_words_with_version", {
+      p_deck_id: deckId,
+      p_expected_version: expectedVersion,
+      p_insert_texts: toInsert,
+      p_reactivate_ids: toReactivateIds,
+      p_deactivate_ids: toDeactivateIds,
+    });
+    if (updateError) {
+      return { success: false, message: `단어 저장에 실패했습니다: ${updateError.message}` };
     }
-    if (toReactivateIds.length > 0) {
-      const { error } = await admin
-        .from("words")
-        .update({ active: true })
-        .in("id", toReactivateIds);
-      if (error) return { success: false, message: `단어 재활성화에 실패했습니다: ${error.message}` };
-    }
-    if (toDeactivateIds.length > 0) {
-      const { error } = await admin
-        .from("words")
-        .update({ active: false })
-        .in("id", toDeactivateIds);
-      if (error) return { success: false, message: `단어 비활성화에 실패했습니다: ${error.message}` };
+    if (!updated) {
+      return {
+        success: false,
+        conflict: true,
+        message: "다른 저장 요청이 먼저 반영됐습니다. 새로고침 후 다시 시도해주세요.",
+      };
     }
 
     revalidatePath(`/d/${deckId}`);

--- a/app/actions/deck.ts
+++ b/app/actions/deck.ts
@@ -23,7 +23,7 @@ import type { Tables } from "@/types/database";
 
 // creator_pw_hash 노출 방지용 화이트리스트
 const DECK_PUBLIC_COLUMNS =
-  "id, name, script, creator_id, creator_nick, image_url, like_count, hidden, report_count, created_at, updated_at";
+  "id, name, script, creator_id, creator_nick, image_url, like_count, hidden, report_count, version, created_at, updated_at";
 
 const DECK_IMAGE_BUCKET = "deck-images";
 const MAX_DECK_IMAGE_BYTES = 2 * 1024 * 1024;
@@ -40,6 +40,8 @@ export interface DeckWithWords {
   deck: PublicDeck;
   words: DeckWord[];
 }
+
+type DeckMutationResponse<T = void> = ActionResponse<T> & { conflict?: boolean };
 
 type CredentialCheck =
   | { ok: true }
@@ -126,6 +128,30 @@ async function removeDeckImagePaths(paths: string[]): Promise<void> {
   if (paths.length === 0) return;
   const admin = createAdminClient();
   await admin.storage.from(DECK_IMAGE_BUCKET).remove(paths);
+}
+
+async function claimDeckVersion(
+  deckId: string,
+  expectedVersion: number,
+): Promise<{ ok: true; nextVersion: number } | { ok: false; message: string }> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("decks")
+    .update({
+      version: expectedVersion + 1,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", deckId)
+    .eq("version", expectedVersion)
+    .select("version");
+
+  if (error) {
+    return { ok: false, message: `덱 버전 갱신에 실패했습니다: ${error.message}` };
+  }
+  if (!data || data.length === 0) {
+    return { ok: false, message: "다른 저장 요청이 먼저 반영됐습니다. 새로고침 후 다시 시도해주세요." };
+  }
+  return { ok: true, nextVersion: data[0].version };
 }
 
 export async function createDeck(formData: FormData): Promise<ActionResponse<{ id: string }>> {
@@ -274,13 +300,14 @@ export async function updateDeckWords(input: {
   deckId: string;
   nick: string;
   password: string;
+  expectedVersion: number;
   addWordsText: string;
   deactivateIds: string[];
-}): Promise<ActionResponse> {
+}): Promise<DeckMutationResponse> {
   return safeAction(async () => {
     const tAuth = await getTranslations("auth");
     const tDeckAction = await getTranslations("deck.action");
-    const { deckId, nick, password, addWordsText, deactivateIds } = input;
+    const { deckId, nick, password, expectedVersion, addWordsText, deactivateIds } = input;
 
     const check = await verifyCredentials(deckId, nick, password, {
       deckNotFound: "덱을 찾을 수 없습니다.",
@@ -314,6 +341,11 @@ export async function updateDeckWords(input: {
     const planResult = planWordUpdate(existing as DeckWordRow[], parsed.words, deactivateIds);
     if (!planResult.ok) return { success: false, message: planResult.message };
 
+    const versionClaim = await claimDeckVersion(deckId, expectedVersion);
+    if (!versionClaim.ok) {
+      return { success: false, conflict: true, message: versionClaim.message };
+    }
+
     const { toInsert, toReactivateIds, toDeactivateIds } = planResult.plan;
 
     if (toInsert.length > 0) {
@@ -337,25 +369,21 @@ export async function updateDeckWords(input: {
       if (error) return { success: false, message: `단어 비활성화에 실패했습니다: ${error.message}` };
     }
 
-    await admin
-      .from("decks")
-      .update({ updated_at: new Date().toISOString() })
-      .eq("id", deckId);
-
     revalidatePath(`/d/${deckId}`);
     return { success: true, message: tDeckAction("updated") };
   });
 }
 
-export async function updateDeckImage(formData: FormData): Promise<ActionResponse<{ imageUrl: string }>> {
+export async function updateDeckImage(formData: FormData): Promise<DeckMutationResponse<{ imageUrl: string }>> {
   return safeAction(async () => {
     const tAuth = await getTranslations("auth");
     const deckId = String(formData.get("deckId") ?? "");
     const nick = String(formData.get("nick") ?? "").trim();
     const password = String(formData.get("password") ?? "");
+    const expectedVersion = Number(formData.get("expectedVersion"));
     const image = readOptionalImage(formData);
 
-    if (!deckId || !image) {
+    if (!deckId || !Number.isInteger(expectedVersion) || expectedVersion < 0 || !image) {
       return { success: false, message: "업로드할 이미지를 선택해주세요." };
     }
 
@@ -370,13 +398,27 @@ export async function updateDeckImage(formData: FormData): Promise<ActionRespons
     if (!upload.ok) return { success: false, message: upload.message };
 
     const admin = createAdminClient();
-    const { error } = await admin
+    const { data, error } = await admin
       .from("decks")
-      .update({ image_url: upload.imageUrl, updated_at: new Date().toISOString() })
-      .eq("id", deckId);
+      .update({
+        image_url: upload.imageUrl,
+        version: expectedVersion + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", deckId)
+      .eq("version", expectedVersion)
+      .select("id");
     if (error) {
       await removeDeckImagePaths([upload.objectPath]);
       return { success: false, message: `이미지 저장에 실패했습니다: ${error.message}` };
+    }
+    if (!data || data.length === 0) {
+      await removeDeckImagePaths([upload.objectPath]);
+      return {
+        success: false,
+        conflict: true,
+        message: "다른 저장 요청이 먼저 반영됐습니다. 새로고침 후 다시 시도해주세요.",
+      };
     }
 
     await removeDeckImagePaths(existingImagePaths.filter((path) => path !== upload.objectPath));

--- a/app/d/[id]/edit/page.tsx
+++ b/app/d/[id]/edit/page.tsx
@@ -18,7 +18,7 @@ export default async function DeckEditPage({ params }: DeckEditPageProps) {
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
       <h1 className="text-2xl font-bold">{deck.name} {t("titleSuffix")}</h1>
-      <DeckEditForm deckId={deck.id} words={words} />
+      <DeckEditForm deckId={deck.id} version={deck.version} words={words} />
     </main>
   );
 }

--- a/components/DeckEditForm.tsx
+++ b/components/DeckEditForm.tsx
@@ -15,10 +15,11 @@ import { cn } from "@/lib/utils";
 
 interface DeckEditFormProps {
   deckId: string;
+  version: number;
   words: DeckWord[];
 }
 
-export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
+export function DeckEditForm({ deckId, version, words }: DeckEditFormProps) {
   const router = useRouter();
   const t = useTranslations("deck.form");
   const [nick, setNick] = useState("");
@@ -78,6 +79,7 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
           deckId,
           nick: nick.trim(),
           password,
+          expectedVersion: version,
           addWordsText: [addWordsText, ...reactivateTexts].join("\n"),
           deactivateIds,
         }),
@@ -85,6 +87,8 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
       if (result.success) {
         setToggledIds(new Set());
         setAddWordsText("");
+        router.refresh();
+      } else if (result.conflict) {
         router.refresh();
       }
     } finally {
@@ -100,10 +104,14 @@ export function DeckEditForm({ deckId, words }: DeckEditFormProps) {
       formData.set("deckId", deckId);
       formData.set("nick", nick.trim());
       formData.set("password", password);
+      formData.set("expectedVersion", String(version));
       formData.set("image", imageFile);
 
       const result = await actionWithToast(() => updateDeckImage(formData));
       if (result.success) {
+        setImageFile(null);
+        router.refresh();
+      } else if (result.conflict) {
         setImageFile(null);
         router.refresh();
       }

--- a/lib/action-with-toast.ts
+++ b/lib/action-with-toast.ts
@@ -31,8 +31,8 @@ import { ActionResponse } from "@/types/action";
  * );
  * ```
  */
-export async function actionWithToast<T>(
-  actionFn: () => Promise<ActionResponse<T>>,
+export async function actionWithToast<TResponse extends ActionResponse<unknown>>(
+  actionFn: () => Promise<TResponse>,
   options?: {
     /** toast를 표시할지 여부 (기본값: true) */
     showToast?: boolean;
@@ -41,7 +41,7 @@ export async function actionWithToast<T>(
     /** 실패 시에만 toast를 표시할지 여부 (기본값: false) */
     showOnlyError?: boolean;
   }
-): Promise<ActionResponse<T>> {
+): Promise<TResponse> {
   const {
     showToast = true,
     showOnlySuccess = false,
@@ -85,6 +85,6 @@ export async function actionWithToast<T>(
     return {
       success: false,
       message: errorMessage,
-    };
+    } as TResponse;
   }
 }

--- a/supabase/migrations/20260616000002_deck_version.sql
+++ b/supabase/migrations/20260616000002_deck_version.sql
@@ -1,0 +1,4 @@
+-- 덱 편집 액션 낙관적 락. 클라이언트는 읽은 version을 expectedVersion으로 동봉한다.
+
+ALTER TABLE public.decks
+  ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 0 CHECK (version >= 0);

--- a/supabase/migrations/20260616000002_deck_version.sql
+++ b/supabase/migrations/20260616000002_deck_version.sql
@@ -2,3 +2,48 @@
 
 ALTER TABLE public.decks
   ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 0 CHECK (version >= 0);
+
+CREATE OR REPLACE FUNCTION public.update_deck_words_with_version(
+  p_deck_id uuid,
+  p_expected_version integer,
+  p_insert_texts text[],
+  p_reactivate_ids uuid[],
+  p_deactivate_ids uuid[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_updated integer;
+BEGIN
+  UPDATE public.decks
+  SET version = version + 1,
+      updated_at = now()
+  WHERE id = p_deck_id
+    AND version = p_expected_version;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated = 0 THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO public.words (deck_id, text)
+  SELECT p_deck_id, inserted_text.text_value
+  FROM unnest(coalesce(p_insert_texts, ARRAY[]::text[])) AS inserted_text(text_value);
+
+  UPDATE public.words
+  SET active = true
+  WHERE deck_id = p_deck_id
+    AND id = ANY(coalesce(p_reactivate_ids, ARRAY[]::uuid[]));
+
+  UPDATE public.words
+  SET active = false
+  WHERE deck_id = p_deck_id
+    AND id = ANY(coalesce(p_deactivate_ids, ARRAY[]::uuid[]));
+
+  RETURN true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_deck_words_with_version(uuid, integer, text[], uuid[], uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_deck_words_with_version(uuid, integer, text[], uuid[], uuid[]) TO service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -328,7 +328,16 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      update_deck_words_with_version: {
+        Args: {
+          p_deck_id: string
+          p_deactivate_ids: string[]
+          p_expected_version: number
+          p_insert_texts: string[]
+          p_reactivate_ids: string[]
+        }
+        Returns: boolean
+      }
     }
     Enums: {
       [_ in never]: never

--- a/types/database.ts
+++ b/types/database.ts
@@ -257,6 +257,7 @@ export type Database = {
           report_count: number
           script: string
           updated_at: string
+          version: number
         }
         Insert: {
           created_at?: string
@@ -271,6 +272,7 @@ export type Database = {
           report_count?: number
           script?: string
           updated_at?: string
+          version?: number
         }
         Update: {
           created_at?: string
@@ -285,6 +287,7 @@ export type Database = {
           report_count?: number
           script?: string
           updated_at?: string
+          version?: number
         }
         Relationships: []
       }


### PR DESCRIPTION
## Summary

덱 편집 액션에 `version` 기반 optimistic locking을 추가합니다.

PR #149에서 이미지 교체 실패 경로는 안전하게 만들었지만, 동시 편집 요청이 겹치면 stale 요청이 나중에 반영될 수 있었습니다. 이 PR은 덱 단어 수정과 대표 이미지 교체가 같은 `decks.version` 경계를 공유하게 만듭니다.

## Changes

- `decks.version integer not null default 0` migration 추가
- 공개 덱 조회에 `version` 포함
- 덱 수정 화면이 현재 `version`을 server action에 `expectedVersion`으로 전달
- `updateDeckWords`
  - 자격증명/입력/단어 계획 검증 후 `version = expectedVersion` 조건으로 version 선점
  - 선점 실패 시 `conflict: true` 반환, 클라이언트 refresh
- `updateDeckImage`
  - 새 이미지 업로드 후 `version = expectedVersion` 조건으로 `image_url` 업데이트
  - conflict 또는 DB 실패 시 새 object 보상 삭제
  - 성공 후 기존 object 삭제
- `actionWithToast`가 `conflict` 같은 확장 응답 필드를 보존하도록 제네릭 개선

## Other Resource Review

- 좋아요: `likes(deck_id, ip_hash)` unique + insert/delete + trigger count 성격이라 version lock보다는 idempotency/unique constraint가 맞습니다.
- 신고: 누적 insert/report count 성격이라 optimistic lock 대상보다는 duplicate/rate-limit/threshold 정책 대상입니다.
- 댓글: 각 댓글 row 단위 생성/삭제 흐름이며, 덱 편집 version과 직접 묶을 필요는 낮습니다.
- daily/challenge rounds: 이미 `expectedVersion` + DB `version` guard가 있습니다.

## Verification

- [x] `TMPDIR=/tmp npm test -- lib/deckWords.test.ts lib/ip.test.ts lib/game-lock.test.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Follow-up

Closes #150 for the deck image replacement race/conflict handling path. Orphan cleanup script can still be considered later as an operational maintenance tool, but it is no longer required for correctness of image replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 덱 편집 중 여러 저장 요청이 발생할 때 충돌을 감지하고 방지합니다. 충돌이 감지되면 화면을 자동으로 갱신하여 최신 데이터를 유지하고 데이터 손실을 방지합니다. 이 보호 기능은 덱 단어 수정 및 이미지 업로드 시에도 동일하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->