### PR TITLE
feat(likes): React Query 캐시에 좋아요 반응성 반영

### DIFF
--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { toggleLike, type LikeActionResponse } from "@/app/actions/like";
+import type { FeedPage } from "@/app/actions/feed";
 import {
   initialLikeState,
   applyClick,
@@ -15,6 +17,7 @@ import {
   LIKE_DEBOUNCE_MS,
   type LikeState,
 } from "@/lib/optimistic-like";
+import { updateDeckLikeInFeedData } from "@/lib/feed-query";
 import { cn } from "@/lib/utils";
 
 interface LikeButtonProps {
@@ -25,10 +28,18 @@ interface LikeButtonProps {
 
 export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonProps) {
   const t = useTranslations('common');
+  const queryClient = useQueryClient();
   const [state, setState] = useState<LikeState>(() => initialLikeState(initialLiked, initialCount));
   const stateRef = useRef(state);
   stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const syncFeedCache = (like: { liked: boolean; count: number }) => {
+    queryClient.setQueriesData<InfiniteData<FeedPage>>(
+      { queryKey: ["feed"] },
+      (data) => (data ? updateDeckLikeInFeedData(data, deckId, like) : data),
+    );
+  };
 
   const flush = async () => {
     const desired = pendingDesired(stateRef.current);
@@ -47,17 +58,33 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
         liked: result.data!.liked,
         count: result.data!.likeCount,
       }));
+      syncFeedCache({ liked: result.data.liked, count: result.data.likeCount });
     } else {
-      setState((prev) => applyRollback(prev));
+      setState((prev) => {
+        const next = applyRollback(prev);
+        syncFeedCache({ liked: next.liked, count: next.count });
+        return next;
+      });
       toast.error(result?.message ?? t('networkError'));
     }
   };
 
   const handleClick = () => {
-    setState((prev) => applyClick(prev)); // 즉시 반영 (AC)
+    setState((prev) => {
+      const next = applyClick(prev); // 즉시 반영 (AC)
+      syncFeedCache({ liked: next.liked, count: next.count });
+      return next;
+    });
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => void flush(), LIKE_DEBOUNCE_MS); // 200ms debounce (AC)
   };
