### PR TITLE
feat(likes): batch liked state for feed

### DIFF
--- a/app/actions/feed.ts
+++ b/app/actions/feed.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { createClient } from "@/lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase-admin";
 import { safeAction } from "@/lib/safe-action";
 import { ActionResponse } from "@/types/action";
 import { sortByHotScore } from "@/lib/hot-score";
 import { escapeLikePattern, normalizeSearchQuery } from "@/lib/search";
+import { getAnonUserId } from "@/lib/anon-session";
 
 // 피드/검색 조회 (#76). decks SELECT는 공개 RLS라 anon 클라이언트로 충분 —
 // creator_pw_hash는 화이트리스트로 제외한다.
@@ -26,6 +28,7 @@ export interface FeedDeck {
   creator_nick: string;
   image_url: string | null;
   like_count: number;
+  likedByMe: boolean;
   created_at: string;
 }
 
@@ -33,6 +36,29 @@ export interface FeedPage {
   decks: FeedDeck[];
   /** 다음 페이지 cursor — null이면 끝 */
   nextOffset: number | null;
+}
+
+type PublicFeedDeck = Omit<FeedDeck, "likedByMe">;
+
+async function likedDeckIdsForAnon(deckIds: string[]): Promise<Set<string>> {
+  if (deckIds.length === 0) return new Set();
+
+  const anonId = await getAnonUserId();
+  if (!anonId) return new Set();
+
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("likes")
+    .select("deck_id")
+    .eq("anon_id", anonId)
+    .in("deck_id", deckIds);
+
+  return new Set((data ?? []).map((like) => like.deck_id));
+}
+
+async function attachLikedByMe(decks: PublicFeedDeck[]): Promise<FeedDeck[]> {
+  const likedIds = await likedDeckIdsForAnon(decks.map((deck) => deck.id));
+  return decks.map((deck) => ({ ...deck, likedByMe: likedIds.has(deck.id) }));
 }
 
 export async function getFeed(input: {
@@ -56,11 +82,11 @@ export async function getFeed(input: {
       if (error) return { success: false, message: `피드를 가져오는데 실패했습니다: ${error.message}` };
 
       const sorted = sortByHotScore(data ?? []);
-      const page = sorted.slice(offset, offset + limit);
+      const page = sorted.slice(offset, offset + limit) as PublicFeedDeck[];
       const end = offset + page.length;
       return {
         success: true,
-        data: { decks: page, nextOffset: end < sorted.length ? end : null },
+        data: { decks: await attachLikedByMe(page), nextOffset: end < sorted.length ? end : null },
         message: "피드를 가져왔습니다.",
       };
     }
@@ -73,11 +99,11 @@ export async function getFeed(input: {
     const { data, error } = await query.range(offset, offset + limit - 1);
     if (error) return { success: false, message: `피드를 가져오는데 실패했습니다: ${error.message}` };
 
-    const decks = data ?? [];
+    const decks = (data ?? []) as PublicFeedDeck[];
     return {
       success: true,
       data: {
-        decks,
+        decks: await attachLikedByMe(decks),
         nextOffset: decks.length === limit ? offset + decks.length : null,
       },
       message: "피드를 가져왔습니다.",
@@ -109,11 +135,11 @@ export async function searchDecks(input: {
       .range(offset, offset + limit - 1);
     if (error) return { success: false, message: `검색에 실패했습니다: ${error.message}` };
 
-    const decks = data ?? [];
+    const decks = (data ?? []) as PublicFeedDeck[];
     return {
       success: true,
       data: {
-        decks,
+        decks: await attachLikedByMe(decks),
         nextOffset: decks.length === limit ? offset + decks.length : null,
       },
       message: "검색했습니다.",

--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -4,9 +4,11 @@ import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { safeAction } from "@/lib/safe-action";
 import { ActionResponse } from "@/types/action";
+import { getAnonUserId, getOrCreateAnonUserId } from "@/lib/anon-session";
 import { hashIp, requestIpFromHeaders } from "@/lib/ip";
 
-// IP 해시 단독 식별 좋아요 (ADR 0002). likes 테이블은 RLS 정책이 없어
+// 익명 세션 기준 좋아요 (#161). ip_hash는 abuse/rate-limit 보조 신호로만 저장한다.
+// likes 테이블은 RLS 정책이 없어
 // client direct 접근이 차단된다 — 모든 read/write는 본 server action만.
 
 export interface LikeStatus {
@@ -19,43 +21,55 @@ export type LikeActionResponse = ActionResponse<LikeStatus> & { conflict?: boole
 
 const PG_UNIQUE_VIOLATION = "23505";
 
-type IpHashResult =
-  | { ok: true; ipHash: string }
-  | { ok: false; message: string };
-
-async function requestIpHash(): Promise<IpHashResult> {
+async function requestIpHash(): Promise<string | null> {
   const salt = process.env.IP_HASH_SALT;
   if (!salt) {
-    console.error("[like] IP_HASH_SALT 환경변수가 설정되지 않았습니다.");
-    return { ok: false, message: "좋아요 설정이 누락되었습니다." };
+    console.warn("[like] IP_HASH_SALT 환경변수가 설정되지 않았습니다.");
+    return null;
   }
   const headerStore = await headers();
   const ip = requestIpFromHeaders(headerStore);
-  if (!ip) return { ok: false, message: "요청 IP를 확인할 수 없습니다." };
-  return { ok: true, ipHash: hashIp(ip, salt) };
+  if (!ip) return null;
+  return hashIp(ip, salt);
 }
 
-async function currentStatus(deckId: string, ipHash: string): Promise<LikeStatus | null> {
+async function currentStatus(deckId: string, anonId: string | null, ipHash?: string | null): Promise<LikeStatus | null> {
   const admin = createAdminClient();
-  const [{ data: deck }, { data: like }] = await Promise.all([
-    admin.from("decks").select("like_count").eq("id", deckId).single(),
-    admin
+  const { data: deck } = await admin.from("decks").select("like_count").eq("id", deckId).single();
+  if (!deck) return null;
+
+  if (!anonId) return { liked: false, likeCount: deck.like_count };
+
+  const { data: like } = await admin
+    .from("likes")
+    .select("deck_id")
+    .eq("deck_id", deckId)
+    .eq("anon_id", anonId)
+    .maybeSingle();
+  if (like) return { liked: true, likeCount: deck.like_count };
+
+  // Legacy compatibility: pre-#161 likes only had ip_hash. Treat a matching legacy row
+  // as liked for this request, but new writes will bind likes to anon_id.
+  if (ipHash) {
+    const { data: legacyLike } = await admin
       .from("likes")
       .select("deck_id")
       .eq("deck_id", deckId)
       .eq("ip_hash", ipHash)
-      .maybeSingle(),
-  ]);
-  if (!deck) return null;
+      .is("anon_id", null)
+      .maybeSingle();
+    if (legacyLike) return { liked: true, likeCount: deck.like_count };
+  }
+
   return { liked: like !== null, likeCount: deck.like_count };
 }
 
 export async function getLikeStatus(deckId: string): Promise<LikeActionResponse> {
   return safeAction(async () => {
+    const anonId = await getAnonUserId();
     const ipHash = await requestIpHash();
-    if (!ipHash.ok) return { success: false, message: ipHash.message };
 
-    const status = await currentStatus(deckId, ipHash.ipHash);
+    const status = await currentStatus(deckId, anonId, ipHash);
     if (!status) return { success: false, message: "덱을 찾을 수 없습니다." };
     return { success: true, data: status, message: "좋아요 상태를 가져왔습니다." };
   });
@@ -67,8 +81,9 @@ export async function toggleLike(
   like: boolean,
 ): Promise<LikeActionResponse> {
   return safeAction(async () => {
+    const anonId = await getOrCreateAnonUserId();
+    if (!anonId) return { success: false, message: "세션 발급에 실패했습니다." };
     const ipHash = await requestIpHash();
-    if (!ipHash.ok) return { success: false, message: ipHash.message };
 
     const admin = createAdminClient();
 
@@ -80,7 +95,7 @@ export async function toggleLike(
       .single();
     if (!deck) return { success: false, message: "덱을 찾을 수 없습니다." };
     if (deck.hidden) {
-      const status = await currentStatus(deckId, ipHash.ipHash);
+      const status = await currentStatus(deckId, anonId, ipHash);
       return {
         success: false,
         conflict: true,
@@ -90,15 +105,42 @@ export async function toggleLike(
     }
 
     if (like) {
+      if (ipHash) {
+        const { data: claimed, error: claimError } = await admin
+          .from("likes")
+          .update({ anon_id: anonId })
+          .eq("deck_id", deckId)
+          .eq("ip_hash", ipHash)
+          .is("anon_id", null)
+          .select("deck_id");
+        if (claimError?.code === PG_UNIQUE_VIOLATION) {
+          const status = await currentStatus(deckId, anonId, ipHash);
+          return {
+            success: false,
+            conflict: true,
+            message: "이미 추천했습니다.",
+            ...(status ? { data: status } : {}),
+          };
+        }
+        if (claimError) {
+          return { success: false, message: `좋아요에 실패했습니다: ${claimError.message}` };
+        }
+        if (claimed && claimed.length > 0) {
+          const status = await currentStatus(deckId, anonId, ipHash);
+          if (!status) return { success: false, message: "덱을 찾을 수 없습니다." };
+          return { success: true, data: status, message: "좋아요!" };
+        }
+      }
+
       const { error } = await admin
         .from("likes")
-        .insert({ deck_id: deckId, ip_hash: ipHash.ipHash });
+        .insert({ deck_id: deckId, anon_id: anonId, ip_hash: ipHash });
       if (error?.code === PG_UNIQUE_VIOLATION) {
-        const status = await currentStatus(deckId, ipHash.ipHash);
+        const status = await currentStatus(deckId, anonId, ipHash);
         return {
           success: false,
           conflict: true,
-          message: "이미 추천한 IP입니다.",
+          message: "이미 추천했습니다.",
           ...(status ? { data: status } : {}),
         };
       }
@@ -110,14 +152,25 @@ export async function toggleLike(
         .from("likes")
         .delete()
         .eq("deck_id", deckId)
-        .eq("ip_hash", ipHash.ipHash);
+        .eq("anon_id", anonId);
       if (error) {
         return { success: false, message: `좋아요 취소에 실패했습니다: ${error.message}` };
+      }
+      if (ipHash) {
+        const { error: legacyError } = await admin
+          .from("likes")
+          .delete()
+          .eq("deck_id", deckId)
+          .eq("ip_hash", ipHash)
+          .is("anon_id", null);
+        if (legacyError) {
+          return { success: false, message: `좋아요 취소에 실패했습니다: ${legacyError.message}` };
+        }
       }
     }
 
     // 트리거 반영 후 서버 진실을 반환 — 클라이언트가 이 값으로 동기화한다
-    const status = await currentStatus(deckId, ipHash.ipHash);
+    const status = await currentStatus(deckId, anonId, ipHash);
     if (!status) return { success: false, message: "덱을 찾을 수 없습니다." };
     return {
       success: true,

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { serializeJsonLd } from "@/lib/security-headers";
 import { getDeckById } from "@/app/actions/deck";
+import { getLikeStatus } from "@/app/actions/like";
 import { DeckMetaCard } from "@/components/DeckMetaCard";
 import { CommentThread } from "@/components/CommentThread";
 import { LikeButton } from "@/components/LikeButton";
@@ -65,6 +66,8 @@ export default async function DeckPage({ params }: DeckPageProps) {
   const { deck, words } = result.data;
   const activeWordCount = words.filter((w) => w.active).length;
   const t = await getTranslations("deck.detail");
+  const likeStatus = await getLikeStatus(deck.id);
+  const likedByMe = likeStatus.success && likeStatus.data ? likeStatus.data.liked : false;
 
   // 직접 링크는 살아있되 인터랙션은 전부 차단 — 작성자 대응 경로만 노출 (ADR 0013)
   if (deck.hidden) {
@@ -108,7 +111,7 @@ export default async function DeckPage({ params }: DeckPageProps) {
         <Button asChild variant="outline">
           <Link href={`/d/${deck.id}/edit`}>{t("editButton")}</Link>
         </Button>
-        <LikeButton deckId={deck.id} initialCount={deck.like_count} />
+        <LikeButton deckId={deck.id} initialCount={deck.like_count} initialLiked={likedByMe} />
         <ReportButton targetType="deck" targetId={deck.id} />
       </div>
 

--- a/components/FeedDeckCard.tsx
+++ b/components/FeedDeckCard.tsx
@@ -31,7 +31,7 @@ export function FeedDeckCard({ deck }: { deck: FeedDeck }) {
           {formatDisplayNick(deck.creator_nick, deck.creator_id)}
         </p>
       </Link>
-      <LikeButton deckId={deck.id} initialCount={deck.like_count} />
+      <LikeButton deckId={deck.id} initialCount={deck.like_count} initialLiked={deck.likedByMe} />
     </div>
   );
 }

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { getLikeStatus, toggleLike, type LikeActionResponse } from "@/app/actions/like";
+import { toggleLike, type LikeActionResponse } from "@/app/actions/like";
 import {
   initialLikeState,
   applyClick,
@@ -20,26 +20,15 @@ import { cn } from "@/lib/utils";
 interface LikeButtonProps {
   deckId: string;
   initialCount: number;
+  initialLiked: boolean;
 }
 
-export function LikeButton({ deckId, initialCount }: LikeButtonProps) {
+export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonProps) {
   const t = useTranslations('common');
-  const [state, setState] = useState<LikeState>(() => initialLikeState(false, initialCount));
+  const [state, setState] = useState<LikeState>(() => initialLikeState(initialLiked, initialCount));
   const stateRef = useRef(state);
   stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // 본인 IP의 liked 여부는 서버만 안다 — 마운트 시 동기화
-  useEffect(() => {
-    let cancelled = false;
-    getLikeStatus(deckId).then((result) => {
-      if (cancelled || !result.success || !result.data) return;
-      setState(initialLikeState(result.data.liked, result.data.likeCount));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [deckId]);
 
   const flush = async () => {
     const desired = pendingDesired(stateRef.current);

--- a/lib/anon-session.ts
+++ b/lib/anon-session.ts
@@ -1,5 +1,11 @@
 import { createClient } from "@/lib/supabase-server";
 
+export async function getAnonUserId(): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user?.id ?? null;
+}
+
 // 익명 세션이 없으면 lazy 발급한다.
 // ADR 0001은 미들웨어 자동 발급을 제시하지만, 모든 방문(봇 포함)마다
 // 익명 유저가 쌓이는 것을 피해 "첫 쓰기/플레이 시점" 발급으로 운영한다.

--- a/lib/optimistic-like.test.ts
+++ b/lib/optimistic-like.test.ts
@@ -17,7 +17,7 @@ describe('낙관적 좋아요 — 성공 시나리오 (AC)', () => {
 
   it('서버 200 + 새 like_count 반환 시 서버 값으로 동기화', () => {
     let state = applyClick(initialLikeState(false, 10));
-    state = applyServerConfirm(state, { liked: true, count: 13 }); // 다른 IP 좋아요 누적 반영
+    state = applyServerConfirm(state, { liked: true, count: 13 }); // 다른 세션 좋아요 누적 반영
     expect(state).toEqual({ liked: true, count: 13, snapshot: null });
   });
 });

--- a/supabase/migrations/20260617000001_likes_anon_id.sql
+++ b/supabase/migrations/20260617000001_likes_anon_id.sql
@@ -1,0 +1,25 @@
+-- 좋아요 식별 기준을 IP hash에서 익명 세션으로 전환한다 (#161).
+-- ip_hash는 abuse/rate-limit 분석용으로 보존하되 likedByMe와 toggle idempotency는 anon_id가 담당한다.
+
+ALTER TABLE public.likes
+  ADD COLUMN IF NOT EXISTS anon_id uuid REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.likes
+  ALTER COLUMN ip_hash DROP NOT NULL;
+
+ALTER TABLE public.likes
+  DROP CONSTRAINT IF EXISTS likes_pkey;
+
+CREATE UNIQUE INDEX IF NOT EXISTS likes_deck_anon_uidx
+  ON public.likes(deck_id, anon_id)
+  WHERE anon_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_likes_deck_id
+  ON public.likes(deck_id);
+
+CREATE INDEX IF NOT EXISTS idx_likes_anon_id
+  ON public.likes(anon_id);
+
+CREATE INDEX IF NOT EXISTS idx_likes_ip_hash
+  ON public.likes(ip_hash)
+  WHERE ip_hash IS NOT NULL;

--- a/types/database.ts
+++ b/types/database.ts
@@ -46,21 +46,31 @@ export type Database = {
       }
       likes: {
         Row: {
+          anon_id: string | null
           created_at: string
           deck_id: string
-          ip_hash: string
+          ip_hash: string | null
         }
         Insert: {
+          anon_id?: string | null
           created_at?: string
           deck_id: string
-          ip_hash: string
+          ip_hash?: string | null
         }
         Update: {
+          anon_id?: string | null
           created_at?: string
           deck_id?: string
-          ip_hash?: string
+          ip_hash?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "likes_anon_id_fkey"
+            columns: ["anon_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "likes_deck_id_fkey"
             columns: ["deck_id"]


### PR DESCRIPTION
## Summary
- Link likes to anonymous Supabase sessions with a new nullable `likes.anon_id` column and unique `(deck_id, anon_id)` index.
- Attach `likedByMe` to feed/search results with one batched likes query for the current anonymous session instead of per-card status requests.
- Keep `ip_hash` as an auxiliary abuse/rate-limit and legacy-compatibility signal, while new like writes are keyed by anonymous session.
- Pass server-provided liked state into `LikeButton`, so deck cards no longer fetch like status on mount.

Closes #161.

## Verification
- `npm run typecheck`
- `npm run lint`
- `TMPDIR=/tmp npm test -- lib/optimistic-like.test.ts lib/ip.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드와 검색 결과에서 내가 좋아요 한 덱을 즉시 확인할 수 있습니다.
  * 익명 사용자 세션 기반의 개선된 좋아요 추적 시스템으로 더욱 정확한 상태 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->