### PR TITLE
docs(adr): 익명 세션 좋아요 표시 정책 정리

### DIFF
--- a/docs/adr/0002-ip-hash-for-likes.md
+++ b/docs/adr/0002-ip-hash-for-likes.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by [0017](./0017-anonymous-session-likes-and-local-count-display.md)
 
 ## Context
 

--- a/docs/adr/0017-anonymous-session-likes-and-local-count-display.md
+++ b/docs/adr/0017-anonymous-session-likes-and-local-count-display.md
@@ -1,0 +1,38 @@
+# 0017. 익명 세션 좋아요와 로컬 count 표시
+
+## Status
+
+Accepted
+
+## Context
+
+좋아요는 덱 디스커버리의 시그널이지만, 사용자가 체감하는 핵심 UX는 두 가지다.
+
+- 내가 이 덱에 좋아요를 눌렀는지
+- 버튼을 눌렀을 때 즉시 반응하는지
+
+기존 [0002](./0002-ip-hash-for-likes.md)는 IP hash를 좋아요 식별 기준으로 삼았다. 그러나 같은 IP를 공유하는 사용자가 서로의 좋아요 상태에 영향을 줄 수 있고, 로그인 없는 환경에서도 Supabase anonymous session이 있으므로 `likedByMe`와 toggle idempotency는 세션 기준이 더 적합하다.
+
+또한 `like_count`를 mutation마다 서버 최신값으로 전역 cache에 동기화하려 하면 overlapping mutation, stale query, rollback snapshot 문제가 커진다. 이 제품에서는 전체 좋아요 수의 실시간 정합성보다 개인 토글 반응성이 더 중요하다.
+
+## Decision
+
+- 좋아요 식별과 idempotency는 `likes.anon_id` 기준으로 처리한다.
+- `ip_hash`는 abuse/rate-limit/운영 분석 보조 신호로만 유지한다.
+- `likedByMe`는 익명 세션 기준으로 정확하게 표시한다.
+- `like_count`는 페이지 로드 시점 값 `n`을 기준으로 표시한다.
+- 이후 내 좋아요/취소는 `n + localDelta`로만 표현한다.
+  - 처음 안 누른 상태: `n -> n + 1 -> n`
+  - 처음 누른 상태: `n -> n - 1 -> n`
+- 좋아요/취소 클릭은 debounce해서 마지막 의도만 서버에 보낸다.
+- 서버 응답의 `likeCount`로 모든 feed/search cache를 매번 덮어쓰지 않는다.
+- 실패 시 내 로컬 토글 상태만 페이지 로드 기준으로 롤백한다.
+
+## Consequences
+
+- 목록의 `like_count`는 다른 사용자의 동시 좋아요를 즉시 반영하지 않을 수 있다.
+- 페이지를 새로 로드하거나 feed를 다시 가져오면 서버의 최신 count를 다시 기준값으로 삼는다.
+- 좋아요 UX는 단순해지고, cache rollback이 다른 덱이나 다른 query 상태를 덮어쓰는 위험이 줄어든다.
+- 정렬은 다음 feed fetch 시점의 서버 count에 따라 갱신된다.
+- `likedByMe`는 개인 상태이므로 전역 공개 feed cache에 섞어 저장하지 않는다.
+- 댓글 리액션이나 실시간 집계가 필요해지면 별도 ADR로 다룬다.

--- a/docs/adr/0017-anonymous-session-likes-and-local-count-display.md
+++ b/docs/adr/0017-anonymous-session-likes-and-local-count-display.md
@@ -13,25 +13,25 @@ Accepted
 
 기존 [0002](./0002-ip-hash-for-likes.md)는 IP hash를 좋아요 식별 기준으로 삼았다. 그러나 같은 IP를 공유하는 사용자가 서로의 좋아요 상태에 영향을 줄 수 있고, 로그인 없는 환경에서도 Supabase anonymous session이 있으므로 `likedByMe`와 toggle idempotency는 세션 기준이 더 적합하다.
 
-또한 `like_count`를 mutation마다 서버 최신값으로 전역 cache에 동기화하려 하면 overlapping mutation, stale query, rollback snapshot 문제가 커진다. 이 제품에서는 전체 좋아요 수의 실시간 정합성보다 개인 토글 반응성이 더 중요하다.
+또한 `like_count`를 mutation마다 서버 최신값으로 전역 cache에 동기화하려 하면 overlapping mutation, stale query, rollback snapshot 문제가 커진다. 이 제품에서는 전체 좋아요 수의 실시간 정합성보다 개인 토글 반응성과 일관된 자기 상태 표시가 더 중요하다.
 
 ## Decision
 
 - 좋아요 식별과 idempotency는 `likes.anon_id` 기준으로 처리한다.
 - `ip_hash`는 abuse/rate-limit/운영 분석 보조 신호로만 유지한다.
 - `likedByMe`는 익명 세션 기준으로 정확하게 표시한다.