+
+  useEffect(() => {
+    setState((prev) => {
+      if (prev.snapshot) return prev;
+      return initialLikeState(initialLiked, initialCount);
+    });
+  }, [initialLiked, initialCount]);
 
   useEffect(() => {
     return () => {

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
@@ -11,19 +11,12 @@ import type { FeedPage } from "@/app/actions/feed";
 import {
   initialLikeState,
   applyClick,
-  applyServerConfirm,
   applyRollback,
   pendingDesired,
   LIKE_DEBOUNCE_MS,
   type LikeState,
 } from "@/lib/optimistic-like";
-import {
-  applyOptimisticDeckLikeInFeedData,
-  restoreFeedQueries,
-  snapshotFeedQueries,
-  updateDeckLikeInFeedData,
-  type FeedQuerySnapshot,
-} from "@/lib/feed-query";
+import { updateDeckLikeInFeedData } from "@/lib/feed-query";
 import { cn } from "@/lib/utils";
 
 interface LikeButtonProps {
@@ -36,40 +29,27 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   const t = useTranslations('common');
   const queryClient = useQueryClient();
   const [state, setState] = useState<LikeState>(() => initialLikeState(initialLiked, initialCount));
+  const othersLikeCountBaseline = useMemo(
+    () => Math.max(0, initialCount - (initialLiked ? 1 : 0)),
+    [initialCount, initialLiked],
+  );
   const stateRef = useRef(state);
   stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const feedSnapshotRef = useRef<FeedQuerySnapshot | null>(null);
+  const displayCount = othersLikeCountBaseline + (state.liked ? 1 : 0);
 
-  const syncFeedCache = useCallback((like: { liked: boolean; count: number }) => {
+  const syncFeedCache = useCallback((liked: boolean) => {
     queryClient.setQueriesData<InfiniteData<FeedPage>>(
       { queryKey: ["feed"] },
-      (data) => (data ? updateDeckLikeInFeedData(data, deckId, like) : data),
+      (data) => (data ? updateDeckLikeInFeedData(data, deckId, { liked }) : data),
     );
   }, [deckId, queryClient]);
-
-  const applyOptimisticFeedCache = useCallback((liked: boolean) => {
-    if (!feedSnapshotRef.current) {
-      feedSnapshotRef.current = snapshotFeedQueries(queryClient);
-    }
-    queryClient.setQueriesData<InfiniteData<FeedPage>>(
-      { queryKey: ["feed"] },
-      (data) => (data ? applyOptimisticDeckLikeInFeedData(data, deckId, liked) : data),
-    );
-  }, [deckId, queryClient]);
-
-  const restoreFeedCache = useCallback(() => {
-    if (!feedSnapshotRef.current) return;
-    restoreFeedQueries(queryClient, feedSnapshotRef.current);
-    feedSnapshotRef.current = null;
-  }, [queryClient]);
 
   const flush = async () => {
     const desired = pendingDesired(stateRef.current);
     if (desired === null) {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
       setState((prev) => ({ ...prev, snapshot: null }));
-      restoreFeedCache();
       return;
     }
 
@@ -78,16 +58,12 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     if (!result) result = await send().catch(() => null); // 네트워크 실패 1회 재시도 (AC)
 
     if (result?.success && result.data) {
-      setState((prev) => applyServerConfirm(prev, {
-        liked: result.data!.liked,
-        count: result.data!.likeCount,
-      }));
-      syncFeedCache({ liked: result.data.liked, count: result.data.likeCount });
-      feedSnapshotRef.current = null;
+      setState((prev) => ({ ...prev, liked: result.data!.liked, snapshot: null }));
+      syncFeedCache(result.data.liked);
     } else {
       setState((prev) => {
         const next = applyRollback(prev);
-        restoreFeedCache();
+        syncFeedCache(next.liked);
         return next;
       });
       toast.error(result?.message ?? t('networkError'));
@@ -97,7 +73,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   const handleClick = () => {
     setState((prev) => {
       const next = applyClick(prev); // 즉시 반영 (AC)
-      applyOptimisticFeedCache(next.liked);
+      syncFeedCache(next.liked);
       return next;
     });
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -114,14 +90,13 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      restoreFeedCache();
     };
-  }, [restoreFeedCache]);
+  }, []);
 
   return (
     <Button type="button" variant="outline" onClick={handleClick} aria-pressed={state.liked}>
       <Heart className={cn("size-4", state.liked && "fill-red-500 text-red-500")} />
-      {state.count}
+      {displayCount}
     </Button>
   );
 }

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
@@ -17,7 +17,13 @@ import {
   LIKE_DEBOUNCE_MS,
   type LikeState,
 } from "@/lib/optimistic-like";
-import { updateDeckLikeInFeedData } from "@/lib/feed-query";
+import {
+  applyOptimisticDeckLikeInFeedData,
+  restoreFeedQueries,
+  snapshotFeedQueries,
+  updateDeckLikeInFeedData,
+  type FeedQuerySnapshot,
+} from "@/lib/feed-query";
 import { cn } from "@/lib/utils";
 
 interface LikeButtonProps {
@@ -33,19 +39,37 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   const stateRef = useRef(state);
   stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feedSnapshotRef = useRef<FeedQuerySnapshot | null>(null);
 
-  const syncFeedCache = (like: { liked: boolean; count: number }) => {
+  const syncFeedCache = useCallback((like: { liked: boolean; count: number }) => {
     queryClient.setQueriesData<InfiniteData<FeedPage>>(
       { queryKey: ["feed"] },
       (data) => (data ? updateDeckLikeInFeedData(data, deckId, like) : data),
     );
-  };
+  }, [deckId, queryClient]);
+
+  const applyOptimisticFeedCache = useCallback((liked: boolean) => {
+    if (!feedSnapshotRef.current) {
+      feedSnapshotRef.current = snapshotFeedQueries(queryClient);
+    }
+    queryClient.setQueriesData<InfiniteData<FeedPage>>(
+      { queryKey: ["feed"] },
+      (data) => (data ? applyOptimisticDeckLikeInFeedData(data, deckId, liked) : data),
+    );
+  }, [deckId, queryClient]);
+
+  const restoreFeedCache = useCallback(() => {
+    if (!feedSnapshotRef.current) return;
+    restoreFeedQueries(queryClient, feedSnapshotRef.current);
+    feedSnapshotRef.current = null;
+  }, [queryClient]);
 
   const flush = async () => {
     const desired = pendingDesired(stateRef.current);
     if (desired === null) {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
       setState((prev) => ({ ...prev, snapshot: null }));
+      restoreFeedCache();
       return;
     }
 
@@ -59,10 +83,11 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
         count: result.data!.likeCount,
       }));
       syncFeedCache({ liked: result.data.liked, count: result.data.likeCount });
+      feedSnapshotRef.current = null;
     } else {
       setState((prev) => {
         const next = applyRollback(prev);
-        syncFeedCache({ liked: next.liked, count: next.count });
+        restoreFeedCache();
         return next;
       });
       toast.error(result?.message ?? t('networkError'));
@@ -72,7 +97,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   const handleClick = () => {
     setState((prev) => {
       const next = applyClick(prev); // 즉시 반영 (AC)
-      syncFeedCache({ liked: next.liked, count: next.count });
+      applyOptimisticFeedCache(next.liked);
       return next;
     });
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -89,8 +114,9 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      restoreFeedCache();
     };
-  }, []);
+  }, [restoreFeedCache]);
 
   return (
     <Button type="button" variant="outline" onClick={handleClick} aria-pressed={state.liked}>

--- a/lib/feed-query.test.ts
+++ b/lib/feed-query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { feedQueryKey, mergeFeedPages } from "./feed-query";
+import { feedQueryKey, mergeFeedPages, updateDeckLikeInFeedData } from "./feed-query";
 import type { FeedPage } from "../app/actions/feed";
 
 function page(ids: string[], nextOffset: number | null): FeedPage {
@@ -33,5 +33,18 @@ describe("feed query helpers", () => {
 
     expect(merged.decks.map((deck) => deck.id)).toEqual(["a", "b", "c"]);
     expect(merged.nextOffset).toBeNull();
+  });
+
+  it("updates a deck like state inside infinite feed data", () => {
+    const data = {
+      pages: [page(["a", "b"], 2), page(["c"], null)],
+      pageParams: [0, 2],
+    };
+
+    const updated = updateDeckLikeInFeedData(data, "b", { liked: true, count: 7 });
+
+    expect(updated.pages[0].decks[1]).toMatchObject({ id: "b", likedByMe: true, like_count: 7 });
+    expect(updated.pages[0].decks[0]).toBe(data.pages[0].decks[0]);
+    expect(updated.pageParams).toBe(data.pageParams);
   });
 });

