### PR TITLE
fix(likes): ack timeout과 최종 의도 수렴 처리

### DIFF
--- a/app/actions/like.ts
+++ b/app/actions/like.ts
@@ -115,6 +115,9 @@ export async function toggleLike(
           .select("deck_id");
         if (claimError?.code === PG_UNIQUE_VIOLATION) {
           const status = await currentStatus(deckId, anonId, ipHash);
+          if (status?.liked) {
+            return { success: true, data: status, message: "좋아요!" };
+          }
           return {
             success: false,
             conflict: true,
@@ -137,6 +140,9 @@ export async function toggleLike(
         .insert({ deck_id: deckId, anon_id: anonId, ip_hash: ipHash });
       if (error?.code === PG_UNIQUE_VIOLATION) {
         const status = await currentStatus(deckId, anonId, ipHash);
+        if (status?.liked) {
+          return { success: true, data: status, message: "좋아요!" };
+        }
         return {
           success: false,
           conflict: true,

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -6,19 +6,38 @@ import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { toggleLike } from "@/app/actions/like";
+import { getLikeStatus, toggleLike } from "@/app/actions/like";
 import type { FeedPage } from "@/app/actions/feed";
 import {
   initialLikeState,
   applyClick,
-  applyRollback,
+  applyServerLiked,
   clearPendingChange,
-  pendingServerDesired,
+  pendingLatestDesired,
   LIKE_DEBOUNCE_MS,
   type LikeState,
 } from "@/lib/optimistic-like";
 import { updateDeckLikeInFeedData } from "@/lib/feed-query";
 import { cn } from "@/lib/utils";
+
+const LIKE_ACK_TIMEOUT_MS = 5000;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("좋아요 응답 시간이 초과되었습니다.")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
 
 interface LikeButtonProps {
   deckId: string;
@@ -40,10 +59,11 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     () => Math.max(0, initialCount - (initialLiked ? 1 : 0)),
     [initialCount, initialLiked],
   );
-  const stateRef = useRef(state);
-  stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const serverTargetRef = useRef(initialLiked);
+  const latestDesiredRef = useRef(initialLiked);
+  const serverKnownRef = useRef(initialLiked);
+  const inFlightRef = useRef<LikeMutationInput | null>(null);
+  const flushRef = useRef<() => void>(() => {});
   const requestIdRef = useRef(0);
   const displayCount = othersLikeCountBaseline + (state.liked ? 1 : 0);
 
@@ -54,33 +74,85 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     );
   }, [deckId, queryClient]);
 
+  const reconcileLikeStatus = useCallback(async (options?: { adoptServerTruth?: boolean }) => {
+    const expectedDesired = latestDesiredRef.current;
+    try {
+      const result = await withTimeout(getLikeStatus(deckId), LIKE_ACK_TIMEOUT_MS);
+      if (!result.success || !result.data) return;
+      if (latestDesiredRef.current !== expectedDesired) return;
+
+      const reconciledLiked = result.data.liked;
+      serverKnownRef.current = reconciledLiked;
+      if (options?.adoptServerTruth || latestDesiredRef.current === reconciledLiked) {
+        latestDesiredRef.current = reconciledLiked;
+        setState((prev) => {
+          const next = applyServerLiked(prev, reconciledLiked);
+          syncFeedCache(next.liked);
+          return next;
+        });
+        return;
+      }
+
+      if (!debounceRef.current && !inFlightRef.current) {
+        setTimeout(() => flushRef.current(), 0);
+      }
+    } catch {
+      // Best-effort reconcile: the next navigation or query refetch can repair drift.
+    }
+  }, [deckId, syncFeedCache]);
+
   const likeMutation = useMutation({
     mutationFn: async ({ liked }: LikeMutationInput) => {
-      const result = await toggleLike(deckId, liked);
+      const result = await withTimeout(toggleLike(deckId, liked), LIKE_ACK_TIMEOUT_MS);
       if (!result.success) {
         throw new Error(result.message);
       }
+      return result.data?.liked ?? liked;
     },
     retry: 3,
-    onSuccess: (_data, variables) => {
-      if (variables.requestId !== requestIdRef.current) return;
-      setState((prev) => (prev.liked === variables.liked ? clearPendingChange(prev) : prev));
+    onSuccess: (serverLiked, variables) => {
+      if (variables.requestId !== inFlightRef.current?.requestId) return;
+      serverKnownRef.current = serverLiked;
+      setState((prev) => (
+        latestDesiredRef.current === serverKnownRef.current
+          ? clearPendingChange(prev)
+          : prev
+      ));
     },
     onError: (error, variables) => {
-      if (variables.requestId !== requestIdRef.current) return;
-      serverTargetRef.current = variables.previousLiked;
-      if (stateRef.current.liked !== variables.liked) return;
+      if (variables.requestId !== inFlightRef.current?.requestId) return;
+      serverKnownRef.current = variables.previousLiked;
+      if (latestDesiredRef.current !== variables.liked) {
+        void reconcileLikeStatus();
+        return;
+      }
+      latestDesiredRef.current = variables.previousLiked;
       setState((prev) => {
-        const next = applyRollback(prev);
+        const next = applyServerLiked(prev, variables.previousLiked);
         syncFeedCache(next.liked);
         return next;
       });
       toast.error(error instanceof Error ? error.message : t('networkError'));
+      void reconcileLikeStatus({ adoptServerTruth: true });
+    },
+    onSettled: (_data, _error, variables) => {
+      if (variables.requestId !== inFlightRef.current?.requestId) return;
+      inFlightRef.current = null;
+      if (
+        !debounceRef.current &&
+        pendingLatestDesired(latestDesiredRef.current, serverKnownRef.current, false) !== null
+      ) {
+        setTimeout(() => flushRef.current(), 0);
+      }
     },
   });
 
-  const flush = () => {
-    const desired = pendingServerDesired(stateRef.current, serverTargetRef.current);
+  const flush = useCallback(() => {
+    const desired = pendingLatestDesired(
+      latestDesiredRef.current,
+      serverKnownRef.current,
+      inFlightRef.current !== null,
+    );
     if (desired === null) {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
       setState((prev) => clearPendingChange(prev));
@@ -89,25 +161,32 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
-    const previousLiked = serverTargetRef.current;
-    serverTargetRef.current = desired;
-    likeMutation.mutate({ liked: desired, previousLiked, requestId });
-  };
+    const variables = { liked: desired, previousLiked: serverKnownRef.current, requestId };
+    inFlightRef.current = variables;
+    likeMutation.mutate(variables);
+  }, [likeMutation]);
+
+  flushRef.current = flush;
 
   const handleClick = () => {
     setState((prev) => {
       const next = applyClick(prev); // 즉시 반영 (AC)
+      latestDesiredRef.current = next.liked;
       syncFeedCache(next.liked);
       return next;
     });
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => void flush(), LIKE_DEBOUNCE_MS); // 200ms debounce (AC)
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      flushRef.current();
+    }, LIKE_DEBOUNCE_MS); // 200ms debounce (AC)
   };
 
   useEffect(() => {
     setState((prev) => {
       if (prev.snapshot) return prev;
-      serverTargetRef.current = initialLiked;
+      latestDesiredRef.current = initialLiked;
+      serverKnownRef.current = initialLiked;
       return initialLikeState(initialLiked, initialCount);
     });
   }, [initialLiked, initialCount]);
@@ -115,6 +194,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = null;
     };
   }, []);
 

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -11,7 +11,9 @@ import type { FeedPage } from "@/app/actions/feed";
 import {
   initialLikeState,
   applyClick,
+  applyServerLiked,
   applyRollback,
+  clearPendingChange,
   pendingDesired,
   LIKE_DEBOUNCE_MS,
   type LikeState,
@@ -49,7 +51,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     const desired = pendingDesired(stateRef.current);
     if (desired === null) {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
-      setState((prev) => ({ ...prev, snapshot: null }));
+      setState((prev) => clearPendingChange(prev));
       return;
     }
 
@@ -58,7 +60,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     if (!result) result = await send().catch(() => null); // 네트워크 실패 1회 재시도 (AC)
 
     if (result?.success && result.data) {
-      setState((prev) => ({ ...prev, liked: result.data!.liked, snapshot: null }));
+      setState((prev) => applyServerLiked(prev, result.data!.liked));
       syncFeedCache(result.data.liked);
     } else {
       setState((prev) => {

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -13,6 +13,8 @@ import {
   applyClick,
   applyServerLiked,
   clearPendingChange,
+  canSyncInitialLikeState,
+  getLikeFlushDecision,
   pendingLatestDesired,
   LIKE_DEBOUNCE_MS,
   type LikeState,
@@ -148,12 +150,13 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   });
 
   const flush = useCallback(() => {
-    const desired = pendingLatestDesired(
+    const decision = getLikeFlushDecision(
       latestDesiredRef.current,
       serverKnownRef.current,
       inFlightRef.current !== null,
     );
-    if (desired === null) {
+    if (decision.type === "defer") return;
+    if (decision.type === "clear") {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
       setState((prev) => clearPendingChange(prev));
       return;
@@ -161,6 +164,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    const desired = decision.liked;
     const variables = { liked: desired, previousLiked: serverKnownRef.current, requestId };
     inFlightRef.current = variables;
     likeMutation.mutate(variables);
@@ -184,7 +188,16 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
 
   useEffect(() => {
     setState((prev) => {
-      if (prev.snapshot) return prev;
+      if (
+        !canSyncInitialLikeState(
+          prev,
+          latestDesiredRef.current,
+          serverKnownRef.current,
+          inFlightRef.current !== null,
+        )
+      ) {
+        return prev;
+      }
       latestDesiredRef.current = initialLiked;
       serverKnownRef.current = initialLiked;
       return initialLikeState(initialLiked, initialCount);

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import { useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Heart } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { toggleLike, type LikeActionResponse } from "@/app/actions/like";
+import { toggleLike } from "@/app/actions/like";
 import type { FeedPage } from "@/app/actions/feed";
 import {
   initialLikeState,
   applyClick,
-  applyServerLiked,
   applyRollback,
   clearPendingChange,
-  pendingDesired,
+  pendingServerDesired,
   LIKE_DEBOUNCE_MS,
   type LikeState,
 } from "@/lib/optimistic-like";
@@ -25,6 +24,12 @@ interface LikeButtonProps {
   deckId: string;
   initialCount: number;
   initialLiked: boolean;
+}
+
+interface LikeMutationInput {
+  liked: boolean;
+  previousLiked: boolean;
+  requestId: number;
 }
 
 export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonProps) {
@@ -38,6 +43,8 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   const stateRef = useRef(state);
   stateRef.current = state;
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const serverTargetRef = useRef(initialLiked);
+  const requestIdRef = useRef(0);
   const displayCount = othersLikeCountBaseline + (state.liked ? 1 : 0);
 
   const syncFeedCache = useCallback((liked: boolean) => {
@@ -47,29 +54,44 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
     );
   }, [deckId, queryClient]);
 
-  const flush = async () => {
-    const desired = pendingDesired(stateRef.current);
+  const likeMutation = useMutation({
+    mutationFn: async ({ liked }: LikeMutationInput) => {
+      const result = await toggleLike(deckId, liked);
+      if (!result.success) {
+        throw new Error(result.message);
+      }
+    },
+    retry: 3,
+    onSuccess: (_data, variables) => {
+      if (variables.requestId !== requestIdRef.current) return;
+      setState((prev) => (prev.liked === variables.liked ? clearPendingChange(prev) : prev));
+    },
+    onError: (error, variables) => {
+      if (variables.requestId !== requestIdRef.current) return;
+      serverTargetRef.current = variables.previousLiked;
+      if (stateRef.current.liked !== variables.liked) return;
+      setState((prev) => {
+        const next = applyRollback(prev);
+        syncFeedCache(next.liked);
+        return next;
+      });
+      toast.error(error instanceof Error ? error.message : t('networkError'));
+    },
+  });
+
+  const flush = () => {
+    const desired = pendingServerDesired(stateRef.current, serverTargetRef.current);
     if (desired === null) {
       // 연타로 원위치 — 전송 생략, snapshot만 해제
       setState((prev) => clearPendingChange(prev));
       return;
     }
 
-    const send = (): Promise<LikeActionResponse> => toggleLike(deckId, desired);
-    let result = await send().catch(() => null);
-    if (!result) result = await send().catch(() => null); // 네트워크 실패 1회 재시도 (AC)
-
-    if (result?.success && result.data) {
-      setState((prev) => applyServerLiked(prev, result.data!.liked));
-      syncFeedCache(result.data.liked);
-    } else {
-      setState((prev) => {
-        const next = applyRollback(prev);
-        syncFeedCache(next.liked);
-        return next;
-      });
-      toast.error(result?.message ?? t('networkError'));
-    }
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const previousLiked = serverTargetRef.current;
+    serverTargetRef.current = desired;
+    likeMutation.mutate({ liked: desired, previousLiked, requestId });
   };
 
   const handleClick = () => {
@@ -85,6 +107,7 @@ export function LikeButton({ deckId, initialCount, initialLiked }: LikeButtonPro
   useEffect(() => {
     setState((prev) => {
       if (prev.snapshot) return prev;
+      serverTargetRef.current = initialLiked;
       return initialLikeState(initialLiked, initialCount);
     });
   }, [initialLiked, initialCount]);

--- a/docs/feature/likes-flow.md
+++ b/docs/feature/likes-flow.md
@@ -1,74 +1,67 @@
-# 덱 목록 페이지 좋아요 기능 흐름
+# 좋아요 흐름
 
-interface DeckWithLikes extends Deck {
-  likeCount: number;
-  isLiked: boolean;
-}
+## 목표
 
-getDecks(queryKey, userId?)
+- 좋아요 버튼은 클릭 즉시 반응한다.
+- 서버 write는 같은 버튼 instance 기준 in-flight 요청 1개만 허용한다.
+- ack timeout/retry 후 최종 실패하면 마지막 서버 ack 기준 `likedByMe`로 롤백한다.
+- 표시 count는 정확한 global count가 아니라 ADR 0017의 로컬 공식으로 계산한다.
 
-- const [likeState, setLikeState] = useState({
-    likes: initialLikes,
-    isLiked: initialIsLiked,
-  });
+## 상태
 
-  const [optimisticState, addOptimisticState] = useOptimistic(
-    likeState,
-    // 실제 상태, addOptimisticState(가짜 상태 업데이트)의 인자
-    (currentState, optimisticUpdate) => {
-      const action = optimisticUpdate.action;
+- `latestDesiredRef`: 사용자의 최신 liked 의도
+- `serverKnownRef`: 마지막 ack 기준 서버 liked 상태
+- `inFlightRef`: 아직 success/error/timeout 처리가 끝나지 않은 서버 요청
+- `otherLikesBaseline`: 페이지 로드 시점의 내 좋아요 제외 count 기준값
 
-      if (action === "LIKE") {
-        return { likes: currentState.likes + 1, isLiked: true };
-      } else if (action === "DISLIKE") {
-        return { likes: currentState.likes - 1, isLiked: false };
-      }
-      return currentState;
-    }
-  );
+## 표시 Count
 
-  const handleLike = async () => {
-    const newIsLiked = !optimisticState.isLiked;
-    const action = newIsLiked ? "LIKE" : "DISLIKE";
+```text
+displayCount = otherLikesBaseline + (likedByMe ? 1 : 0)
+```
 
-    // 1. 낙관적 업데이트: UI를 즉시 변경
-    addOptimisticState({ action: action });
-    
-    try {
-      // 2. 서버에 요청 전송
-      await updateLikeStatus(postId, newIsLiked);
+- 서버 ack의 `likeCount`로 버튼 count를 즉시 덮어쓰지 않는다.
+- 다음 page load/feed refetch 때 최신 `like_count`와 `likedByMe`로 baseline을 다시 계산한다.
 
-      // 3. 서버 요청 성공: 실제 상태를 업데이트하여 낙관적 상태를 최종 상태로 확정
-      // startTransition을 사용하여 상태 업데이트가 UI 블로킹을 일으키지 않도록 합니다.
-      startTransition(() => {
-        setState({ likes: optimisticState.likes, isLiked: newIsLiked });
-      });
+## 클릭 흐름
 
-    } catch (error) {
-      // 4. 서버 요청 실패: 실제 상태가 변경되지 않았으므로
-      // useOptimistic이 자동으로 낙관적 상태를 **초기 상태 (state)**로 롤백합니다.
-      console.error(error.message);
-      // 사용자에게 실패 알림 등을 추가할 수 있습니다.
-      alert("좋아요 처리 실패: " + error.message); 
-      
-      // setState 호출이 없어도, useOptimistic의 내부 메커니즘이 
-      // 비동기 작업(updateLikeStatus)이 끝났을 때 현재의 'state' 값으로 
-      // 'optimisticState'를 재설정합니다.
-    }
-  };
+```text
+click
+→ latestDesiredRef + optimistic UI/cache update
+→ debounce
+→ no in-flight && latestDesired != serverKnown 이면 setLike(latestDesired)
+```
 
-- likeCount, isLiked (optimistically update)
-- toggleLike(deck.id)
-  - if (isLiked) {
-    setIsLiked(false)
-    setLikeCount(prev => prev - 1)
-    startTransition(() => {
-      deleteLike(deck.id)
-    })
-  } else {
-    setIsLiked(true)
-    setLikeCount(prev => prev + 1)
-    startTransition(() => {
-      createLike(deck.id)
-    })
-  }
+- 사용자가 in-flight 중 다시 누르면 UI/cache만 즉시 바꾼다.
+- 새 서버 요청은 기존 요청의 ack/timeout 처리가 끝난 뒤 보낸다.
+
+## Ack 흐름
+
+```text
+ack success
+→ serverKnownRef 갱신
+→ serverKnown != latestDesired 이면 최신 의도 재전송
+```
+
+- 성공 응답은 버튼 count를 덮어쓰지 않는다.
+- 오래된 응답은 UI/cache를 직접 덮어쓰지 않는다.
+
+## Timeout / 실패 흐름
+
+```text
+ack timeout
+→ mutation error
+→ React Query retry
+→ retries exhausted
+→ toast + rollback likedByMe to serverKnownRef
+→ best-effort getLikeStatus reconcile
+```
+
+- timeout은 서버 write 취소가 아니라 "ack 미수신"이다.
+- reconcile이 실패하면 다음 navigation/refetch가 eventual drift를 복구한다.
+
+## 서버 액션
+
+- `setLike(true)`는 이미 liked여도 success다.
+- `setLike(false)`는 이미 unliked여도 success다.
+- hidden deck conflict는 실패로 유지한다.

--- a/docs/superpowers/plans/2026-06-18-like-ack-timeout.md
+++ b/docs/superpowers/plans/2026-06-18-like-ack-timeout.md
@@ -1,0 +1,331 @@
+# Like Ack Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 좋아요 UI는 즉시 반응시키되, 서버 write는 in-flight 요청 1개로 제한하고 ack timeout/retry 후 최종 실패 시 올바른 서버 기준 상태로 롤백한다.
+
+**Architecture:** `LikeButton`은 `latestDesiredRef`(현재 사용자의 최신 의도), `serverKnownRef`(마지막 ack 기준 liked 상태), `inFlightRef`(응답 대기 중인 서버 write)를 분리한다. 클릭은 ref/UI/cache를 동기적으로 바꾸고, debounce 후 in-flight가 없을 때만 `setLike(desired)`를 보낸다. ack 또는 timeout/retry 종료 후 `serverKnownRef.current !== latestDesiredRef.current`이면 다음 desired를 다시 전송해 최종 상태로 수렴한다. 표시 count는 ADR 0017에 따라 `otherLikesBaseline + (latestDesired ? 1 : 0)`로 계산하고, 서버 ack의 `likeCount`로 즉시 덮어쓰지 않는다.
+
+**Tech Stack:** Next.js Server Actions, React Query mutation, Supabase service-role client, Vitest, Playwright smoke test.
+
+---
+
+## File Map
+
+- Modify: `components/LikeButton.tsx`
+  - in-flight 요청 1개 제한
+  - ack timeout wrapper
+  - React state timing에 기대지 않는 `latestDesiredRef`/`serverKnownRef` 비교
+  - 최종 실패 시 toast + `serverKnownRef` 롤백
+  - terminal timeout/failure 후 best-effort 상태 재조회
+- Modify: `lib/optimistic-like.ts`
+  - snapshot rollback보다 마지막 서버 기준 liked rollback을 우선 사용
+  - 표시 count는 reducer count가 아니라 `otherLikesBaseline + userLike` 공식이 담당
+- Modify: `lib/optimistic-like.test.ts`
+  - ack 후 반대 의도 재전송 조건
+  - 최종 실패 시 서버 기준 롤백 조건
+  - ack timeout 이후 retry 대상 error 경로
+- Modify: `app/actions/like.ts`
+  - `toggleLike(deckId, like)`를 desired-state 멱등 처리로 정리
+  - `like=true`인데 이미 liked면 success
+  - `like=false`인데 이미 liked row가 없어도 success
+- Modify after implementation: `docs/feature/likes-flow.md`
+  - 현재 문서는 `useOptimistic` 예시 중심이라 실제 React Query reducer 흐름으로 갱신
+
+## Policy
+
+- 이 이슈에서는 DB `version` 컬럼을 추가하지 않는다.
+- 좋아요는 0/1 상태이므로 `setLike(true/false)` 멱등 처리와 최종 desired 재전송으로 수렴시킨다.
+- `retry: 3`은 최초 시도 후 최대 3회 재시도(총 4 attempts)를 뜻한다.
+- ack timeout은 "서버 변경 실패"가 아니라 "클라이언트가 ack를 받지 못함"으로 취급한다.
+- `Promise.race` timeout은 server action을 취소하지 못한다. timeout된 원 요청의 late success는 완전히 판별할 수 없으므로 terminal failure 후 best-effort refetch/reconcile을 수행한다.
+- 클라이언트 표시 count는 정확한 global count가 아니어도 된다. 표시값은 `otherLikesBaseline + (likedByMe ? 1 : 0)`로만 계산한다.
+- 서버 ack/reconcile은 `likedByMe` 수렴에 집중한다. `likeCount`는 다음 page load/feed refetch 때 baseline 재계산에만 사용한다.
+- in-flight 제한 범위는 mounted `LikeButton` instance다. 같은 deck의 버튼을 한 화면에 여러 개 동시에 mount하는 요구가 생기면 per-deck coordinator를 별도 설계한다.
+- 중요한 write 모델에 필요한 optimistic lock/version/idempotency key는 별도 설계 범위다.
+
+## Rejected Alternatives
+
+- `serverKnownRef`를 `{ liked, count }`로 들고 `applyServerKnown(state, { liked, count })` helper를 추가하는 계획은 반려한다.
+  - 이유: ADR 0017 기준으로 버튼 표시 count는 정확한 global count가 아니어도 된다.
+  - 표시 count는 `otherLikesBaseline + userLike` 공식으로만 계산한다.
+  - 서버 ack/reconcile의 `likeCount`를 즉시 반영하면 feed/search cache churn과 rollback 복잡도가 다시 커진다.
+- 서버 ack의 `likeCount`로 버튼 표시 count를 즉시 덮어쓰는 계획은 반려한다.
+  - 이유: 다른 사용자의 동시 좋아요까지 실시간 반영하려는 목표가 아니다.
+  - `likeCount`는 다음 page load/feed refetch 때 새 baseline 계산에만 사용한다.
+- 이 이슈에서 DB `version` 또는 operation-id를 추가하는 계획은 반려한다.
+  - 이유: 좋아요는 낮은 중요도의 0/1 상태이고, 현재 목표는 사용자 반응성과 최종 desired 수렴이다.
+  - 결제/문서 저장 같은 중요한 write에는 별도 optimistic lock/idempotency 설계가 필요하다.
+- ack 전까지 버튼을 비활성화하는 계획은 반려한다.
+  - 이유: 좋아요의 핵심 UX는 즉시 반응이다.
+  - 서버 write만 in-flight 1개로 제한하고, UI/cache는 계속 낙관적으로 갱신한다.
+
+## Task 1: Reducer Semantics
+
+**Files:**
+- Modify: `lib/optimistic-like.ts`
+- Modify: `lib/optimistic-like.test.ts`
+
+- [ ] **Step 1: Add a failing test for server-known rollback**
+
+Add this test to `lib/optimistic-like.test.ts`:
+
+```ts
+it('최종 실패 시 최초 snapshot이 아니라 마지막 서버 기준 liked로 롤백한다', () => {
+  let state = initialLikeState(false, 10);
+  state = applyClick(state); // optimistic liked
+  state = applyServerLiked(state, true); // first ack confirmed liked
+  state = applyClick(state); // user now wants unliked
+
+  state = applyServerLiked(state, true); // unlike failed after retries; server remains liked
+
+  expect(state.liked).toBe(true);
+  expect(state.snapshot).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the focused reducer test**
+
+Run: `TMPDIR=/tmp npm test -- lib/optimistic-like.test.ts`
+
+Expected before implementation: the new expectation should expose whether server-known rollback is expressible with the helper API.
+
+- [ ] **Step 3: Keep rollback liked-only**
+
+Use `applyServerLiked(state, serverKnownLiked)` for final failure rollback in `LikeButton`.
+
+Do not add count reconciliation to the reducer for this issue. `LikeButton` display should compute:
+
+```ts
+const displayCount = othersLikeCountBaseline + (state.liked ? 1 : 0);
+```
+
+Do not use `applyRollback` for mutation retry exhaustion, because `applyRollback` restores the first optimistic snapshot and can be stale after an earlier ack.
+
+- [ ] **Step 4: Run the focused reducer test again**
+
+Run: `TMPDIR=/tmp npm test -- lib/optimistic-like.test.ts`
+
+Expected: PASS.
+
+## Task 2: In-Flight Request Limit
+
+**Files:**
+- Modify: `components/LikeButton.tsx`
+
+- [ ] **Step 1: Add refs for server/write coordination**
+
+Add refs with these responsibilities:
+
+```ts
+const latestDesiredRef = useRef(initialLiked);
+const serverKnownRef = useRef(initialLiked);
+const inFlightRef = useRef<LikeMutationInput | null>(null);
+const flushRef = useRef<() => void>(() => {});
+```
+
+- [ ] **Step 2: Change flush to skip while one request is in-flight**
+
+`flush` should:
+
+```ts
+if (inFlightRef.current) return;
+
+const desired = latestDesiredRef.current;
+if (desired === serverKnownRef.current) {
+  setState((prev) => clearPendingChange(prev));
+  return;
+}
+
+const variables = {
+  liked: desired,
+  previousLiked: serverKnownRef.current,
+  requestId: requestIdRef.current + 1,
+};
+requestIdRef.current = variables.requestId;
+inFlightRef.current = variables;
+likeMutation.mutate(variables);
+```
+
+- [ ] **Step 3: On ack, compare server-known with latest desired**
+
+On mutation success:
+
+```ts
+serverKnownRef.current = variables.liked;
+setState((prev) => (
+  latestDesiredRef.current === serverKnownRef.current
+    ? clearPendingChange(prev)
+    : prev
+));
+```
+
+On mutation settled:
+
+```ts
+if (variables.requestId !== inFlightRef.current?.requestId) return;
+inFlightRef.current = null;
+if (!debounceRef.current && latestDesiredRef.current !== serverKnownRef.current) {
+  setTimeout(() => flushRef.current(), 0);
+}
+```
+
+- [ ] **Step 4: Preserve optimistic UI on every click and clear debounce refs**
+
+`handleClick` still calls `applyClick` and `syncFeedCache(next.liked)` immediately. It must also update `latestDesiredRef.current = next.liked` inside the state updater. The button should not be disabled while a request is in-flight.
+
+When the debounce timer fires, clear the ref before flushing:
+
+```ts
+debounceRef.current = setTimeout(() => {
+  debounceRef.current = null;
+  flushRef.current();
+}, LIKE_DEBOUNCE_MS);
+```
+
+Assign `flushRef.current = flush` every render or in an effect so `onSettled` calls the latest flush function.
+
+## Task 3: Ack Timeout and Retry
+
+**Files:**
+- Modify: `components/LikeButton.tsx`
+
+- [ ] **Step 1: Define an ack timeout constant**
+
+Add a local constant near `LIKE_DEBOUNCE_MS` usage:
+
+```ts
+const LIKE_ACK_TIMEOUT_MS = 5000;
+```
+
+- [ ] **Step 2: Wrap the server action with timeout**
+
+Add a helper in `components/LikeButton.tsx`:
+
+```ts
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("좋아요 응답 시간이 초과되었습니다.")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+```
+
+- [ ] **Step 3: Make timeout participate in React Query retry**
+
+Use the helper in `mutationFn`:
+
+```ts
+const result = await withTimeout(toggleLike(deckId, liked), LIKE_ACK_TIMEOUT_MS);
+if (!result.success) {
+  throw new Error(result.message);
+}
+return result.data;
+```
+
+Keep `retry: 3`.
+
+- [ ] **Step 4: Roll back only after all retries fail**
+
+In `onError`, for the latest in-flight request:
+
+```ts
+serverKnownRef.current = variables.previousLiked;
+latestDesiredRef.current = variables.previousLiked;
+setState((prev) => {
+  const next = applyServerLiked(prev, variables.previousLiked);
+  syncFeedCache(next.liked);
+  return next;
+});
+toast.error(error instanceof Error ? error.message : t("networkError"));
+```
+
+If `latestDesiredRef.current !== variables.liked`, skip rollback/toast and let `onSettled` send the current latest desired if needed.
+
+- [ ] **Step 5: Reconcile after terminal timeout/failure**
+
+After terminal failure, call `getLikeStatus(deckId)` with the same timeout as a best-effort reconcile. If it succeeds, update `serverKnownRef` with the returned liked truth. Adopt that server truth into `latestDesiredRef` and local UI only when no newer local intent appeared while reconcile was pending; otherwise keep the user's latest desired and schedule a follow-up flush. Do not overwrite the button display count with `likeCount`; keep `otherLikesBaseline + userLike` until the next page load/feed refetch recomputes the baseline. If reconcile also fails, keep the rollback and let the next navigation/refetch repair eventual drift.
+
+## Task 4: Server Desired-State Idempotence
+
+**Files:**
+- Modify: `app/actions/like.ts`
+
+- [ ] **Step 1: Treat already-liked as desired success**
+
+For `like=true`, if legacy claim or insert hits `PG_UNIQUE_VIOLATION`, call `currentStatus`. If `status?.liked === true`, return success with that status instead of conflict.
+
+- [ ] **Step 2: Treat already-unliked as desired success**
+
+For `like=false`, a delete that affects no rows is still success. Keep the final `currentStatus` return path.
+
+- [ ] **Step 3: Preserve hidden-deck conflict**
+
+Do not change the hidden deck branch. Hidden deck should still return `success: false, conflict: true`.
+
+## Task 5: Verification
+
+**Files:**
+- Modify: `docs/feature/likes-flow.md`
+- Modify: `lib/optimistic-like.test.ts`
+
+- [ ] **Step 1: Update the feature document**
+
+Replace the `useOptimistic` example with this concise flow:
+
+```text
+click -> optimistic UI/cache update
+count -> otherLikesBaseline + userLike
+debounce -> send setLike(desired) only if no in-flight request
+ack -> update serverKnown
+serverKnown != latestDesired -> send latest desired again
+ack timeout -> React Query retry
+all retries failed -> toast + rollback to serverKnown
+terminal timeout/failure -> best-effort getLikeStatus reconcile
+```
+
+- [ ] **Step 2: Add a callback-ordering regression test**
+
+Add a pure regression test that models this order without React rendering:
+
+```text
+initial unliked
+click like -> latestDesired true, send like=true
+click unlike while request in-flight -> latestDesired false, do not send
+ack like=true -> serverKnown true
+settled -> latestDesired false differs, next flush sends like=false
+final failure of like=false -> rollback to serverKnown true
+```
+
+The assertion should prove the decision logic uses `latestDesiredRef`/`serverKnownRef` values, not a possibly stale React `stateRef.current`.
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `TMPDIR=/tmp npm test -- lib/optimistic-like.test.ts lib/feed-query.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full local checks**
+
+Run:
+
+```bash
+npm run typecheck
+npm run lint
+TMPDIR=/tmp npm test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run build**
+
+Run: `npm run build`
+
+Expected: PASS. If the sandbox blocks Turbopack port binding, rerun with approved escalation and record that in the PR.

--- a/lib/optimistic-like.test.ts
+++ b/lib/optimistic-like.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   initialLikeState,
   applyClick,
-  applyServerConfirm,
+  applyServerLiked,
+  clearPendingChange,
   applyRollback,
   pendingDesired,
 } from './optimistic-like';
@@ -15,10 +16,10 @@ describe('낙관적 좋아요 — 성공 시나리오 (AC)', () => {
     expect(pendingDesired(state)).toBe(true);
   });
 
-  it('서버 200 + 새 like_count 반환 시 서버 값으로 동기화', () => {
+  it('서버 200 반환 시 liked만 서버 값으로 확정한다', () => {
     let state = applyClick(initialLikeState(false, 10));
-    state = applyServerConfirm(state, { liked: true, count: 13 }); // 다른 세션 좋아요 누적 반영
-    expect(state).toEqual({ liked: true, count: 13, snapshot: null });
+    state = applyServerLiked(state, true);
+    expect(state).toEqual({ liked: true, count: 11, snapshot: null });
   });
 });
 
@@ -50,6 +51,7 @@ describe('낙관적 좋아요 — debounce 연타 수렴 (AC)', () => {
     expect(state.liked).toBe(false);
     expect(state.count).toBe(10);
     expect(pendingDesired(state)).toBeNull();
+    expect(clearPendingChange(state)).toEqual({ liked: false, count: 10, snapshot: null });
   });
 
   it('연타 후 최종 상태만 desired로 전송된다 (마지막 상태가 서버 진실로 수렴)', () => {

--- a/lib/optimistic-like.test.ts
+++ b/lib/optimistic-like.test.ts
@@ -8,6 +8,8 @@ import {
   pendingDesired,
   pendingServerDesired,
   pendingLatestDesired,
+  getLikeFlushDecision,
+  canSyncInitialLikeState,
 } from './optimistic-like';
 
 describe('낙관적 좋아요 — 성공 시나리오 (AC)', () => {
@@ -104,5 +106,21 @@ describe('낙관적 좋아요 — debounce 연타 수렴 (AC)', () => {
     serverKnown = true; // like=true ack
     hasInFlight = false;
     expect(pendingLatestDesired(latestDesired, serverKnown, hasInFlight)).toBe(false);
+  });
+
+  it('in-flight 중 debounce flush는 pending marker를 clear하지 않고 defer한다', () => {
+    expect(getLikeFlushDecision(false, true, true)).toEqual({ type: "defer" });
+    expect(getLikeFlushDecision(false, true, false)).toEqual({ type: "send", liked: false });
+    expect(getLikeFlushDecision(true, true, false)).toEqual({ type: "clear" });
+  });
+
+  it('in-flight 또는 미수렴 의도가 있으면 initial props sync를 보류한다', () => {
+    const settled = initialLikeState(false, 10);
+    const pending = applyClick(settled);
+
+    expect(canSyncInitialLikeState(settled, false, false, false)).toBe(true);
+    expect(canSyncInitialLikeState(settled, false, true, true)).toBe(false);
+    expect(canSyncInitialLikeState(settled, false, true, false)).toBe(false);
+    expect(canSyncInitialLikeState(pending, true, false, false)).toBe(false);
   });
 });

--- a/lib/optimistic-like.test.ts
+++ b/lib/optimistic-like.test.ts
@@ -7,6 +7,7 @@ import {
   applyRollback,
   pendingDesired,
   pendingServerDesired,
+  pendingLatestDesired,
 } from './optimistic-like';
 
 describe('낙관적 좋아요 — 성공 시나리오 (AC)', () => {
@@ -42,6 +43,18 @@ describe('낙관적 좋아요 — 롤백 시나리오 (AC)', () => {
     const state = initialLikeState(false, 10);
     expect(applyRollback(state)).toEqual(state);
   });
+
+  it('재시도 최종 실패 시 최초 snapshot이 아니라 마지막 서버 ack 기준 liked로 롤백한다', () => {
+    let state = initialLikeState(false, 10);
+    state = applyClick(state); // like=true 요청
+    state = applyServerLiked(state, true); // 서버가 liked를 ack
+    state = applyClick(state); // unlike=false 요청
+
+    state = applyServerLiked(state, true); // unlike 실패, 서버 기준은 liked 유지
+
+    expect(state.liked).toBe(true);
+    expect(state.snapshot).toBeNull();
+  });
 });
 
 describe('낙관적 좋아요 — debounce 연타 수렴 (AC)', () => {
@@ -74,5 +87,22 @@ describe('낙관적 좋아요 — debounce 연타 수렴 (AC)', () => {
     state = applyClick(state); // like=true 요청이 이미 나간 직후 unlike
     expect(pendingDesired(state)).toBeNull();
     expect(pendingServerDesired(state, true)).toBe(false);
+  });
+
+  it('in-flight 중에는 새 요청을 보류하고 ack 후 최신 의도로 후속 전송한다', () => {
+    let latestDesired = false;
+    let serverKnown = false;
+    let hasInFlight = false;
+
+    latestDesired = true;
+    expect(pendingLatestDesired(latestDesired, serverKnown, hasInFlight)).toBe(true);
+
+    hasInFlight = true;
+    latestDesired = false;
+    expect(pendingLatestDesired(latestDesired, serverKnown, hasInFlight)).toBeNull();
+
+    serverKnown = true; // like=true ack
+    hasInFlight = false;
+    expect(pendingLatestDesired(latestDesired, serverKnown, hasInFlight)).toBe(false);
   });
 });

--- a/lib/optimistic-like.test.ts
+++ b/lib/optimistic-like.test.ts
@@ -6,6 +6,7 @@ import {
   clearPendingChange,
   applyRollback,
   pendingDesired,
+  pendingServerDesired,
 } from './optimistic-like';
 
 describe('낙관적 좋아요 — 성공 시나리오 (AC)', () => {
@@ -63,5 +64,15 @@ describe('낙관적 좋아요 — debounce 연타 수렴 (AC)', () => {
     // snapshot은 최초 확정값 유지 → 실패 시 (false, 10)으로 정확히 롤백
     state = applyRollback(state);
     expect(state).toEqual({ liked: false, count: 10, snapshot: null });
+  });
+
+  it('요청 전송 직후 반대로 클릭하면 마지막 서버 목표와 비교해 다음 의도를 만든다', () => {
+    let state = initialLikeState(false, 10);
+    state = applyClick(state); // like 요청 전송 예정
+    expect(pendingServerDesired(state, false)).toBe(true);
+
+    state = applyClick(state); // like=true 요청이 이미 나간 직후 unlike
+    expect(pendingDesired(state)).toBeNull();
+    expect(pendingServerDesired(state, true)).toBe(false);
   });
 });

--- a/lib/optimistic-like.ts
+++ b/lib/optimistic-like.ts
@@ -36,7 +36,8 @@ export function clearPendingChange(state: LikeState): LikeState {
   return { ...state, snapshot: null };
 }
 
-// 409(이미 추천) 또는 재시도 후에도 실패: snapshot으로 롤백.
+// 409 같은 즉시 실패: 최초 낙관적 변경 전 snapshot으로 롤백.
+// retry exhaustion 이후에는 최신 서버 ack 기준으로 applyServerLiked를 사용한다.
 export function applyRollback(state: LikeState): LikeState {
   if (!state.snapshot) return state;
   return { liked: state.snapshot.liked, count: state.snapshot.count, snapshot: null };
@@ -51,4 +52,13 @@ export function pendingDesired(state: LikeState): boolean | null {
 // in-flight 요청이 있을 때는 최초 snapshot보다 마지막으로 서버에 보낸 목표 상태가 중요하다.
 export function pendingServerDesired(state: LikeState, serverLiked: boolean): boolean | null {
   return state.liked === serverLiked ? null : state.liked;
+}
+
+export function pendingLatestDesired(
+  latestDesired: boolean,
+  serverLiked: boolean,
+  hasInFlight: boolean,
+): boolean | null {
+  if (hasInFlight) return null;
+  return latestDesired === serverLiked ? null : latestDesired;
 }

--- a/lib/optimistic-like.ts
+++ b/lib/optimistic-like.ts
@@ -13,6 +13,11 @@ export interface LikeState {
 
 export const LIKE_DEBOUNCE_MS = 200;
 
+export type LikeFlushDecision =
+  | { type: "defer" }
+  | { type: "clear" }
+  | { type: "send"; liked: boolean };
+
 export function initialLikeState(liked: boolean, count: number): LikeState {
   return { liked, count, snapshot: null };
 }
@@ -59,6 +64,25 @@ export function pendingLatestDesired(
   serverLiked: boolean,
   hasInFlight: boolean,
 ): boolean | null {
-  if (hasInFlight) return null;
-  return latestDesired === serverLiked ? null : latestDesired;
+  const decision = getLikeFlushDecision(latestDesired, serverLiked, hasInFlight);
+  return decision.type === "send" ? decision.liked : null;
+}
+
+export function getLikeFlushDecision(
+  latestDesired: boolean,
+  serverLiked: boolean,
+  hasInFlight: boolean,
+): LikeFlushDecision {
+  if (hasInFlight) return { type: "defer" };
+  if (latestDesired === serverLiked) return { type: "clear" };
+  return { type: "send", liked: latestDesired };
+}
+
+export function canSyncInitialLikeState(
+  state: LikeState,
+  latestDesired: boolean,
+  serverLiked: boolean,
+  hasInFlight: boolean,
+): boolean {
+  return !state.snapshot && !hasInFlight && latestDesired === serverLiked;
 }

--- a/lib/optimistic-like.ts
+++ b/lib/optimistic-like.ts
@@ -1,8 +1,8 @@
-// 낙관적 좋아요 상태 머신 (#48, ADR 0002)
+// 낙관적 좋아요 상태 머신 (#48, ADR 0017)
 // UI 의존 없는 순수 reducer로 분리해 성공/롤백/debounce 수렴을 단위 테스트한다.
 //
 // 흐름: 클릭 → 즉시 로컬 반영(snapshot 보관) → 200ms debounce 후 마지막
-// desired 상태만 서버 전송 → 성공이면 서버 값으로 동기화, 409/실패면 snapshot 롤백.
+// desired 상태만 서버 전송 → 성공이면 liked만 확정, 409/실패면 snapshot 롤백.
 
 export interface LikeState {
   liked: boolean;
@@ -26,12 +26,14 @@ export function applyClick(state: LikeState): LikeState {
   };
 }
 
-// 서버 성공: 서버 값이 진실 — 마지막 상태가 서버 진실로 수렴한다.
-export function applyServerConfirm(
-  _state: LikeState,
-  server: { liked: boolean; count: number },
-): LikeState {
-  return { liked: server.liked, count: server.count, snapshot: null };
+// 서버 성공: liked만 서버 진실로 수렴한다. count 표시는 ADR 0017의 baseline 공식이 담당한다.
+export function applyServerLiked(state: LikeState, liked: boolean): LikeState {
+  return { ...state, liked, snapshot: null };
+}
+
+// debounce 후 전송할 변경이 없으면 snapshot만 해제한다.
+export function clearPendingChange(state: LikeState): LikeState {
+  return { ...state, snapshot: null };
 }
 
 // 409(이미 추천) 또는 재시도 후에도 실패: snapshot으로 롤백.

--- a/lib/optimistic-like.ts
+++ b/lib/optimistic-like.ts
@@ -47,3 +47,8 @@ export function pendingDesired(state: LikeState): boolean | null {
   if (!state.snapshot) return null;
   return state.liked === state.snapshot.liked ? null : state.liked;
 }
+
+// in-flight 요청이 있을 때는 최초 snapshot보다 마지막으로 서버에 보낸 목표 상태가 중요하다.
+export function pendingServerDesired(state: LikeState, serverLiked: boolean): boolean | null {
+  return state.liked === serverLiked ? null : state.liked;
+}


### PR DESCRIPTION
## 요약

- 좋아요 서버 write를 mounted `LikeButton` instance 기준 in-flight 1개로 제한합니다.
- 클릭 UI/cache는 즉시 낙관적으로 반영하고, 서버 요청은 debounce 후 최신 desired state만 보냅니다.
- React state timing에 기대지 않도록 `latestDesiredRef`와 `serverKnownRef`를 분리했습니다.
- ack timeout을 추가해 응답이 오지 않는 요청이 React Query retry 대상이 되게 했습니다.
- 모든 retry가 실패하면 마지막 서버 ack 기준 `likedByMe`로 rollback하고 toast를 표시합니다.
- terminal failure 후 `getLikeStatus`로 best-effort reconcile을 시도합니다.
- 서버 액션은 이미 liked/unliked인 desired-state 요청을 success로 처리합니다.
- 버튼 표시 count는 ADR 0017대로 `otherLikesBaseline + userLike`를 유지하고 서버 ack의 `likeCount`로 즉시 덮어쓰지 않습니다.
- 구현 계획과 반려된 대안을 `docs/superpowers/plans/2026-06-18-like-ack-timeout.md`에 기록했습니다.

## useOptimistic을 쓰지 않는 이유

- 이 좋아요 버튼은 단순 optimistic render가 아니라 debounce, in-flight 요청 1개 제한, ack timeout/retry, latest desired 수렴, React Query feed/search cache 갱신을 함께 관리합니다.
- React `useOptimistic`보다 명시적인 reducer와 React Query mutation을 조합하는 편이 요청 타이밍과 cache 반영 정책을 더 직접적으로 제어할 수 있습니다.

## 관련 이슈

- Closes #168

## 검증

- `TMPDIR=/tmp npm test -- lib/optimistic-like.test.ts lib/feed-query.test.ts`
- `npm run typecheck`
- `npm run lint`
- `TMPDIR=/tmp npm test`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 좋아요 버튼의 응답 속도와 서버 동기화 안정성 향상
  * 빠른 연속 클릭(연타) 시 의도 반영을 우선하고, 불필요한 전송은 줄여 더 일관된 상태 제공
  * 서버 확인 지연/오류 시에도 표시 상태가 정확히 수렴하며, 필요 시 사용자에게 알림 제공

* **테스트**
  * 좋아요 승인/타임아웃/롤백 시나리오에 대한 회귀 테스트 강화

* **문서**
  * 좋아요 흐름 및 타임아웃 처리 규칙 문서 업데이트



<!-- end of auto-generated comment: release notes by coderabbit.ai -->