### PR TITLE
feat(deck): preview selected cover images

### DIFF
--- a/components/DeckEditForm.tsx
+++ b/components/DeckEditForm.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ImagePlus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,6 +13,7 @@ import { actionWithToast } from "@/lib/action-with-toast";
 import { verifyDeckCredentials, updateDeckImage, updateDeckWords, type DeckWord } from "@/app/actions/deck";
 import { loadCachedCredentials, saveCachedCredentials } from "@/lib/credentialCache";
 import { cn } from "@/lib/utils";
+import { ImageFilePreview } from "@/components/ImageFilePreview";
 
 interface DeckEditFormProps {
   deckId: string;
@@ -196,13 +198,22 @@ export function DeckEditForm({ deckId, version, words }: DeckEditFormProps) {
 
       <section className="space-y-2">
         <Label htmlFor="edit-image">{t("label.image")}</Label>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Input
+            key={imageFile ? "selected" : "empty"}
             id="edit-image"
             type="file"
             accept="image/jpeg,image/png,image/webp"
+            className="sr-only"
             onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
           />
+          <Label
+            htmlFor="edit-image"
+            className={cn(buttonVariants({ variant: "outline" }), "w-fit cursor-pointer")}
+          >
+            <ImagePlus className="size-4" />
+            {t("button.selectImage")}
+          </Label>
           <Button
             type="button"
             variant="outline"
@@ -212,6 +223,7 @@ export function DeckEditForm({ deckId, version, words }: DeckEditFormProps) {
             {uploadingImage ? t("button.uploadingImage") : t("button.uploadImage")}
           </Button>
         </div>
+        <ImageFilePreview file={imageFile} label={t("label.image")} />
         <p className="text-sm text-muted-foreground">{t("hint.image")}</p>
       </section>
 

--- a/components/DeckForm.tsx
+++ b/components/DeckForm.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { ImagePlus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -20,11 +21,13 @@ import { parseWordLines } from "@/lib/deckWords";
 import { SUPPORTED_SCRIPTS } from "@/lib/scripts";
 import type { ScriptId } from "@/lib/scripts/types";
 import { DeckSimulator } from "@/components/DeckSimulator";
+import { ImageFilePreview } from "@/components/ImageFilePreview";
 import {
   loadCachedCredentials,
   saveCachedCredentials,
   appendMyDeck,
 } from "@/lib/credentialCache";
+import { cn } from "@/lib/utils";
 
 export function DeckForm() {
   const router = useRouter();
@@ -158,12 +161,24 @@ export function DeckForm() {
 
       <div className="space-y-2">
         <Label htmlFor="deck-image">{t("label.image")}</Label>
-        <Input
-          id="deck-image"
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
-        />
+        <div className="space-y-3">
+          <Input
+            key={imageFile ? "selected" : "empty"}
+            id="deck-image"
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="sr-only"
+            onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+          />
+          <Label
+            htmlFor="deck-image"
+            className={cn(buttonVariants({ variant: "outline" }), "w-fit cursor-pointer")}
+          >
+            <ImagePlus className="size-4" />
+            {t("button.selectImage")}
+          </Label>
+          <ImageFilePreview file={imageFile} label={t("label.image")} />
+        </div>
         <p className="text-sm text-muted-foreground">{t("hint.image")}</p>
       </div>
 

--- a/components/ImageFilePreview.tsx
+++ b/components/ImageFilePreview.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ImageFilePreviewProps {
+  file: File | null;
+  label: string;
+}
+
+export function ImageFilePreview({ file, label }: ImageFilePreviewProps) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  if (!previewUrl) return null;
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className="aspect-video w-full max-w-sm rounded-md border bg-muted bg-cover bg-center"
+      style={{ backgroundImage: `url(${previewUrl})` }}
+    />
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -83,6 +83,7 @@
         "verifying": "Verifying...",
         "deactivate": "Deactivate",
         "reactivate": "Reactivate",
+        "selectImage": "Select image",
         "uploadImage": "Save image",
         "uploadingImage": "Saving..."
       },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -83,6 +83,7 @@
         "verifying": "確認中...",
         "deactivate": "無効化",
         "reactivate": "再有効化",
+        "selectImage": "画像を選択",
         "uploadImage": "画像を保存",
         "uploadingImage": "保存中..."
       },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -83,6 +83,7 @@
         "verifying": "확인 중...",
         "deactivate": "비활성화",
         "reactivate": "재활성화",
+        "selectImage": "이미지 선택",
         "uploadImage": "이미지 저장",
         "uploadingImage": "저장 중..."
       },


### PR DESCRIPTION
## Summary

덱 생성/편집 폼에서 native file input 파일명 대신 선택 이미지 미리보기를 보여줍니다.

## Changes

- 선택 이미지 preview 컴포넌트 추가
- file input은 접근성용으로 유지하고 label 버튼으로 열도록 변경
- 선택 파일 변경/unmount 시 object URL 정리
- 이미지 선택 버튼 다국어 문구 추가

## Verification

- [x] 기존 브랜치에서 `npm run lint`
- [x] 기존 브랜치에서 `npm run build`