### PR TITLE
fix(game): improve deck play navigation and display

### DIFF
--- a/app/d/[id]/edit/page.tsx
+++ b/app/d/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getDeckById } from "@/app/actions/deck";
 import { DeckEditForm } from "@/components/DeckEditForm";
+import { PageTopBar } from "@/components/PageTopBar";
 
 interface DeckEditPageProps {
   params: Promise<{ id: string }>;
@@ -17,6 +18,7 @@ export default async function DeckEditPage({ params }: DeckEditPageProps) {
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <PageTopBar backHref={`/d/${deck.id}`} backLabel={t("backToDeck")} />
       <h1 className="text-2xl font-bold">{deck.name} {t("titleSuffix")}</h1>
       <DeckEditForm deckId={deck.id} version={deck.version} words={words} />
     </main>

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { ArrowLeft } from "lucide-react";
 import { serializeJsonLd } from "@/lib/security-headers";
 import { getDeckById } from "@/app/actions/deck";
 import { DeckMetaCard } from "@/components/DeckMetaCard";
@@ -69,6 +70,12 @@ export default async function DeckPage({ params }: DeckPageProps) {
   if (deck.hidden) {
     return (
       <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/">
+            <ArrowLeft className="size-4" />
+            {t("backToList")}
+          </Link>
+        </Button>
         <HiddenDeckBanner deckId={deck.id} />
         <DeckMetaCard deck={deck} activeWordCount={activeWordCount} />
       </main>
@@ -94,6 +101,12 @@ export default async function DeckPage({ params }: DeckPageProps) {
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <Button asChild variant="ghost" size="sm">
+        <Link href="/">
+          <ArrowLeft className="size-4" />
+          {t("backToList")}
+        </Link>
+      </Button>
       {/* JSON-LD: serializeJsonLd로 `<` 이스케이프 → </script> 브레이크아웃 차단 (sanitized) */}
       {/* eslint-disable-next-line react/no-danger -- sanitized via serializeJsonLd */}
       <script type="application/ld+json" nonce={nonce} dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }} />

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import { ArrowLeft } from "lucide-react";
 import { serializeJsonLd } from "@/lib/security-headers";
 import { getDeckById } from "@/app/actions/deck";
 import { DeckMetaCard } from "@/components/DeckMetaCard";
@@ -12,6 +11,7 @@ import { LikeButton } from "@/components/LikeButton";
 import { ReportButton } from "@/components/ReportButton";
 import { HiddenDeckBanner } from "@/components/HiddenDeckBanner";
 import { Button } from "@/components/ui/button";
+import { PageTopBar } from "@/components/PageTopBar";
 
 interface DeckPageProps {
   params: Promise<{ id: string }>;
@@ -70,12 +70,7 @@ export default async function DeckPage({ params }: DeckPageProps) {
   if (deck.hidden) {
     return (
       <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
-        <Button asChild variant="ghost" size="sm">
-          <Link href="/">
-            <ArrowLeft className="size-4" />
-            {t("backToList")}
-          </Link>
-        </Button>
+        <PageTopBar backHref="/" backLabel={t("backToList")} />
         <HiddenDeckBanner deckId={deck.id} />
         <DeckMetaCard deck={deck} activeWordCount={activeWordCount} />
       </main>
@@ -101,12 +96,7 @@ export default async function DeckPage({ params }: DeckPageProps) {
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
-      <Button asChild variant="ghost" size="sm">
-        <Link href="/">
-          <ArrowLeft className="size-4" />
-          {t("backToList")}
-        </Link>
-      </Button>
+      <PageTopBar backHref="/" backLabel={t("backToList")} />
       {/* JSON-LD: serializeJsonLd로 `<` 이스케이프 → </script> 브레이크아웃 차단 (sanitized) */}
       {/* eslint-disable-next-line react/no-danger -- sanitized via serializeJsonLd */}
       <script type="application/ld+json" nonce={nonce} dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }} />

--- a/app/d/[id]/play/page.tsx
+++ b/app/d/[id]/play/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { ArrowLeft } from "lucide-react";
 import { createClient } from "@/lib/supabase-server";
 import { isSupportedScript } from "@/lib/scripts";
 import { DailyGame } from "@/components/DailyGame";
 import { ChallengeGame } from "@/components/ChallengeGame";
+import { Button } from "@/components/ui/button";
 
 interface PlayPageProps {
   params: Promise<{ id: string }>;
@@ -36,14 +39,26 @@ export default async function PlayPage({ params, searchParams }: PlayPageProps) 
   // 가려진 덱은 플레이 차단 — server action도 동일하게 거부한다 (#55)
   if (deck.hidden) {
     return (
-      <main className="mx-auto max-w-xl px-4 py-8 text-center text-sm text-muted-foreground">
-        {t("hiddenDeck")}
+      <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/d/${deck.id}`}>
+            <ArrowLeft className="size-4" />
+            {t("backToDeck")}
+          </Link>
+        </Button>
+        <p className="text-center text-sm text-muted-foreground">{t("hiddenDeck")}</p>
       </main>
     );
   }
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
+      <Button asChild variant="ghost" size="sm">
+        <Link href={`/d/${deck.id}`}>
+          <ArrowLeft className="size-4" />
+          {t("backToDeck")}
+        </Link>
+      </Button>
       <h1 className="text-center text-2xl font-bold">
         {deck.name}
         {mode === "challenge" && <span className="ml-2 text-base font-normal">{t("challengeModeLabel")}</span>}

--- a/app/d/[id]/play/page.tsx
+++ b/app/d/[id]/play/page.tsx
@@ -1,13 +1,11 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import { ArrowLeft } from "lucide-react";
 import { createClient } from "@/lib/supabase-server";
 import { isSupportedScript } from "@/lib/scripts";
 import { DailyGame } from "@/components/DailyGame";
 import { ChallengeGame } from "@/components/ChallengeGame";
-import { Button } from "@/components/ui/button";
+import { PageTopBar } from "@/components/PageTopBar";
 
 interface PlayPageProps {
   params: Promise<{ id: string }>;
@@ -40,12 +38,7 @@ export default async function PlayPage({ params, searchParams }: PlayPageProps) 
   if (deck.hidden) {
     return (
       <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
-        <Button asChild variant="ghost" size="sm">
-          <Link href={`/d/${deck.id}`}>
-            <ArrowLeft className="size-4" />
-            {t("backToDeck")}
-          </Link>
-        </Button>
+        <PageTopBar backHref={`/d/${deck.id}`} backLabel={t("backToDeck")} />
         <p className="text-center text-sm text-muted-foreground">{t("hiddenDeck")}</p>
       </main>
     );
@@ -53,12 +46,7 @@ export default async function PlayPage({ params, searchParams }: PlayPageProps) 
 
   return (
     <main className="mx-auto max-w-xl space-y-6 px-4 py-8">
-      <Button asChild variant="ghost" size="sm">
-        <Link href={`/d/${deck.id}`}>
-          <ArrowLeft className="size-4" />
-          {t("backToDeck")}
-        </Link>
-      </Button>
+      <PageTopBar backHref={`/d/${deck.id}`} backLabel={t("backToDeck")} />
       <h1 className="text-center text-2xl font-bold">
         {deck.name}
         {mode === "challenge" && <span className="ml-2 text-base font-normal">{t("challengeModeLabel")}</span>}

--- a/components/AttemptHistory.tsx
+++ b/components/AttemptHistory.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { DailyAttemptView } from "@/app/actions/daily";
+import { formatGameUnit } from "@/lib/game-display";
+import type { ScriptId } from "@/lib/scripts/types";
 import type { LetterState } from "@/lib/wordleGame";
 import { cn } from "@/lib/utils";
 
@@ -13,9 +15,10 @@ export const TILE_STYLES: Record<LetterState, string> = {
 
 interface AttemptHistoryProps {
   attempts: DailyAttemptView[];
+  script: ScriptId;
 }
 
-export function AttemptHistory({ attempts }: AttemptHistoryProps) {
+export function AttemptHistory({ attempts, script }: AttemptHistoryProps) {
   return (
     <>
       {attempts.map((attempt, i) => (
@@ -28,7 +31,7 @@ export function AttemptHistory({ attempts }: AttemptHistoryProps) {
                 TILE_STYLES[attempt.states[j] ?? "empty"],
               )}
             >
-              {unit}
+              {formatGameUnit(unit, script)}
             </span>
           ))}
         </div>

--- a/components/ChallengeGame.tsx
+++ b/components/ChallengeGame.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -133,7 +134,7 @@ export function ChallengeGame({ deckId, deckName, script }: ChallengeGameProps) 
   if (!view) return <p className="text-center text-sm text-muted-foreground">{tGame("loading")}</p>;
 
   if (view.endedReason === "completed") {
-    return <PerfectClearScreen deckName={deckName} date={view.date} totalRounds={view.totalRounds} />;
+    return <PerfectClearScreen deckId={deckId} deckName={deckName} date={view.date} totalRounds={view.totalRounds} />;
   }
 
   return (
@@ -166,9 +167,14 @@ export function ChallengeGame({ deckId, deckName, script }: ChallengeGameProps) 
               {t("blockedWordLabel")} <span className="font-semibold text-foreground">{view.answer}</span>
             </p>
           )}
-          <Button type="button" onClick={handleCopyFailed}>
-            {t("copyButton")}
-          </Button>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Button type="button" onClick={handleCopyFailed}>
+              {t("copyButton")}
+            </Button>
+            <Button asChild variant="outline">
+              <Link href={`/d/${deckId}#comments`}>{t("viewComments")}</Link>
+            </Button>
+          </div>
           <p className="text-xs text-muted-foreground">{t("nextRetry")}</p>
         </div>
       ) : (

--- a/components/ChallengeGame.tsx
+++ b/components/ChallengeGame.tsx
@@ -153,6 +153,7 @@ export function ChallengeGame({ deckId, deckName, script }: ChallengeGameProps) 
         targetLength={view.targetLength}
         maxAttempts={view.maxAttempts}
         finished={ended}
+        script={script}
       />
 
       {view.endedReason === "failed" ? (

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -46,7 +46,7 @@ export function CommentThread({ deckId }: CommentThreadProps) {
   if (!view) return <p className="text-sm text-muted-foreground">{t("loading")}</p>;
 
   return (
-    <section className="space-y-6">
+    <section id="comments" className="scroll-mt-6 space-y-6">
       <h2 className="text-lg font-bold">{t("title")}</h2>
 
       {view.todayLocked ? (

--- a/components/DailyGame.tsx
+++ b/components/DailyGame.tsx
@@ -130,6 +130,7 @@ export function DailyGame({ deckId, deckName, script }: DailyGameProps) {
         targetLength={view.targetLength}
         maxAttempts={view.maxAttempts}
         finished={finished}
+        script={script}
       />
 
       {finished ? (

--- a/components/DeckSimulator.tsx
+++ b/components/DeckSimulator.tsx
@@ -42,8 +42,7 @@ export function DeckSimulator({ words, script }: DeckSimulatorProps) {
     setLengthError(null);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = () => {
     const normalized = normalizeWord(guess.trim());
     const guessLength = adapter.splitUnits(normalized).length;
     if (guessLength !== targetLength) {
@@ -80,17 +79,22 @@ export function DeckSimulator({ words, script }: DeckSimulatorProps) {
       </div>
 
       {game.gameStatus === "playing" ? (
-        <form onSubmit={handleSubmit} className="flex gap-2">
+        <div className="flex gap-2">
           <Input
             value={guess}
             onChange={(e) => setGuess(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter") return;
+              e.preventDefault();
+              handleSubmit();
+            }}
             placeholder="추측 단어 입력"
             aria-label="추측 단어"
           />
-          <Button type="submit" variant="secondary">
+          <Button type="button" variant="secondary" onClick={handleSubmit}>
             제출
           </Button>
-        </form>
+        </div>
       ) : (
         <p className="text-sm font-medium">
           {game.gameStatus === "won" ? "정답!" : `실패 — 정답은 "${game.targetWord}"`}

--- a/components/GameBoard.tsx
+++ b/components/GameBoard.tsx
@@ -2,6 +2,8 @@
 
 import type { DailyAttemptView } from "@/app/actions/daily";
 import { AttemptHistory } from "@/components/AttemptHistory";
+import { formatGameUnit } from "@/lib/game-display";
+import type { ScriptId } from "@/lib/scripts/types";
 import { cn } from "@/lib/utils";
 
 interface GameBoardProps {
@@ -10,6 +12,7 @@ interface GameBoardProps {
   targetLength: number;
   maxAttempts: number;
   finished: boolean;
+  script: ScriptId;
 }
 
 // 가변 격자: 열 수 = 단어 글자(unit) 수, 행 수 = maxAttempts
@@ -19,6 +22,7 @@ export function GameBoard({
   targetLength,
   maxAttempts,
   finished,
+  script,
 }: GameBoardProps) {
   const emptyRows = Math.max(
     0,
@@ -27,7 +31,7 @@ export function GameBoard({
 
   return (
     <div className="space-y-1">
-      <AttemptHistory attempts={attempts} />
+      <AttemptHistory attempts={attempts} script={script} />
 
       {!finished && (
         <div className="flex justify-center gap-1">
@@ -39,7 +43,7 @@ export function GameBoard({
                 currentUnits[i] ? "border-foreground" : "border-muted",
               )}
             >
-              {currentUnits[i] ?? ""}
+              {currentUnits[i] ? formatGameUnit(currentUnits[i], script) : ""}
             </span>
           ))}
         </div>

--- a/components/PageTopBar.tsx
+++ b/components/PageTopBar.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface PageTopBarProps {
+  backHref: string;
+  backLabel: string;
+}
+
+export function PageTopBar({ backHref, backLabel }: PageTopBarProps) {
+  return (
+    <div className="flex min-h-9 items-center">
+      <Button asChild variant="ghost" size="sm">
+        <Link href={backHref}>
+          <ArrowLeft className="size-4" />
+          {backLabel}
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/components/PerfectClearScreen.tsx
+++ b/components/PerfectClearScreen.tsx
@@ -1,16 +1,18 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 
 interface PerfectClearScreenProps {
+  deckId: string;
   deckName: string;
   date: string;
   totalRounds: number;
 }
 
-export function PerfectClearScreen({ deckName, date, totalRounds }: PerfectClearScreenProps) {
+export function PerfectClearScreen({ deckId, deckName, date, totalRounds }: PerfectClearScreenProps) {
   const t = useTranslations("game.perfectClear");
 
   const handleCopy = async () => {
@@ -31,9 +33,14 @@ export function PerfectClearScreen({ deckName, date, totalRounds }: PerfectClear
       <p className="text-sm text-muted-foreground">
         {t("description", { count: totalRounds })}
       </p>
-      <Button type="button" onClick={handleCopy}>
-        {t("copyButton")}
-      </Button>
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button type="button" onClick={handleCopy}>
+          {t("copyButton")}
+        </Button>
+        <Button asChild variant="outline">
+          <Link href={`/d/${deckId}#comments`}>{t("viewComments")}</Link>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/components/ResultScreen.tsx
+++ b/components/ResultScreen.tsx
@@ -55,13 +55,18 @@ export function ResultScreen({ deckName, view, deckId }: ResultScreenProps) {
           ? t("attemptsCount", { current: view.attempts.length, max: view.maxAttempts })
           : t("attemptsExhausted", { max: view.maxAttempts })}
       </p>
-      <div className="flex justify-center gap-2">
+      <div className="flex flex-wrap justify-center gap-2">
         <Button type="button" onClick={handleCopy}>
           {t("copyButton")}
         </Button>
         {deckId && (
           <Button asChild variant="outline">
             <Link href={`/d/${deckId}/play?mode=challenge`}>{t("challengeCta")}</Link>
+          </Button>
+        )}
+        {deckId && (
+          <Button asChild variant="outline">
+            <Link href={`/d/${deckId}#comments`}>{t("viewComments")}</Link>
           </Button>
         )}
       </div>

--- a/e2e/deck-form.spec.ts
+++ b/e2e/deck-form.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "./fixtures";
+
+test.describe("deck form", () => {
+  test("simulator submit does not submit the surrounding deck form", async ({ page }) => {
+    await page.goto("/d/new");
+    await page.getByLabel("덱 이름").fill("preview-only");
+    await page.getByLabel("닉네임").fill("preview");
+    await page.getByLabel("비밀번호 (덱 전용 PIN)").fill("previewpw");
+    await page.getByLabel("단어 목록 (줄당 1개)").fill("abcde");
+
+    await page.getByRole("button", { name: "시뮬레이션" }).click();
+    await page.getByLabel("추측 단어").fill("abcde");
+    await page.getByLabel("추측 단어").press("Enter");
+
+    await expect(page).toHaveURL(/\/d\/new$/);
+    await expect(page.getByText("정답!")).toBeVisible();
+  });
+});

--- a/lib/game-display.test.ts
+++ b/lib/game-display.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatGameUnit } from "./game-display";
+
+describe("formatGameUnit", () => {
+  it("latin unit은 대문자로 표시한다", () => {
+    expect(formatGameUnit("a", "latin")).toBe("A");
+  });
+
+  it("latin이 아닌 script는 원문 그대로 표시한다", () => {
+    expect(formatGameUnit("ㅏ", "hangul")).toBe("ㅏ");
+    expect(formatGameUnit("あ", "kana")).toBe("あ");
+  });
+});

--- a/lib/game-display.ts
+++ b/lib/game-display.ts
@@ -1,0 +1,6 @@
+import type { ScriptId } from "@/lib/scripts/types";
+
+export function formatGameUnit(unit: string, script: ScriptId): string {
+  if (script === "latin") return unit.toUpperCase();
+  return unit;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,7 @@
       "titleSuffix": "Edit"
     },
     "detail": {
+      "backToList": "Deck list",
       "playDaily": "Play Today's Daily",
       "editButton": "Edit",
       "scriptLabel": {
@@ -118,6 +119,7 @@
     "loading": "Loading...",
     "play": {
       "hiddenDeck": "This deck is hidden and cannot be played.",
+      "backToDeck": "Deck detail",
       "challengeModeLabel": "🔥 Challenge"
     },
     "board": {
@@ -133,6 +135,7 @@
       "copySuccess": "Result copied.",
       "copyFailure": "Failed to copy to clipboard.",
       "challengeCta": "🔥 Try Challenge",
+      "viewComments": "View comments",
       "nextWordUnlock": "A new word unlocks tomorrow.",
       "shareText": "{deckName} Daily {date}"
     },
@@ -150,6 +153,7 @@
       "copyFailure": "Failed to copy to clipboard.",
       "nextRetry": "Come back tomorrow to try again.",
       "giveUp": "Give up",
+      "viewComments": "View comments",
       "shareText": "{deckName} Challenge {date} {score}/{total} 🔥"
     },
     "perfectClear": {
@@ -158,6 +162,7 @@
       "copyButton": "Copy result",
       "copySuccess": "Result copied.",
       "copyFailure": "Failed to copy to clipboard.",
+      "viewComments": "View comments",
       "shareText": "🎉 PERFECT CLEAR — {deckName} Challenge {date} {total}/{total}"
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -37,7 +37,8 @@
       "pageTitle": "Create New Deck | wordledecks"
     },
     "edit": {
-      "titleSuffix": "Edit"
+      "titleSuffix": "Edit",
+      "backToDeck": "Deck detail"
     },
     "detail": {
       "backToList": "Deck list",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -37,7 +37,8 @@
       "pageTitle": "新しいデッキを作成 | wordledecks"
     },
     "edit": {
-      "titleSuffix": "編集"
+      "titleSuffix": "編集",
+      "backToDeck": "デッキ詳細"
     },
     "detail": {
       "backToList": "デッキ一覧",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -40,6 +40,7 @@
       "titleSuffix": "編集"
     },
     "detail": {
+      "backToList": "デッキ一覧",
       "playDaily": "今日のデイリーをプレイ",
       "editButton": "編集",
       "scriptLabel": {
@@ -118,6 +119,7 @@
     "loading": "読み込み中...",
     "play": {
       "hiddenDeck": "非公開のデッキはプレイできません。",
+      "backToDeck": "デッキ詳細",
       "challengeModeLabel": "🔥 チャレンジ"
     },
     "board": {
@@ -133,6 +135,7 @@
       "copySuccess": "結果をコピーしました。",
       "copyFailure": "クリップボードへのコピーに失敗しました。",
       "challengeCta": "🔥 チャレンジに挑戦",
+      "viewComments": "コメントを見る",
       "nextWordUnlock": "明日、新しい単語が解放されます。",
       "shareText": "{deckName} デイリー {date}"
     },
@@ -150,6 +153,7 @@
       "copyFailure": "クリップボードへのコピーに失敗しました。",
       "nextRetry": "明日また挑戦できます。",
       "giveUp": "あきらめる",
+      "viewComments": "コメントを見る",
       "shareText": "{deckName} チャレンジ {date} {score}/{total} 🔥"
     },
     "perfectClear": {
@@ -158,6 +162,7 @@
       "copyButton": "結果をコピー",
       "copySuccess": "結果をコピーしました。",
       "copyFailure": "クリップボードへのコピーに失敗しました。",
+      "viewComments": "コメントを見る",
       "shareText": "🎉 PERFECT CLEAR — {deckName} チャレンジ {date} {total}/{total}"
     }
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -40,6 +40,7 @@
       "titleSuffix": "편집"
     },
     "detail": {
+      "backToList": "덱 목록",
       "playDaily": "오늘의 데일리 플레이",
       "editButton": "편집",
       "scriptLabel": {
@@ -118,6 +119,7 @@
     "loading": "불러오는 중...",
     "play": {
       "hiddenDeck": "비공개 덱은 플레이할 수 없습니다.",
+      "backToDeck": "덱 상세",
       "challengeModeLabel": "🔥 챌린지"
     },
     "board": {
@@ -133,6 +135,7 @@
       "copySuccess": "결과를 복사했습니다.",
       "copyFailure": "클립보드 복사에 실패했습니다.",
       "challengeCta": "🔥 챌린지 도전",
+      "viewComments": "댓글 보러가기",
       "nextWordUnlock": "내일 새로운 단어가 잠금 해제됩니다.",
       "shareText": "{deckName} 데일리 {date}"
     },
@@ -150,6 +153,7 @@
       "copyFailure": "클립보드 복사에 실패했습니다.",
       "nextRetry": "내일 다시 도전할 수 있습니다.",
       "giveUp": "포기하기",
+      "viewComments": "댓글 보러가기",
       "shareText": "{deckName} 챌린지 {date} {score}/{total} 🔥"
     },
     "perfectClear": {
@@ -158,6 +162,7 @@
       "copyButton": "결과 복사",
       "copySuccess": "결과를 복사했습니다.",
       "copyFailure": "클립보드 복사에 실패했습니다.",
+      "viewComments": "댓글 보러가기",
       "shareText": "🎉 PERFECT CLEAR — {deckName} 챌린지 {date} {total}/{total}"
     }
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -37,7 +37,8 @@
       "pageTitle": "새 덱 만들기 | wordledecks"
     },
     "edit": {
-      "titleSuffix": "편집"
+      "titleSuffix": "편집",
+      "backToDeck": "덱 상세"
     },
     "detail": {
       "backToList": "덱 목록",


### PR DESCRIPTION
## Summary

덱 작성/플레이 흐름의 작은 UX 버그와 이동 버튼을 정리합니다.

## Changes

- 덱 작성 시뮬레이터 제출이 폼 submit으로 전파되어 새로고침되는 문제 수정
- 라틴 게임 보드 표시를 대문자로 통일
- 덱 상세/게임 화면에 목록/덱 상세로 돌아가는 상단 이동 버튼 추가
- 실패/클리어 결과에서 댓글 보기 버튼 추가
- 공통 `PageTopBar` 컴포넌트로 상단 바 정리

## Verification

- [x] 기존 브랜치에서 `npm run lint`
- [x] 기존 브랜치에서 `npm run build`