--- a/lib/feed-query.test.ts
+++ b/lib/feed-query.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { QueryClient, type InfiniteData } from "@tanstack/react-query";
-import {
-  applyOptimisticDeckLikeInFeedData,
-  feedQueryKey,
-  mergeFeedPages,
-  restoreFeedQueries,
-  snapshotFeedQueries,
-  updateDeckLikeInFeedData,
-} from "./feed-query";
+import { feedQueryKey, mergeFeedPages, updateDeckLikeInFeedData } from "./feed-query";
 import type { FeedPage } from "../app/actions/feed";
 
-function deck(id: string, likeCount = 0) {
+function deck(id: string, likeCount = 0, likedByMe = false) {
   return {
     id,
     name: `deck-${id}`,
@@ -19,7 +11,7 @@ function deck(id: string, likeCount = 0) {
     creator_nick: "nick",
     image_url: null,
     like_count: likeCount,
-    likedByMe: false,
+    likedByMe,
     created_at: "2026-06-17T00:00:00.000Z",
   };
 }
@@ -47,43 +39,18 @@ describe("feed query helpers", () => {
     expect(merged.nextOffset).toBeNull();
   });
 
-  it("updates a deck like state inside infinite feed data", () => {
+  it("displays count as others baseline plus likedByMe", () => {
     const data = {
-      pages: [page(["a", "b"], 2), page(["c"], null)],
+      pages: [{ decks: [deck("a"), deck("b", 7, false), deck("c", 11, true)], nextOffset: null }],
       pageParams: [0, 2],
     };
 
-    const updated = updateDeckLikeInFeedData(data, "b", { liked: true, count: 7 });
+    const liked = updateDeckLikeInFeedData(data, "b", { liked: true });
+    const unliked = updateDeckLikeInFeedData(data, "c", { liked: false });
 
-    expect(updated.pages[0].decks[1]).toMatchObject({ id: "b", likedByMe: true, like_count: 7 });
-    expect(updated.pages[0].decks[0]).toBe(data.pages[0].decks[0]);
-    expect(updated.pageParams).toBe(data.pageParams);
-  });
-
-  it("restores exact feed/search cache snapshots after optimistic updates", () => {
-    const queryClient = new QueryClient();
-    const feedKey = feedQueryKey({ sort: "hot" });
-    const searchKey = feedQueryKey({ sort: "likes", query: "blue archive" });
-    queryClient.setQueryData(feedKey, {
-      pages: [{ decks: [deck("b", 7)], nextOffset: null }],
-      pageParams: [0],
-    });
-    queryClient.setQueryData(searchKey, {
-      pages: [{ decks: [deck("b", 11)], nextOffset: null }],
-      pageParams: [0],
-    });
-    const snapshot = snapshotFeedQueries(queryClient);
-
-    queryClient.setQueriesData<InfiniteData<FeedPage>>({ queryKey: ["feed"] }, (data) =>
-      data ? applyOptimisticDeckLikeInFeedData(data, "b", true) : data,
-    );
-    restoreFeedQueries(queryClient, snapshot);
-
-    expect(queryClient.getQueryData(feedKey)).toMatchObject({
-      pages: [{ decks: [{ id: "b", likedByMe: false, like_count: 7 }] }],
-    });
-    expect(queryClient.getQueryData(searchKey)).toMatchObject({
-      pages: [{ decks: [{ id: "b", likedByMe: false, like_count: 11 }] }],
-    });
+    expect(liked.pages[0].decks[1]).toMatchObject({ id: "b", likedByMe: true, like_count: 8 });
+    expect(unliked.pages[0].decks[2]).toMatchObject({ id: "c", likedByMe: false, like_count: 10 });
+    expect(liked.pages[0].decks[0]).toBe(data.pages[0].decks[0]);
+    expect(liked.pageParams).toBe(data.pageParams);
   });
 });

--- a/lib/feed-query.test.ts
+++ b/lib/feed-query.test.ts
@@ -1,20 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { feedQueryKey, mergeFeedPages, updateDeckLikeInFeedData } from "./feed-query";
+import { QueryClient, type InfiniteData } from "@tanstack/react-query";
+import {
+  applyOptimisticDeckLikeInFeedData,
+  feedQueryKey,
+  mergeFeedPages,
+  restoreFeedQueries,
+  snapshotFeedQueries,
+  updateDeckLikeInFeedData,
+} from "./feed-query";
 import type { FeedPage } from "../app/actions/feed";
+
+function deck(id: string, likeCount = 0) {
+  return {
+    id,
+    name: `deck-${id}`,
+    script: "latin",
+    creator_id: "creator",
+    creator_nick: "nick",
+    image_url: null,
+    like_count: likeCount,
+    likedByMe: false,
+    created_at: "2026-06-17T00:00:00.000Z",
+  };
+}
 
 function page(ids: string[], nextOffset: number | null): FeedPage {
   return {
-    decks: ids.map((id) => ({
-      id,
-      name: `deck-${id}`,
-      script: "latin",
-      creator_id: "creator",
-      creator_nick: "nick",
-      image_url: null,
-      like_count: 0,
-      likedByMe: false,
-      created_at: "2026-06-17T00:00:00.000Z",
-    })),
+    decks: ids.map((id) => deck(id)),
     nextOffset,
   };
 }
@@ -46,5 +58,32 @@ describe("feed query helpers", () => {
     expect(updated.pages[0].decks[1]).toMatchObject({ id: "b", likedByMe: true, like_count: 7 });
     expect(updated.pages[0].decks[0]).toBe(data.pages[0].decks[0]);
     expect(updated.pageParams).toBe(data.pageParams);
+  });
+
+  it("restores exact feed/search cache snapshots after optimistic updates", () => {
+    const queryClient = new QueryClient();
+    const feedKey = feedQueryKey({ sort: "hot" });
+    const searchKey = feedQueryKey({ sort: "likes", query: "blue archive" });
+    queryClient.setQueryData(feedKey, {
+      pages: [{ decks: [deck("b", 7)], nextOffset: null }],
+      pageParams: [0],
+    });
+    queryClient.setQueryData(searchKey, {
+      pages: [{ decks: [deck("b", 11)], nextOffset: null }],
+      pageParams: [0],
+    });
+    const snapshot = snapshotFeedQueries(queryClient);
+
+    queryClient.setQueriesData<InfiniteData<FeedPage>>({ queryKey: ["feed"] }, (data) =>
+      data ? applyOptimisticDeckLikeInFeedData(data, "b", true) : data,
+    );
+    restoreFeedQueries(queryClient, snapshot);
+
+    expect(queryClient.getQueryData(feedKey)).toMatchObject({
+      pages: [{ decks: [{ id: "b", likedByMe: false, like_count: 7 }] }],
+    });
+    expect(queryClient.getQueryData(searchKey)).toMatchObject({
+      pages: [{ decks: [{ id: "b", likedByMe: false, like_count: 11 }] }],
+    });
   });
 });