-- `like_count`는 페이지 로드 시점 값 `n`을 기준으로 표시한다.
-- 이후 내 좋아요/취소는 `n + localDelta`로만 표현한다.
-  - 처음 안 누른 상태: `n -> n + 1 -> n`
-  - 처음 누른 상태: `n -> n - 1 -> n`
+- `like_count` 표시는 페이지 로드 시점의 "내 좋아요를 제외한 좋아요 수"를 기준값으로 삼는다.
+- 화면 표시값은 `othersLikeCountBaseline + (likedByMe ? 1 : 0)`로 계산한다.
+  - 처음 안 누른 상태: `othersBaseline = n`, 표시값 `n -> n + 1 -> n`
+  - 처음 누른 상태: `othersBaseline = n - 1`, 표시값 `n -> n - 1 -> n`
 - 좋아요/취소 클릭은 debounce해서 마지막 의도만 서버에 보낸다.
 - 서버 응답의 `likeCount`로 모든 feed/search cache를 매번 덮어쓰지 않는다.
-- 실패 시 내 로컬 토글 상태만 페이지 로드 기준으로 롤백한다.
+- 실패 시 `likedByMe`만 이전 상태로 롤백하고, 표시 count는 위 공식으로 다시 계산한다.
 
 ## Consequences
 
 - 목록의 `like_count`는 다른 사용자의 동시 좋아요를 즉시 반영하지 않을 수 있다.
-- 페이지를 새로 로드하거나 feed를 다시 가져오면 서버의 최신 count를 다시 기준값으로 삼는다.
+- 페이지를 새로 로드하거나 feed를 다시 가져오면 서버의 최신 count와 `likedByMe`로 `othersLikeCountBaseline`을 다시 계산한다.
 - 좋아요 UX는 단순해지고, cache rollback이 다른 덱이나 다른 query 상태를 덮어쓰는 위험이 줄어든다.
 - 정렬은 다음 feed fetch 시점의 서버 count에 따라 갱신된다.
 - `likedByMe`는 개인 상태이므로 전역 공개 feed cache에 섞어 저장하지 않는다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@
 
 ### 신원 / 인증
 - [0001](./0001-anon-auth-and-nick-pw-identity.md) — Supabase Anonymous Auth + 단일 nick/pw 자격증명
-- [0002](./0002-ip-hash-for-likes.md) — 좋아요는 IP 해시 단독 식별
+- [0002](./0002-ip-hash-for-likes.md) — 좋아요는 IP 해시 단독 식별 (Superseded by 0017)
 
 ### 게임 디자인 철학
 - [0003](./0003-no-public-user-leaderboard.md) — 사용자 점수 랭킹/리더보드 없음
@@ -31,6 +31,7 @@
 ### 엔지니어링
 - [0009](./0009-optimistic-locking-with-version.md) — 모든 액션에 expected_version 동봉
 - [0015](./0015-round-state-capture.md) — DailyWord에 active_word_ids 스냅샷 + 라운드는 date만 캡처
+- [0017](./0017-anonymous-session-likes-and-local-count-display.md) — 익명 세션 좋아요 + 페이지 로드 기준 로컬 count 표시
 
 ### 운영
 - [0011](./0011-operator-seed-via-public-api.md) — 운영자 시드 덱은 일반 API 호출 + 지속 업데이트


### PR DESCRIPTION
## 요약
- ADR 0017을 추가해 익명 세션 기준 좋아요와 로컬 count 표시 정책을 기록합니다.
- 기존 ADR 0002의 IP hash 단독 식별 결정을 `Superseded by 0017`로 표시합니다.
- ADR 인덱스를 갱신합니다.

## 결정 내용
- `likedByMe`와 좋아요 toggle idempotency는 `likes.anon_id` 기준으로 판단합니다.
- `ip_hash`는 abuse/rate-limit/운영 분석용 보조 신호로만 유지합니다.
- 좋아요 수 표시는 `othersLikeCountBaseline + (likedByMe ? 1 : 0)`로 계산합니다.
- 좋아요/취소 클릭은 debounce해서 마지막 의도만 서버에 보냅니다.
- 서버 응답의 `likeCount`로 모든 feed/search cache를 매 mutation마다 덮어쓰지 않습니다.

관련 이슈: #161