### PR TITLE
fix(db): order likes migration constraint change

### DIFF
--- a/supabase/migrations/20260617000001_likes_anon_id.sql
+++ b/supabase/migrations/20260617000001_likes_anon_id.sql
@@ -5,10 +5,10 @@ ALTER TABLE public.likes
   ADD COLUMN IF NOT EXISTS anon_id uuid REFERENCES auth.users(id) ON DELETE CASCADE;
 
 ALTER TABLE public.likes
-  ALTER COLUMN ip_hash DROP NOT NULL;
+  DROP CONSTRAINT IF EXISTS likes_pkey;
 
 ALTER TABLE public.likes
-  DROP CONSTRAINT IF EXISTS likes_pkey;
+  ALTER COLUMN ip_hash DROP NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS likes_deck_anon_uidx
   ON public.likes(deck_id, anon_id)


### PR DESCRIPTION
## Summary
- Reorder the `20260617000001_likes_anon_id.sql` migration so the old `likes_pkey` constraint is dropped before `ip_hash` is made nullable.
- This matches the SQL that was successfully applied to the linked Supabase database via `supabase db push`.

## Why
`supabase db push` initially failed because `ip_hash` was still part of the primary key when `ALTER COLUMN ip_hash DROP NOT NULL` ran. Dropping the constraint first fixes fresh-environment migration runs.

## Verification
- `node_modules/.bin/supabase db push` completed successfully after the reorder.
- `node_modules/.bin/supabase migration list` shows `20260617000001` present locally and remotely.