--- a/lib/feed-query.test.ts
+++ b/lib/feed-query.test.ts
@@ -53,4 +53,19 @@ describe("feed query helpers", () => {
     expect(liked.pages[0].decks[0]).toBe(data.pages[0].decks[0]);
     expect(liked.pageParams).toBe(data.pageParams);
   });
+
+  it("clamps malformed others baseline to zero", () => {
+    const data = {
+      pages: [{ decks: [deck("a", 0, true)], nextOffset: null }],
+      pageParams: [0],
+    };
+
+    const updated = updateDeckLikeInFeedData(data, "a", { liked: false });
+
+    expect(updated.pages[0].decks[0]).toMatchObject({
+      id: "a",
+      likedByMe: false,
+      like_count: 0,
+    });
+  });
 });

--- a/lib/feed-query.ts
+++ b/lib/feed-query.ts
@@ -1,3 +1,4 @@
+import type { InfiniteData } from "@tanstack/react-query";
 import type { FeedPage, FeedSort } from "@/app/actions/feed";
 
 export function feedQueryKey(input: { sort: FeedSort; query?: string }) {
@@ -17,5 +18,23 @@ export function mergeFeedPages(pages: FeedPage[]): FeedPage {
   return {
     decks,
     nextOffset: pages.at(-1)?.nextOffset ?? null,
+  };
+}
+
+export function updateDeckLikeInFeedData(
+  data: InfiniteData<FeedPage>,
+  deckId: string,
+  like: { liked: boolean; count: number },
+): InfiniteData<FeedPage> {
+  return {
+    pageParams: data.pageParams,
+    pages: data.pages.map((page) => ({
+      ...page,
+      decks: page.decks.map((deck) =>
+        deck.id === deckId
+          ? { ...deck, likedByMe: like.liked, like_count: like.count }
+          : deck,
+      ),
+    })),
   };
 }

--- a/lib/feed-query.ts
+++ b/lib/feed-query.ts
@@ -1,5 +1,7 @@
-import type { InfiniteData } from "@tanstack/react-query";
+import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query";
 import type { FeedPage, FeedSort } from "@/app/actions/feed";
+
+export type FeedQuerySnapshot = Array<[QueryKey, InfiniteData<FeedPage> | undefined]>;
 
 export function feedQueryKey(input: { sort: FeedSort; query?: string }) {
   return ["feed", { sort: input.sort, query: input.query ?? null }] as const;
@@ -37,4 +39,32 @@ export function updateDeckLikeInFeedData(
       ),
     })),
   };
