### PR TITLE
feat(feed): cache list pagination with React Query

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { Suspense } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { getSiteUrl } from "@/lib/site";
+import { QueryProvider } from "@/components/QueryProvider";
 
 const pretendard = localFont({
   src: [
@@ -55,12 +56,14 @@ export default async function RootLayout({
         style={{ fontFamily: "var(--font-pretendard)" }}
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <ErrorBoundary>
-            <Suspense fallback={<Loading />}>
-              {children}
-            </Suspense>
-          </ErrorBoundary>
-          <Toaster />
+          <QueryProvider>
+            <ErrorBoundary>
+              <Suspense fallback={<Loading />}>
+                {children}
+              </Suspense>
+            </ErrorBoundary>
+            <Toaster />
+          </QueryProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/components/FeedList.tsx
+++ b/components/FeedList.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { FeedDeckCard } from "@/components/FeedDeckCard";
 import { EmptyResult } from "@/components/EmptyResult";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { getFeed, searchDecks, type FeedDeck, type FeedSort } from "@/app/actions/feed";
+import { feedQueryKey, mergeFeedPages } from "@/lib/feed-query";
 
 interface FeedListProps {
   /** 서버에서 렌더한 첫 페이지 */
@@ -18,40 +20,50 @@ interface FeedListProps {
 
 export function FeedList({ initialDecks, initialNextOffset, sort, query }: FeedListProps) {
   const t = useTranslations("deck.list");
-  const [decks, setDecks] = useState(initialDecks);
-  const [nextOffset, setNextOffset] = useState(initialNextOffset);
-  const loadingRef = useRef(false);
+  const initialPage = useMemo(
+    () => ({ decks: initialDecks, nextOffset: initialNextOffset }),
+    [initialDecks, initialNextOffset],
+  );
+  const feedQuery = useInfiniteQuery({
+    queryKey: feedQueryKey({ sort, query }),
+    queryFn: async ({ pageParam }) => {
+      const result =
+        query !== undefined
+          ? await searchDecks({ q: query, offset: pageParam })
+          : await getFeed({ sort, offset: pageParam });
+      if (!result.success || !result.data) {
+        throw new Error(result.message);
+      }
+      return result.data;
+    },
+    initialData: {
+      pages: [initialPage],
+      pageParams: [0],
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextOffset,
+  });
+
+  const page = useMemo(
+    () => mergeFeedPages(feedQuery.data?.pages ?? [initialPage]),
+    [feedQuery.data?.pages, initialPage],
+  );
 
   const loadMore = useCallback(async () => {
-    if (loadingRef.current || nextOffset === null) return;
-    loadingRef.current = true;
-    try {
-      const result = query !== undefined
-        ? await searchDecks({ q: query, offset: nextOffset })
-        : await getFeed({ sort, offset: nextOffset });
-      if (result.success && result.data) {
-        const { decks: more, nextOffset: next } = result.data;
-        setDecks((prev) => {
-          const seen = new Set(prev.map((d) => d.id));
-          return [...prev, ...more.filter((d) => !seen.has(d.id))];
-        });
-        setNextOffset(next);
-      }
-    } finally {
-      loadingRef.current = false;
-    }
-  }, [nextOffset, sort, query]);
+    if (!feedQuery.hasNextPage || feedQuery.isFetchingNextPage) return;
+    await feedQuery.fetchNextPage();
+  }, [feedQuery]);
 
   const sentinelRef = useIntersectionObserver(loadMore);
 
-  if (decks.length === 0) return <EmptyResult query={query} />;
+  if (page.decks.length === 0) return <EmptyResult query={query} />;
 
   return (
     <div className="space-y-3">
-      {decks.map((deck) => (
+      {page.decks.map((deck) => (
         <FeedDeckCard key={deck.id} deck={deck} />
       ))}
-      {nextOffset !== null && (
+      {page.nextOffset !== null && (
         <div ref={sentinelRef} className="py-4 text-center text-sm text-muted-foreground">
           {t("loading")}
         </div>

--- a/components/QueryProvider.tsx
+++ b/components/QueryProvider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1000,
+            refetchOnWindowFocus: false,
+            staleTime: 30 * 1000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/lib/feed-query.test.ts
+++ b/lib/feed-query.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { feedQueryKey, mergeFeedPages } from "./feed-query";
+import type { FeedPage } from "../app/actions/feed";
+
+function page(ids: string[], nextOffset: number | null): FeedPage {
+  return {
+    decks: ids.map((id) => ({
+      id,
+      name: `deck-${id}`,
+      script: "latin",
+      creator_id: "creator",
+      creator_nick: "nick",
+      image_url: null,
+      like_count: 0,
+      likedByMe: false,
+      created_at: "2026-06-17T00:00:00.000Z",
+    })),
+    nextOffset,
+  };
+}
+
+describe("feed query helpers", () => {
+  it("separates feed and search query keys", () => {
+    expect(feedQueryKey({ sort: "hot" })).toEqual(["feed", { sort: "hot", query: null }]);
+    expect(feedQueryKey({ sort: "likes", query: "blue archive" })).toEqual([
+      "feed",
+      { sort: "likes", query: "blue archive" },
+    ]);
+  });
+
+  it("merges infinite pages without duplicating decks", () => {
+    const merged = mergeFeedPages([page(["a", "b"], 2), page(["b", "c"], null)]);
+
+    expect(merged.decks.map((deck) => deck.id)).toEqual(["a", "b", "c"]);
+    expect(merged.nextOffset).toBeNull();
+  });
+});

--- a/lib/feed-query.ts
+++ b/lib/feed-query.ts
@@ -1,0 +1,21 @@
+import type { FeedPage, FeedSort } from "@/app/actions/feed";
+
+export function feedQueryKey(input: { sort: FeedSort; query?: string }) {
+  return ["feed", { sort: input.sort, query: input.query ?? null }] as const;
+}
+
+export function mergeFeedPages(pages: FeedPage[]): FeedPage {
+  const seen = new Set<string>();
+  const decks = pages.flatMap((page) =>
+    page.decks.filter((deck) => {
+      if (seen.has(deck.id)) return false;
+      seen.add(deck.id);
+      return true;
+    }),
+  );
+
+  return {
+    decks,
+    nextOffset: pages.at(-1)?.nextOffset ?? null,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.58.0",
+    "@tanstack/react-query": "^5.101.0",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.58.0
         version: 2.58.0
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.4)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1353,6 +1356,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.14':
     resolution: {integrity: sha512-BdMjIxy7HUNThK87C7BC8I1rE8BVUsfNQSI5siQ4JK3iIa3w0XyVvVL9SXLWO//CtYTcp1v7zci0fYwJOjB+Zg==}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4215,6 +4226,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.14
       postcss: 8.5.6
       tailwindcss: 4.1.14
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.4
 
   '@tybys/wasm-util@0.10.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@tanstack/react-query` and a root `QueryProvider`.
- Convert `FeedList` from local `useState` pagination to `useInfiniteQuery` with server-rendered first-page `initialData`.
- Add small feed query helpers for stable query keys and deduped infinite-page merging.

## Scope
This PR intentionally only introduces feed/search pagination caching. Likes optimistic cache updates and comment lazy loading should stay in follow-up PRs.

## Verification
- `TMPDIR=/tmp npm test -- lib/feed-query.test.ts`
- `npm run typecheck`
- `npm run lint`
- `TMPDIR=/tmp npm test`
- `npm run build`