+}
+
+export function applyOptimisticDeckLikeInFeedData(
+  data: InfiniteData<FeedPage>,
+  deckId: string,
+  liked: boolean,
+): InfiniteData<FeedPage> {
+  return {
+    pageParams: data.pageParams,
+    pages: data.pages.map((page) => ({
+      ...page,
+      decks: page.decks.map((deck) => {
+        if (deck.id !== deckId) return deck;
+        const delta = deck.likedByMe === liked ? 0 : liked ? 1 : -1;
+        return { ...deck, likedByMe: liked, like_count: deck.like_count + delta };
+      }),
+    })),
+  };
+}
+
+export function snapshotFeedQueries(queryClient: QueryClient): FeedQuerySnapshot {
+  return queryClient.getQueriesData<InfiniteData<FeedPage>>({ queryKey: ["feed"] });
+}
+
+export function restoreFeedQueries(queryClient: QueryClient, snapshot: FeedQuerySnapshot) {
+  snapshot.forEach(([queryKey, data]) => {
+    queryClient.setQueryData(queryKey, data);
+  });
 }

--- a/lib/feed-query.ts
+++ b/lib/feed-query.ts
@@ -32,7 +32,10 @@ export function updateDeckLikeInFeedData(
       ...page,
       decks: page.decks.map((deck) => {
         if (deck.id !== deckId) return deck;
-        const othersLikeCountBaseline = deck.like_count - (deck.likedByMe ? 1 : 0);
+        const othersLikeCountBaseline = Math.max(
+          0,
+          deck.like_count - (deck.likedByMe ? 1 : 0),
+        );
         return {
           ...deck,
           likedByMe: like.liked,

--- a/lib/feed-query.ts
+++ b/lib/feed-query.ts
@@ -1,7 +1,5 @@
-import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query";
+import type { InfiniteData } from "@tanstack/react-query";
 import type { FeedPage, FeedSort } from "@/app/actions/feed";
-
-export type FeedQuerySnapshot = Array<[QueryKey, InfiniteData<FeedPage> | undefined]>;
 
 export function feedQueryKey(input: { sort: FeedSort; query?: string }) {
   return ["feed", { sort: input.sort, query: input.query ?? null }] as const;
@@ -26,25 +24,7 @@ export function mergeFeedPages(pages: FeedPage[]): FeedPage {
 export function updateDeckLikeInFeedData(
   data: InfiniteData<FeedPage>,
   deckId: string,
-  like: { liked: boolean; count: number },
-): InfiniteData<FeedPage> {
-  return {
-    pageParams: data.pageParams,
-    pages: data.pages.map((page) => ({
-      ...page,
-      decks: page.decks.map((deck) =>
-        deck.id === deckId
-          ? { ...deck, likedByMe: like.liked, like_count: like.count }
-          : deck,
-      ),
-    })),
-  };
-}
-
-export function applyOptimisticDeckLikeInFeedData(
-  data: InfiniteData<FeedPage>,
-  deckId: string,
-  liked: boolean,
+  like: { liked: boolean },
 ): InfiniteData<FeedPage> {
   return {
     pageParams: data.pageParams,
@@ -52,19 +32,13 @@ export function applyOptimisticDeckLikeInFeedData(
       ...page,
       decks: page.decks.map((deck) => {
         if (deck.id !== deckId) return deck;
-        const delta = deck.likedByMe === liked ? 0 : liked ? 1 : -1;
-        return { ...deck, likedByMe: liked, like_count: deck.like_count + delta };
+        const othersLikeCountBaseline = deck.like_count - (deck.likedByMe ? 1 : 0);
+        return {
+          ...deck,
+          likedByMe: like.liked,
+          like_count: othersLikeCountBaseline + (like.liked ? 1 : 0),
+        };
       }),
     })),
   };
-}
-
-export function snapshotFeedQueries(queryClient: QueryClient): FeedQuerySnapshot {
-  return queryClient.getQueriesData<InfiniteData<FeedPage>>({ queryKey: ["feed"] });
-}
-
-export function restoreFeedQueries(queryClient: QueryClient, snapshot: FeedQuerySnapshot) {
-  snapshot.forEach(([queryKey, data]) => {
-    queryClient.setQueryData(queryKey, data);
-  });
 }


### PR DESCRIPTION
## 요약
- 좋아요 버튼 클릭 시 feed/search React Query cache의 `likedByMe`와 표시 count를 즉시 갱신합니다.
- 표시 count는 ADR 0017의 `othersLikeCountBaseline + (likedByMe ? 1 : 0)` 모델을 따릅니다.
- 서버 응답의 `likeCount`로 모든 feed/search cache를 매번 덮어쓰지 않습니다.
- debounce/retry 기반 기존 토글 흐름은 유지합니다.

## 범위
- 이 PR은 좋아요/취소 반응성과 feed/search cache 반영만 다룹니다.
- 댓글 lazy loading은 후속 작업입니다.

## 검증
- `TMPDIR=/tmp npm test -- lib/feed-query.test.ts lib/optimistic-like.test.ts`
- `npm run typecheck`
- `npm run lint`
- `TMPDIR=/tmp npm test`
- `npm run build`